### PR TITLE
refactor(button): remove pointer-events-none from button in disabled state

### DIFF
--- a/libs/ui-react/src/lib/Components/Button/Button.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.tsx
@@ -6,7 +6,7 @@ import { IconSize } from '../Icon/Icon';
 import { Slot } from '@radix-ui/react-slot';
 
 const buttonVariants = cva(
-  'inline-flex h-fit w-fit cursor-pointer items-center justify-center rounded-full transition-colors body-1-semi-bold focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus disabled:pointer-events-none disabled:bg-disabled disabled:text-disabled',
+  'inline-flex h-fit w-fit cursor-pointer items-center justify-center rounded-full transition-colors body-1-semi-bold focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus disabled:bg-disabled disabled:text-disabled',
   {
     variants: {
       appearance: {
@@ -28,9 +28,6 @@ const buttonVariants = cva(
       },
       isFull: {
         true: 'w-full',
-      },
-      loading: {
-        true: 'pointer-events-none',
       },
       iconOnly: {
         true: '',
@@ -177,6 +174,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       loading,
       icon,
       asChild = false,
+      onClick,
+      disabled,
       ...props
     },
     ref,
@@ -198,17 +197,17 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <Comp
         ref={ref}
+        onClick={disabled || loading ? undefined : onClick}
         className={cn(
           className,
           buttonVariants({
             appearance,
             size,
             isFull,
-            loading,
             iconOnly,
           }),
         )}
-        disabled={props.disabled}
+        disabled={disabled}
         {...props}
       >
         {asChild ? (


### PR DESCRIPTION
Signed-off-by: Simon Bruneaud <simon.bruneaud@ledger.fr>

## Investigation:
After taking a look at 
- Radix
- Uber Base
- Primer

I noticed that they don't use `pointer-events-none` when a component is `disabled`.

## Rule
I suggest not to use `pointer-events-none` for elements that can be wrapped in another elements that required a `ref`. E.g.
- TooltipTrigger
- DropdownTrigger
- ...

The `disabled` state can be handled differently without affecting the UI or UX, and offering the best flexibility for later designers use.