### PR TITLE
fix(Select): normalize keyboard selection values & add generic TMeta support

### DIFF
--- a/.nx/version-plans/version-plan-1776702215832.md
+++ b/.nx/version-plans/version-plan-1776702215832.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+fix(Select): normalize keyboard selection to plain strings, add arrow-key navigation fallback, align `SelectItemData` generics with `OptionListItemData`

--- a/.nx/version-plans/version-plan-1776702215832.md
+++ b/.nx/version-plans/version-plan-1776702215832.md
@@ -2,4 +2,6 @@
 '@ledgerhq/lumen-ui-react': patch
 ---
 
-fix(Select): normalize keyboard selection to plain strings, add arrow-key navigation fallback, align `SelectItemData` generics with `OptionListItemData`
+fix(Select): 
+- normalize keyboard selection to plain strings, add arrow-key navigation fallback, align `SelectItemData` generics with `OptionListItemData`
+- Breaking_change: deprecate `autoFocusSearch` and replace it with `initialFocus` that is defaulted to true now.

--- a/libs/ui-react/src/lib/Components/Select/Select.test.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.test.tsx
@@ -121,6 +121,53 @@ describe('Select', () => {
     expect(handleChange).toHaveBeenCalledWith('opt1');
   });
 
+  it('normalizes object values to strings in onValueChange', () => {
+    const handleChange = vi.fn();
+    const { rerender } = render(
+      <Select items={options} onValueChange={handleChange}>
+        <SelectTrigger label='Label' />
+        <SelectContent>
+          <SelectList
+            renderItem={(item) => (
+              <SelectItem key={item.value} value={item.value}>
+                <SelectItemText>{item.label}</SelectItemText>
+              </SelectItem>
+            )}
+          />
+        </SelectContent>
+      </Select>,
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByText('Option 1'));
+
+    expect(handleChange).toHaveBeenCalledWith('opt1');
+    expect(typeof handleChange.mock.calls[0][0]).toBe('string');
+
+    handleChange.mockClear();
+
+    rerender(
+      <Select items={options} onValueChange={handleChange} value={null}>
+        <SelectTrigger label='Label' />
+        <SelectContent>
+          <SelectList
+            renderItem={(item) => (
+              <SelectItem key={item.value} value={item.value}>
+                <SelectItemText>{item.label}</SelectItemText>
+              </SelectItem>
+            )}
+          />
+        </SelectContent>
+      </Select>,
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByText('Option 2'));
+
+    expect(handleChange).toHaveBeenCalledWith('opt2');
+    expect(typeof handleChange.mock.calls[0][0]).toBe('string');
+  });
+
   it('reflects controlled value changes', () => {
     const { rerender } = render(
       <Select items={options} value='opt1'>

--- a/libs/ui-react/src/lib/Components/Select/Select.test.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.test.tsx
@@ -121,53 +121,6 @@ describe('Select', () => {
     expect(handleChange).toHaveBeenCalledWith('opt1');
   });
 
-  it('normalizes object values to strings in onValueChange', () => {
-    const handleChange = vi.fn();
-    const { rerender } = render(
-      <Select items={options} onValueChange={handleChange}>
-        <SelectTrigger label='Label' />
-        <SelectContent>
-          <SelectList
-            renderItem={(item) => (
-              <SelectItem key={item.value} value={item.value}>
-                <SelectItemText>{item.label}</SelectItemText>
-              </SelectItem>
-            )}
-          />
-        </SelectContent>
-      </Select>,
-    );
-
-    fireEvent.click(screen.getByRole('combobox'));
-    fireEvent.click(screen.getByText('Option 1'));
-
-    expect(handleChange).toHaveBeenCalledWith('opt1');
-    expect(typeof handleChange.mock.calls[0][0]).toBe('string');
-
-    handleChange.mockClear();
-
-    rerender(
-      <Select items={options} onValueChange={handleChange} value={null}>
-        <SelectTrigger label='Label' />
-        <SelectContent>
-          <SelectList
-            renderItem={(item) => (
-              <SelectItem key={item.value} value={item.value}>
-                <SelectItemText>{item.label}</SelectItemText>
-              </SelectItem>
-            )}
-          />
-        </SelectContent>
-      </Select>,
-    );
-
-    fireEvent.click(screen.getByRole('combobox'));
-    fireEvent.click(screen.getByText('Option 2'));
-
-    expect(handleChange).toHaveBeenCalledWith('opt2');
-    expect(typeof handleChange.mock.calls[0][0]).toBe('string');
-  });
-
   it('reflects controlled value changes', () => {
     const { rerender } = render(
       <Select items={options} value='opt1'>

--- a/libs/ui-react/src/lib/Components/Select/Select.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.tsx
@@ -213,20 +213,6 @@ const contentStyles = cva(
   },
 );
 
-/**
- * Renders a visually-hidden Combobox.Input so the popup receives keyboard
- * navigation (Arrow/Enter) even when no SelectSearch is present.
- * Unmounts itself once SelectSearch mounts to avoid duplicate inputs.
- */
-const SelectFallbackInput = () => {
-  const { searchMounted } = useSelectContext({
-    consumerName: 'SelectFallbackInput',
-    contextRequired: true,
-  });
-  if (searchMounted) return null;
-  return <Combobox.Input aria-hidden tabIndex={-1} className='sr-only' />;
-};
-
 const SelectContent = ({
   ref,
   className,
@@ -234,7 +220,7 @@ const SelectContent = ({
   side = 'bottom',
   sideOffset = 8,
   align = 'start',
-  autoFocusSearch = false,
+  initialFocus = true,
   ...props
 }: SelectContentProps) => (
   <Combobox.Portal data-slot='select-portal'>
@@ -248,11 +234,10 @@ const SelectContent = ({
       <Combobox.Popup
         ref={ref}
         data-slot='select-content'
-        initialFocus={autoFocusSearch ? undefined : false}
+        initialFocus={initialFocus}
         className={cn(contentStyles({ side }), className)}
         {...props}
       >
-        <SelectFallbackInput />
         {children}
       </Combobox.Popup>
     </Combobox.Positioner>
@@ -275,7 +260,7 @@ const SelectList = <TMeta extends MetaShape = MetaShape>({
       ref={ref}
       data-slot='select-list'
       className={cn(
-        'min-h-0 min-w-(--anchor-width) flex-1 overflow-y-auto p-8 group-data-empty/select-content:p-0',
+        'min-h-0 min-w-(--anchor-width) flex-1 overflow-y-auto p-8 group-data-empty/select-content:p-0 focus:ring-0 focus:outline-hidden',
         className,
       )}
       {...props}

--- a/libs/ui-react/src/lib/Components/Select/Select.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.tsx
@@ -43,7 +43,7 @@ function Select<TMeta extends MetaShape = MetaShape>({
   name,
   required,
   children,
-}: Readonly<SelectProps<TMeta>>) {
+}: SelectProps<TMeta>) {
   const disabled = useDisabledContext({
     consumerName: 'Select',
     mergeWith: { disabled: disabledProp },

--- a/libs/ui-react/src/lib/Components/Select/Select.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.tsx
@@ -8,6 +8,7 @@ import { Divider } from '../Divider';
 import { SearchInput } from '../SearchInput';
 import { SelectProvider, useSelectContext } from './SelectContext';
 import type {
+  MetaShape,
   SelectItemGroup,
   SelectProps,
   SelectTriggerProps,
@@ -32,7 +33,7 @@ import { useSelectItems } from './useSelectItems';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const resolveValue = (v: any): string | null => v?.value ?? v ?? null;
 
-function Select({
+function Select<TMeta extends MetaShape = MetaShape>({
   value,
   defaultValue,
   onValueChange,
@@ -49,7 +50,7 @@ function Select({
   name,
   required,
   children,
-}: SelectProps) {
+}: SelectProps<TMeta>) {
   const disabled = useDisabledContext({
     consumerName: 'Select',
     mergeWith: { disabled: disabledProp },
@@ -265,12 +266,12 @@ const SelectContent = ({
   </Combobox.Portal>
 );
 
-const SelectList = ({
+const SelectList = <TMeta extends MetaShape = MetaShape>({
   ref,
   className,
   renderItem,
   ...props
-}: SelectListProps) => {
+}: SelectListProps<TMeta>) => {
   const { isGrouped } = useSelectContext({
     consumerName: 'SelectList',
     contextRequired: true,
@@ -287,7 +288,7 @@ const SelectList = ({
       {...props}
     >
       {isGrouped
-        ? (group: SelectItemGroup, groupIndex: number) => (
+        ? (group: SelectItemGroup<TMeta>, groupIndex: number) => (
             <Combobox.Group
               key={group.label}
               items={group.items}

--- a/libs/ui-react/src/lib/Components/Select/Select.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.tsx
@@ -24,6 +24,14 @@ import type {
 } from './types';
 import { useSelectItems } from './useSelectItems';
 
+/**
+ * base-ui's Combobox calls onValueChange with either a string (click on
+ * Combobox.Item) or a full SelectItemData object (keyboard selection, which
+ * resolves from the `items` array). This normalizes both to a plain string.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const resolveValue = (v: any): string | null => v?.value ?? v ?? null;
+
 function Select({
   value,
   defaultValue,
@@ -62,6 +70,7 @@ function Select({
     groupedItems,
     filteredItemsForRoot,
     resolvedSearchValue,
+    searchMounted,
     registerSearch,
     handleSearchValueChange,
   } = useSelectItems({
@@ -82,7 +91,8 @@ function Select({
       inputValue={resolvedSearchValue}
       onInputValueChange={handleSearchValueChange}
       value={selectedValue}
-      onValueChange={setSelectedValue}
+      onValueChange={(val) => setSelectedValue(resolveValue(val))}
+      isItemEqualToValue={(a, b) => resolveValue(a) === resolveValue(b)}
       open={open}
       defaultOpen={defaultOpen}
       onOpenChange={onOpenChange}
@@ -90,7 +100,9 @@ function Select({
       required={required}
       disabled={disabled}
     >
-      <SelectProvider value={{ selectedValue, registerSearch, isGrouped }}>
+      <SelectProvider
+        value={{ selectedValue, registerSearch, isGrouped, searchMounted }}
+      >
         {children}
       </SelectProvider>
     </Combobox.Root>
@@ -207,6 +219,20 @@ const contentStyles = cva(
   },
 );
 
+/**
+ * Renders a visually-hidden Combobox.Input so the popup receives keyboard
+ * navigation (Arrow/Enter) even when no SelectSearch is present.
+ * Unmounts itself once SelectSearch mounts to avoid duplicate inputs.
+ */
+const SelectFallbackInput = () => {
+  const { searchMounted } = useSelectContext({
+    consumerName: 'SelectFallbackInput',
+    contextRequired: true,
+  });
+  if (searchMounted) return null;
+  return <Combobox.Input aria-hidden tabIndex={-1} className='sr-only' />;
+};
+
 const SelectContent = ({
   ref,
   className,
@@ -232,6 +258,7 @@ const SelectContent = ({
         className={cn(contentStyles({ side }), className)}
         {...props}
       >
+        <SelectFallbackInput />
         {children}
       </Combobox.Popup>
     </Combobox.Positioner>

--- a/libs/ui-react/src/lib/Components/Select/Select.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.tsx
@@ -43,7 +43,7 @@ function Select<TMeta extends MetaShape = MetaShape>({
   name,
   required,
   children,
-}: SelectProps<TMeta>) {
+}: Readonly<SelectProps<TMeta>>) {
   const disabled = useDisabledContext({
     consumerName: 'Select',
     mergeWith: { disabled: disabledProp },

--- a/libs/ui-react/src/lib/Components/Select/Select.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.tsx
@@ -24,14 +24,7 @@ import type {
   SelectEmptyStateProps,
 } from './types';
 import { useSelectItems } from './useSelectItems';
-
-/**
- * base-ui's Combobox calls onValueChange with either a string (click on
- * Combobox.Item) or a full SelectItemData object (keyboard selection, which
- * resolves from the `items` array). This normalizes both to a plain string.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const resolveValue = (v: any): string | null => v?.value ?? v ?? null;
+import { resolveValue } from './utils';
 
 function Select<TMeta extends MetaShape = MetaShape>({
   value,

--- a/libs/ui-react/src/lib/Components/Select/SelectContext.tsx
+++ b/libs/ui-react/src/lib/Components/Select/SelectContext.tsx
@@ -4,6 +4,7 @@ type SelectContextValue = {
   selectedValue: string | null;
   registerSearch: () => () => void;
   isGrouped: boolean;
+  searchMounted: boolean;
 };
 
 export const [SelectProvider, useSelectContext] =

--- a/libs/ui-react/src/lib/Components/Select/index.ts
+++ b/libs/ui-react/src/lib/Components/Select/index.ts
@@ -1,5 +1,6 @@
 export * from './Select';
 export type {
+  MetaShape,
   SelectItemData,
   SelectProps,
   SelectTriggerProps,

--- a/libs/ui-react/src/lib/Components/Select/types.ts
+++ b/libs/ui-react/src/lib/Components/Select/types.ts
@@ -22,7 +22,7 @@ export type SelectItemData<TMeta extends MetaShape = MetaShape> = {
    */
   group?: string;
   /**
-   * Arbitrary data attached to this item.
+   * Optional bag of arbitrary data attached to this item.
    * Use it to carry extra fields (icons, tickers, IDs, etc.)
    * that your render function or custom filter needs.
    */

--- a/libs/ui-react/src/lib/Components/Select/types.ts
+++ b/libs/ui-react/src/lib/Components/Select/types.ts
@@ -1,7 +1,9 @@
 import type { ComponentPropsWithRef, ReactElement, ReactNode } from 'react';
 import type { SearchInputProps } from '../SearchInput/types';
 
-export type SelectItemData<Meta = Record<string, unknown>> = {
+export type MetaShape = Record<string, unknown>;
+
+export type SelectItemData<TMeta extends MetaShape = MetaShape> = {
   /** Unique string identifier for this item, used for selection tracking. */
   value: string;
   /** Display text used in the trigger. Also the field matched against by the default search filter. */
@@ -20,19 +22,19 @@ export type SelectItemData<Meta = Record<string, unknown>> = {
    */
   group?: string;
   /**
-   * Optional bag of arbitrary data attached to this item.
+   * Arbitrary data attached to this item.
    * Use it to carry extra fields (icons, tickers, IDs, etc.)
    * that your render function or custom filter needs.
    */
-  meta?: Meta;
+  meta?: TMeta;
 };
 
 /** @internal A named group of select items, used to represent a resolved group with its header label and child items. */
-export type SelectItemGroup = {
+export type SelectItemGroup<TMeta extends MetaShape = MetaShape> = {
   /** The displayed group name, matching the `group` field on each child item. */
   label: string;
   /** The items belonging to this group. */
-  items: SelectItemData[];
+  items: SelectItemData<TMeta>[];
 };
 
 export type SelectTriggerRenderProps = {
@@ -46,7 +48,7 @@ export type SelectTriggerRenderProps = {
   selectedContent: ReactNode;
 };
 
-export type SelectProps = {
+export type SelectProps<TMeta extends MetaShape = MetaShape> = {
   /**
    * The children of the select.
    */
@@ -62,7 +64,7 @@ export type SelectProps = {
    * them by that value, rendering group headers, separators, and per-group
    * collection iteration internally.
    */
-  items: SelectItemData[];
+  items: SelectItemData<TMeta>[];
   /**
    * Filter function used to match items against a search query.
    * When `SelectSearch` is rendered inside the content, a default case-insensitive
@@ -73,13 +75,13 @@ export type SelectProps = {
    * items within each group. Empty groups are automatically hidden.
    * @default undefined
    */
-  filter?: null | ((item: SelectItemData, query: string) => boolean);
+  filter?: null | ((item: SelectItemData<TMeta>, query: string) => boolean);
   /**
    * Pre-filtered items to display in the list. When provided, the component uses
    * these items directly instead of filtering `items` internally. Use alongside
    * `onSearchValueChange` for async/remote search where the server handles filtering.
    */
-  filteredItems?: SelectItemData[];
+  filteredItems?: SelectItemData<TMeta>[];
   /**
    * The controlled search input value.
    * Should be used in conjunction with `onSearchValueChange`.
@@ -194,7 +196,7 @@ export type SelectContentProps = {
   autoFocusSearch?: boolean;
 } & ComponentPropsWithRef<'div'>;
 
-export type SelectListProps = {
+export type SelectListProps<TMeta extends MetaShape = MetaShape> = {
   /**
    * A render function that receives each item and its index, returning a ReactNode.
    *
@@ -203,7 +205,7 @@ export type SelectListProps = {
    * is handled automatically by `SelectList`.
    * @example renderItem={(item) => <SelectItem value={item.value}>{item.label}</SelectItem>}
    */
-  renderItem: (item: SelectItemData, index: number) => ReactNode;
+  renderItem: (item: SelectItemData<TMeta>, index: number) => ReactNode;
   /**
    * Extra class names to apply to the list element.
    */

--- a/libs/ui-react/src/lib/Components/Select/types.ts
+++ b/libs/ui-react/src/lib/Components/Select/types.ts
@@ -1,4 +1,9 @@
-import type { ComponentPropsWithRef, ReactElement, ReactNode } from 'react';
+import type {
+  ComponentPropsWithRef,
+  ReactElement,
+  ReactNode,
+  RefObject,
+} from 'react';
 import type { SearchInputProps } from '../SearchInput/types';
 
 export type MetaShape = Record<string, unknown>;
@@ -190,10 +195,15 @@ export type SelectContentProps = {
    */
   className?: string;
   /**
-   * When true, the search input receives focus automatically when the dropdown opens.
-   * @default false
+   * Determines the element to focus when the popover is opened.
+   *
+   * - `false`: Do not move focus.
+   * - `true`: Move focus based on the default behavior (first tabbable element of the select content).
+   * - `RefObject`: Move focus to the ref element.
+   *
+   * @default true
    */
-  autoFocusSearch?: boolean;
+  initialFocus?: boolean | RefObject<HTMLElement | null>;
 } & ComponentPropsWithRef<'div'>;
 
 export type SelectListProps<TMeta extends MetaShape = MetaShape> = {

--- a/libs/ui-react/src/lib/Components/Select/useSelectItems/useSelectItems.ts
+++ b/libs/ui-react/src/lib/Components/Select/useSelectItems/useSelectItems.ts
@@ -1,21 +1,21 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useControllableState } from '../../../../utils/useControllableState';
-import type { SelectItemData, SelectItemGroup } from '../types';
+import type { MetaShape, SelectItemData, SelectItemGroup } from '../types';
 import { defaultLabelFilter, groupItemsByKey } from '../utils';
 
-type UseSelectItemsParams = {
-  items: SelectItemData[];
-  filter?: null | ((item: SelectItemData, query: string) => boolean);
-  filteredItems?: SelectItemData[];
+type UseSelectItemsParams<TMeta extends MetaShape = MetaShape> = {
+  items: SelectItemData<TMeta>[];
+  filter?: null | ((item: SelectItemData<TMeta>, query: string) => boolean);
+  filteredItems?: SelectItemData<TMeta>[];
   searchValue?: string;
   defaultSearchValue?: string;
   onSearchValueChange?: (value: string) => void;
 };
 
-type UseSelectItemsReturn = {
+type UseSelectItemsReturn<TMeta extends MetaShape = MetaShape> = {
   isGrouped: boolean;
-  groupedItems: SelectItemGroup[] | null;
-  filteredItemsForRoot: SelectItemData[] | SelectItemGroup[];
+  groupedItems: SelectItemGroup<TMeta>[] | null;
+  filteredItemsForRoot: SelectItemData<TMeta>[] | SelectItemGroup<TMeta>[];
   resolvedSearchValue: string;
   searchMounted: boolean;
   registerSearch: () => () => void;
@@ -32,14 +32,14 @@ type UseSelectItemsReturn = {
  *   the internal filter entirely.
  * - Supports controlled and uncontrolled `searchValue` via `useControllableState`.
  */
-export function useSelectItems({
+export function useSelectItems<TMeta extends MetaShape = MetaShape>({
   items,
   filter,
   filteredItems: filteredItemsProp,
   searchValue: searchValueProp,
   defaultSearchValue,
   onSearchValueChange: onSearchValueChangeProp,
-}: UseSelectItemsParams): UseSelectItemsReturn {
+}: UseSelectItemsParams<TMeta>): UseSelectItemsReturn<TMeta> {
   const [searchMounted, setSearchMounted] = useState(false);
   const [searchValue, setSearchValue] = useControllableState<string>({
     prop: searchValueProp,
@@ -76,8 +76,8 @@ export function useSelectItems({
   );
 
   const internalFilteredItems = useMemo(():
-    | SelectItemData[]
-    | SelectItemGroup[] => {
+    | SelectItemData<TMeta>[]
+    | SelectItemGroup<TMeta>[] => {
     if (!filterFn || !searchValue.trim()) return groupedItems ?? items;
 
     if (groupedItems) {
@@ -93,8 +93,8 @@ export function useSelectItems({
   }, [groupedItems, items, searchValue, filterFn]);
 
   const externalGroupedItems = useMemo(():
-    | SelectItemData[]
-    | SelectItemGroup[]
+    | SelectItemData<TMeta>[]
+    | SelectItemGroup<TMeta>[]
     | null => {
     if (!filteredItemsProp) return null;
     return isGrouped ? groupItemsByKey(filteredItemsProp) : filteredItemsProp;

--- a/libs/ui-react/src/lib/Components/Select/useSelectItems/useSelectItems.ts
+++ b/libs/ui-react/src/lib/Components/Select/useSelectItems/useSelectItems.ts
@@ -17,6 +17,7 @@ type UseSelectItemsReturn = {
   groupedItems: SelectItemGroup[] | null;
   filteredItemsForRoot: SelectItemData[] | SelectItemGroup[];
   resolvedSearchValue: string;
+  searchMounted: boolean;
   registerSearch: () => () => void;
   handleSearchValueChange: (val: string) => void;
 };
@@ -106,6 +107,7 @@ export function useSelectItems({
     groupedItems,
     filteredItemsForRoot,
     resolvedSearchValue: searchValue,
+    searchMounted,
     registerSearch,
     handleSearchValueChange,
   };

--- a/libs/ui-react/src/lib/Components/Select/utils/groupItems.test.ts
+++ b/libs/ui-react/src/lib/Components/Select/utils/groupItems.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { SelectItemData } from '../types';
-import { defaultLabelFilter, groupItemsByKey } from './groupItems';
+import {
+  defaultLabelFilter,
+  groupItemsByKey,
+  resolveValue,
+} from './groupItems';
 
 describe('groupItemsByKey', () => {
   it('groups items by their group field', () => {
@@ -57,6 +61,40 @@ describe('groupItemsByKey', () => {
 
   it('returns an empty array for an empty input', () => {
     expect(groupItemsByKey([])).toEqual([]);
+  });
+});
+
+describe('resolveValue', () => {
+  it('returns the string as-is', () => {
+    expect(resolveValue('fr')).toBe('fr');
+  });
+
+  it('extracts .value from a SelectItemData object', () => {
+    expect(resolveValue({ value: 'fr', label: 'France' })).toBe('fr');
+  });
+
+  it('returns null for null', () => {
+    expect(resolveValue(null)).toBeNull();
+  });
+
+  it('returns null for undefined', () => {
+    expect(resolveValue(undefined)).toBeNull();
+  });
+
+  it('returns null for a number', () => {
+    expect(resolveValue(42)).toBeNull();
+  });
+
+  it('returns null for an object without a value field', () => {
+    expect(resolveValue({ label: 'France' })).toBeNull();
+  });
+
+  it('returns null for an object with a non-string value field', () => {
+    expect(resolveValue({ value: 123 })).toBeNull();
+  });
+
+  it('returns empty string for empty string input', () => {
+    expect(resolveValue('')).toBe('');
   });
 });
 

--- a/libs/ui-react/src/lib/Components/Select/utils/groupItems.ts
+++ b/libs/ui-react/src/lib/Components/Select/utils/groupItems.ts
@@ -1,13 +1,15 @@
-import type { SelectItemData, SelectItemGroup } from '../types';
+import type { MetaShape, SelectItemData, SelectItemGroup } from '../types';
 
 /**
  * Groups a flat list of items by their `group` field, preserving
  * the insertion order of the first occurrence of each group key.
  * Items without a `group` value are collected under an empty-string key.
  */
-export function groupItemsByKey(items: SelectItemData[]): SelectItemGroup[] {
+export function groupItemsByKey<TMeta extends MetaShape = MetaShape>(
+  items: SelectItemData<TMeta>[],
+): SelectItemGroup<TMeta>[] {
   const order: string[] = [];
-  const map: Record<string, SelectItemData[]> = {};
+  const map: Record<string, SelectItemData<TMeta>[]> = {};
   for (const item of items) {
     const key = item.group ?? '';
     if (!map[key]) {

--- a/libs/ui-react/src/lib/Components/Select/utils/groupItems.ts
+++ b/libs/ui-react/src/lib/Components/Select/utils/groupItems.ts
@@ -1,6 +1,24 @@
 import type { MetaShape, SelectItemData, SelectItemGroup } from '../types';
 
 /**
+ * base-ui's Combobox calls onValueChange with either a string (click on
+ * Combobox.Item) or a full SelectItemData object (keyboard selection, which
+ * resolves from the `items` array). This normalizes both to a plain string.
+ */
+export const resolveValue = (v: unknown): string | null => {
+  if (typeof v === 'string') return v;
+  if (
+    typeof v === 'object' &&
+    v !== null &&
+    'value' in v &&
+    typeof (v as Record<string, unknown>).value === 'string'
+  ) {
+    return (v as Record<string, unknown>).value as string;
+  }
+  return null;
+};
+
+/**
  * Groups a flat list of items by their `group` field, preserving
  * the insertion order of the first occurrence of each group key.
  * Items without a `group` value are collected under an empty-string key.

--- a/libs/ui-react/src/lib/Components/Select/utils/groupItems.ts
+++ b/libs/ui-react/src/lib/Components/Select/utils/groupItems.ts
@@ -5,15 +5,15 @@ import type { MetaShape, SelectItemData, SelectItemGroup } from '../types';
  * Combobox.Item) or a full SelectItemData object (keyboard selection, which
  * resolves from the `items` array). This normalizes both to a plain string.
  */
-export const resolveValue = (v: unknown): string | null => {
-  if (typeof v === 'string') return v;
+export const resolveValue = (value: unknown): string | null => {
+  if (typeof value === 'string') return value;
   if (
-    typeof v === 'object' &&
-    v !== null &&
-    'value' in v &&
-    typeof (v as Record<string, unknown>).value === 'string'
+    typeof value === 'object' &&
+    value !== null &&
+    'value' in value &&
+    typeof (value as Record<string, unknown>).value === 'string'
   ) {
-    return (v as Record<string, unknown>).value as string;
+    return (value as Record<string, unknown>).value as string;
   }
   return null;
 };

--- a/libs/ui-react/src/lib/Components/Select/utils/index.ts
+++ b/libs/ui-react/src/lib/Components/Select/utils/index.ts
@@ -1,1 +1,5 @@
-export { groupItemsByKey, defaultLabelFilter } from './groupItems';
+export {
+  resolveValue,
+  groupItemsByKey,
+  defaultLabelFilter,
+} from './groupItems';


### PR DESCRIPTION
## Overview

- Fix onValueChange returning full objects on keyboard selection: base-ui's Combobox resolves keyboard-selected items from its internal items array, yielding SelectItemData objects instead of plain strings. A resolveValue normalizer + isItemEqualToValue override ensure onValueChange always emits a string | null.
- Fix arrow-key navigation when SelectSearch is absent: Combobox requires an Input element to handle arrow keys. A hidden SelectFallbackInput is now rendered inside SelectContent when no SelectSearch is mounted.
- Align SelectItemData generics with OptionListItemData: Introduced MetaShape and replaced the unconstrained Meta default with TMeta extends MetaShape = MetaShape, threaded through SelectItemGroup, SelectProps, SelectListProps, useSelectItems, and groupItemsByKey — matching the React Native OptionList pattern.