### PR TITLE
chore: update React and React-DOM version constraints in package.json

### DIFF
--- a/libs/ui-react/package.json
+++ b/libs/ui-react/package.json
@@ -33,8 +33,8 @@
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "react": "~18.3.1",
-    "react-dom": "~18.3.1",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "tailwind-merge": "^2.6.0"
   }
 }


### PR DESCRIPTION
add support for React 19

Updates the peer dependency range for react and react-dom to support both v18 and v19.

This resolves npm ERESOLVE errors when installing the library into a host application that has upgraded to React 19, ensuring broader compatibility.