### PR TITLE
chore: convert `.prettierrc` to a js file

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,4 @@
-{
+export default {
   "singleQuote": true,
   "plugins": ["prettier-plugin-tailwindcss"],
   "tailwindConfig": "./libs/ui-react/tailwind.config.ts",


### PR DESCRIPTION
Convert prettier to a js file to enable support for modern JavaScript module features that `prettier-plugin-tailwindcss` relies on.


![image](https://github.com/user-attachments/assets/53faafdb-3266-494f-af59-4969f520252d)
