### PR TITLE
doc: add storybook documentation exemples

### DIFF
--- a/libs/ui-react/.storybook/main.ts
+++ b/libs/ui-react/.storybook/main.ts
@@ -3,17 +3,21 @@ import type { StorybookConfig } from '@storybook/react-vite';
 import { mergeConfig } from 'vite';
 
 const config: StorybookConfig = {
-  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+  stories: [
+    '../src/lib/**/*.mdx',
+    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
   addons: [
     '@storybook/addon-essentials',
-    '@storybook/addon-interactions'
+    '@storybook/addon-interactions',
+    '@storybook/addon-docs',
   ],
   framework: {
     name: '@storybook/react-vite',
     options: {},
   },
-  viteFinal: async (config) =>
-    mergeConfig(config, {
+  viteFinal: async (viteConfig) =>
+    mergeConfig(viteConfig, {
       plugins: [nxViteTsPaths()],
       css: {
         postcss: {
@@ -23,17 +27,21 @@ const config: StorybookConfig = {
           ],
         },
       },
+      optimizeDeps: {
+        exclude: [
+          '@storybook/blocks',
+          '@storybook/addon-essentials',
+          '@storybook/addon-interactions',
+          '@storybook/addon-docs',
+          '@storybook/react',
+          '@storybook/react-vite',
+        ],
+      },
     }),
   core: {
     disableTelemetry: true,
   },
-  features: {
-    interactionsDebugger: true,
-  },
 };
 
 export default config;
-function awaitimport(arg0: string): any {
-  throw new Error('Function not implemented.');
-}
 

--- a/libs/ui-react/src/index.ts
+++ b/libs/ui-react/src/index.ts
@@ -1,3 +1,3 @@
 export * from './lib/Components';
 export * from './lib/Patterns';
-export * from './lib/Symbols/Button/Button';
+export * from './lib/Components/Button/Button';

--- a/libs/ui-react/src/lib/Components/Button/Button.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.stories.tsx
@@ -1,11 +1,41 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { within, userEvent } from '@storybook/testing-library';
+import {
+  Title,
+  Subtitle,
+  Primary as PrimaryDocBlock,
+  Controls,
+  Stories,
+} from '@storybook/blocks';
 import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   component: Button,
   title: 'Components/Button',
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <Subtitle>
+            The main button component for user interactions.
+          </Subtitle>
+          <div>
+            <p>This is the <strong>custom description</strong> of the button, written directly in <code>Button.stories.tsx</code>.</p>
+            <p>It supports <em>Markdown simulated here via HTML</em> for formatting, like <a href="https://storybook.js.org">links</a> or lists:</p>
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+            </ul>
+          </div>
+          <PrimaryDocBlock />
+          <Controls />
+          <Stories title='Autres Exemples' />
+        </>
+      ),
+    },
+  },
 };
 
 // Story Definition

--- a/libs/ui-react/src/lib/Components/Button/Button.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { tailwindColors } from '@ldls/design-tokens';
 
 export interface ButtonProps {

--- a/libs/ui-react/src/lib/Components/Button/ButtonsDocs.mdx
+++ b/libs/ui-react/src/lib/Components/Button/ButtonsDocs.mdx
@@ -1,0 +1,35 @@
+import { Meta, Story, Canvas } from '@storybook/blocks';
+import * as ButtonStories from './Button.stories';
+
+<Meta of={ButtonStories} title="Design System/Components/Button" />
+
+# Button Component
+
+Welcome to the documentation for the `Button` component. Buttons are a fundamental part of any user interface,
+allowing users to take actions and make choices with a single tap or click.
+
+Our `Button` component is designed to be versatile, accessible, and easy to integrate. It supports various styles (variants) and sizes to fit different contexts within your application.
+
+## Variants and Sizes
+
+Below are examples of the primary and secondary button variants, showcased in different sizes.
+
+### Primary Buttons
+
+Primary buttons are used for the main call to action on a page.
+
+The `Button` component is essential for all user interactions requiring an action.
+It is available in several variants and sizes.
+
+**Example of a Primary Button:**
+
+<Canvas>
+  <Story of={ButtonStories.Primary} />
+</Canvas>
+
+**Example of a Secondary Button:**
+
+<Canvas>
+  <Story of={ButtonStories.Secondary} />
+</Canvas>
+

--- a/libs/ui-rnative/src/lib/Symbols/Button/Button.stories.tsx
+++ b/libs/ui-rnative/src/lib/Symbols/Button/Button.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { within, userEvent } from '@storybook/testing-library';
 import { View } from 'react-native';


### PR DESCRIPTION
## description 

As we quick of the documentation of the DLS @LaurineDevergne and @blucet-ledger  need some exemples to check how the doc can be written in storybook,

This PR is setting 2 exemples of how to document the button component, in markdown and in a classic `tsx` story. 


**Important note:** ⚠️  please note that this is just for the sake of exploration the button story and component are just placeholder ⚠️  they do not represent real components (UI wise and code wise) ⚠️ 


mdx ⏬ 
<img width="1073" alt="Screenshot 2025-05-28 at 10 00 32" src="https://github.com/user-attachments/assets/15e39f05-ea2f-4334-bd57-58abf7de396c" />

tsx ⏬ 
<img width="1126" alt="Screenshot 2025-05-28 at 10 00 36" src="https://github.com/user-attachments/assets/c5e539d9-2d25-49fe-9dcb-bc88e56c108c" />
