### PR TITLE
fix(app-sandbox-rnative): add intl-pluralrules polyfill

### DIFF
--- a/apps/app-sandbox-rnative/index.js
+++ b/apps/app-sandbox-rnative/index.js
@@ -1,7 +1,4 @@
-/**
- * @format
- */
-
+import 'intl-pluralrules';
 import { registerRootComponent } from 'expo';
 
 import App from './App';

--- a/apps/app-sandbox-rnative/package.json
+++ b/apps/app-sandbox-rnative/package.json
@@ -17,6 +17,7 @@
     "@sbaiahmed1/react-native-blur": "^4.5.5",
     "expo": "~53.0.0",
     "expo-haptics": "~14.1.4",
+    "intl-pluralrules": "^2.0.1",
     "react": "19.0.0",
     "react-native": "0.79.7",
     "react-native-gesture-handler": "^2.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,7 @@
         "@sbaiahmed1/react-native-blur": "^4.5.5",
         "expo": "~53.0.0",
         "expo-haptics": "~14.1.4",
+        "intl-pluralrules": "^2.0.1",
         "react": "19.0.0",
         "react-native": "0.79.7",
         "react-native-gesture-handler": "^2.28.0",
@@ -28818,6 +28819,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/intl-pluralrules": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/intl-pluralrules/-/intl-pluralrules-2.0.1.tgz",
+      "integrity": "sha512-astxTLzIdXPeN0K9Rumi6LfMpm3rvNO0iJE+h/k8Kr/is+wPbRe4ikyDjlLr6VTh/mEfNv8RjN+gu3KwDiuhqg==",
+      "license": "ISC"
     },
     "node_modules/invariant": {
       "version": "2.2.4",


### PR DESCRIPTION
Adds the `intl-pluralrules` polyfill to fix that annoying `Intl.PluralRules` compatibility warning we've been having for months now:

> i18next::pluralResolver: Your environment seems not to be Intl API compatible, use an Intl.PluralRules polyfill. Will fallback to the compatibilityJSON v3 format handling

Followed https://stackoverflow.com/a/70865185.
No more issues after testing on my end.