### PR TITLE
chore: file key default value

### DIFF
--- a/.github/workflows/figma-export-design-tokens.yml
+++ b/.github/workflows/figma-export-design-tokens.yml
@@ -5,7 +5,6 @@ on:
     inputs:
       figma_file_key:
         description: 'Figma File Key (use default if empty)'
-        default: ''
 
 env:
   NX_NO_CLOUD: true


### PR DESCRIPTION
Goal
Ease the triggering of the Export Design Tokens workflow by making the foundations file key be the default value when the input field is empty.

The CI workflow has been modified to fall back to a github actions variable when empty.

How to test:

- [x] With an invalid filekey: It should fail with a 404
- [x] With no file key: It should retrieve the default file key
- [x] With a valid file key: It should retrieve token from this file key