### PR TITLE
feat: add Vercel configuration for SEO headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Introduced a new vercel.json file to set X-Robots-Tag header to noindex for all routes.