### PR TITLE
fix: use correct name for artifacts

### DIFF
--- a/.github/workflows/sync-figma.yml
+++ b/.github/workflows/sync-figma.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Download design tokens artifacts
         uses: actions/download-artifact@v4
         with:
-          name: design-core
+          name: design-tokens
           path: libs/design-core/tokens/
 
       - name: Run Design Tokens ETL


### PR DESCRIPTION
Use correct name for artifacts in "sync figma" workflow