### PR TITLE
ci: initial version plan test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ test-output
 .nx/*
 !.nx/version-plans/
 !.nx/version-plans/**
+mise.toml

--- a/.nx/version-plans/version-plan-1752225928873.md
+++ b/.nx/version-plans/version-plan-1752225928873.md
@@ -1,0 +1,9 @@
+---
+'@ldls/utils-shared': patch
+'@ldls/design-core': patch
+'@ldls/ui-rnative': patch
+'@ldls/ui-react': patch
+'@ldls/ui-core': patch
+---
+
+Initial Release


### PR DESCRIPTION
First official test of the version plans.
This should release the version `0.0.2` for all packages.