### PR TITLE
[M]DLS-706-feat(visualisation): Add Point subcomponent

### DIFF
--- a/.nx/version-plans/version-plan-1777563340916.md
+++ b/.nx/version-plans/version-plan-1777563340916.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative-visualization': patch
+---
+
+feat(Point): Introduce Point component

--- a/apps/app-sandbox-rnative/src/app/blocks/LineCharts.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/LineCharts.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from '@ledgerhq/lumen-ui-rnative';
 import { useTheme } from '@ledgerhq/lumen-ui-rnative/styles';
-import { LineChart } from '@ledgerhq/lumen-ui-rnative-visualization';
+import { LineChart, Point } from '@ledgerhq/lumen-ui-rnative-visualization';
 
 const sampleSeries = [
   {
@@ -56,6 +56,62 @@ const Section = ({
     </Box>
   );
 };
+
+const PointMinMax = () => {
+  const data = sampleSeries[0].data;
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const minIdx = data.indexOf(min);
+  const maxIdx = data.indexOf(max);
+
+  return (
+    <LineChart series={sampleSeries} width={320} height={200} showArea>
+      <Point dataX={maxIdx} dataY={max} color='#47883A' label={`$${max}`} />
+      <Point
+        dataX={minIdx}
+        dataY={min}
+        color='#C24244'
+        label={`$${min}`}
+        labelPosition='bottom'
+      />
+    </LineChart>
+  );
+};
+
+const months = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+  'Jan',
+  'Feb',
+];
+
+const PointLabelFunction = () => (
+  <LineChart series={sampleSeries} width={320} height={200}>
+    <Point
+      dataX={4}
+      dataY={98}
+      color='#47883A'
+      label={(i) => `${months[i]}: $${sampleSeries[0].data[i]}`}
+    />
+    <Point
+      dataX={9}
+      dataY={4}
+      color='#C24244'
+      label={(i) => `${months[i]}: $${sampleSeries[0].data[i]}`}
+      labelPosition='bottom'
+    />
+  </LineChart>
+);
 
 export const LineCharts = () => {
   return (
@@ -182,6 +238,61 @@ export const LineCharts = () => {
             domain: { min: 0, max: 100 },
           }}
         />
+      </Section>
+
+      <Section title='Point – min/max highlights'>
+        <PointMinMax />
+      </Section>
+
+      <Section title='Point – all data points'>
+        <LineChart series={sampleSeries} width={320} height={200} showArea>
+          {sampleSeries[0].data.map((value, i) => (
+            <Point key={i} dataX={i} dataY={value} size={8} />
+          ))}
+        </LineChart>
+      </Section>
+
+      <Section title='Point – label function'>
+        <PointLabelFunction />
+      </Section>
+
+      <Section title='Point – hidden point (label only)'>
+        <LineChart series={sampleSeries} width={320} height={200} showArea>
+          <Point dataX={4} dataY={98} hidePoint label='Peak' />
+          <Point
+            dataX={9}
+            dataY={4}
+            hidePoint
+            label='Low'
+            labelPosition='bottom'
+          />
+        </LineChart>
+      </Section>
+
+      <Section title='Point – with axes'>
+        <LineChart
+          series={sampleSeries}
+          width={320}
+          height={220}
+          showArea
+          showXAxis
+          showYAxis
+          xAxis={{ showLine: true, showGrid: true }}
+          yAxis={{
+            showLine: true,
+            showGrid: true,
+            tickLabelFormatter: (v) => `$${v}`,
+          }}
+        >
+          <Point dataX={4} dataY={98} color='#47883A' label='$98' />
+          <Point
+            dataX={9}
+            dataY={4}
+            color='#C24244'
+            label='$4'
+            labelPosition='bottom'
+          />
+        </LineChart>
       </Section>
     </Box>
   );

--- a/libs/ui-react-visualization/eslint.config.mjs
+++ b/libs/ui-react-visualization/eslint.config.mjs
@@ -1,3 +1,4 @@
+import eslintPluginBetterTailwindcss from 'eslint-plugin-better-tailwindcss';
 import storybook from 'eslint-plugin-storybook';
 
 import { prodConfig } from '../../eslint.config.mjs';
@@ -5,9 +6,10 @@ import { prodConfig } from '../../eslint.config.mjs';
 export default [
   ...prodConfig,
   {
-    files: ['**/*.{js,jsx,ts,tsx,cjs,cts,mjs,mts}'],
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
     plugins: {
       storybook,
+      'better-tailwindcss': eslintPluginBetterTailwindcss,
     },
     rules: {
       'storybook/no-uninstalled-addons': [
@@ -16,6 +18,29 @@ export default [
           packageJsonLocation: '../../package.json',
         },
       ],
+      ...eslintPluginBetterTailwindcss.configs['recommended-warn'].rules,
+      ...eslintPluginBetterTailwindcss.configs['recommended-error'].rules,
+      'better-tailwindcss/enforce-consistent-line-wrapping': 'off',
+    },
+    settings: {
+      'better-tailwindcss': {
+        callees: [
+          ['cn', [{ match: 'strings' }]],
+          [
+            'cva',
+            [
+              { match: 'strings' },
+              {
+                match: 'objectValues',
+                pathPattern:
+                  '^compoundVariants\\[\\d+\\]\\.(?:className|class)$',
+              },
+            ],
+          ],
+        ],
+        entryPoint: './src/styles.css',
+        tailwindConfig: './tailwind.config.ts',
+      },
     },
   },
 ];

--- a/libs/ui-react-visualization/src/styles.css
+++ b/libs/ui-react-visualization/src/styles.css
@@ -1,0 +1,2 @@
+@import 'tailwindcss';
+@config '../tailwind.config.ts';

--- a/libs/ui-react-visualization/tailwind.config.ts
+++ b/libs/ui-react-visualization/tailwind.config.ts
@@ -1,0 +1,13 @@
+import { allBrandsPreset } from '@ledgerhq/lumen-design-core';
+import type { Config } from 'tailwindcss';
+
+const config = {
+  content: [
+    './src/**/*.{js,jsx,ts,tsx}',
+    '.storybook/**/*.{js,jsx,ts,tsx}',
+    './lib/**/*.stories.{js,jsx,ts,tsx}',
+  ],
+  presets: [allBrandsPreset],
+} satisfies Config;
+
+export default config;

--- a/libs/ui-rnative-visualization/jest.setup.ts
+++ b/libs/ui-rnative-visualization/jest.setup.ts
@@ -26,6 +26,7 @@ jest.mock('react-native-svg', () => {
     Rect: createMockComponent('Rect'),
     Path: createMockComponent('Path'),
     Line: createMockComponent('Line'),
+    Polygon: createMockComponent('Polygon'),
     G: createMockComponent('G'),
     Text: createMockComponent('Text'),
     Defs: createMockComponent('Defs'),

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
@@ -2,68 +2,16 @@ import { useCallback, useMemo, useState } from 'react';
 import { View, type LayoutChangeEvent } from 'react-native';
 import { Svg } from 'react-native-svg';
 
-import type { ChartInset } from '../../utils/types';
-
 import { CartesianChartProvider, useBuildChartContext } from './context';
 import type { CartesianChartProps } from './types';
+import {
+  DEFAULT_HEIGHT,
+  OVERFLOW_NEGATIVE_MARGIN,
+  resolveAxisPadding,
+  resolveInset,
+} from './utils';
 
-const DEFAULT_HEIGHT = 160;
-const DEFAULT_INSET: ChartInset = {
-  top: 30,
-  right: 20,
-  bottom: 30,
-  left: 20,
-};
-
-const DEFAULT_NEGATIVE_MARGIN = {
-  marginLeft: -20,
-  marginRight: -20,
-};
-
-const ZERO_PADDING: ChartInset = {
-  top: 0,
-  right: 0,
-  bottom: 0,
-  left: 0,
-};
-
-const resolveInset = (inset: CartesianChartProps['inset']): ChartInset => {
-  if (inset === undefined) {
-    return DEFAULT_INSET;
-  }
-
-  if (typeof inset === 'number') {
-    return {
-      top: inset + DEFAULT_INSET.top,
-      right: inset + DEFAULT_INSET.right,
-      bottom: inset + DEFAULT_INSET.bottom,
-      left: inset + DEFAULT_INSET.left,
-    };
-  }
-  return {
-    top: (inset.top ?? 0) + DEFAULT_INSET.top,
-    right: (inset.right ?? 0) + DEFAULT_INSET.right,
-    bottom: (inset.bottom ?? 0) + DEFAULT_INSET.bottom,
-    left: (inset.left ?? 0) + DEFAULT_INSET.left,
-  };
-};
-
-const resolveAxisPadding = (
-  padding: CartesianChartProps['axisPadding'],
-): ChartInset => {
-  if (padding === undefined) {
-    return ZERO_PADDING;
-  }
-
-  return {
-    top: padding.top ?? 0,
-    right: padding.right ?? 0,
-    bottom: padding.bottom ?? 0,
-    left: padding.left ?? 0,
-  };
-};
-
-export const CartesianChart = ({
+export function CartesianChart({
   series,
   xAxis,
   yAxis,
@@ -73,7 +21,7 @@ export const CartesianChart = ({
   axisPadding,
   ariaLabel = 'Chart',
   children,
-}: CartesianChartProps) => {
+}: CartesianChartProps) {
   const [measuredWidth, setMeasuredWidth] = useState<number | undefined>(width);
 
   const needsMeasurement = width === undefined;
@@ -125,7 +73,7 @@ export const CartesianChart = ({
         onLayout={handleLayout}
         style={{
           height,
-          ...DEFAULT_NEGATIVE_MARGIN,
+          ...OVERFLOW_NEGATIVE_MARGIN,
         }}
         accessibilityRole='image'
         accessibilityLabel={ariaLabel}
@@ -143,11 +91,10 @@ export const CartesianChart = ({
       style={{
         width: resolvedWidth,
         height,
-        marginLeft: -20,
-        marginRight: -20,
+        ...OVERFLOW_NEGATIVE_MARGIN,
       }}
     >
       {svgContent}
     </View>
   );
-};
+}

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
@@ -9,9 +9,9 @@ import type { CartesianChartProps } from './types';
 
 const DEFAULT_HEIGHT = 160;
 const DEFAULT_INSET: ChartInset = {
-  top: 5,
+  top: 30,
   right: 20,
-  bottom: 0,
+  bottom: 30,
   left: 20,
 };
 

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
@@ -21,7 +21,7 @@ export function CartesianChart({
   axisPadding,
   ariaLabel = 'Chart',
   children,
-}: CartesianChartProps) {
+}: Readonly<CartesianChartProps>) {
   const [measuredWidth, setMeasuredWidth] = useState<number | undefined>(width);
 
   const needsMeasurement = width === undefined;

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/types.ts
@@ -26,8 +26,10 @@ export type CartesianChartProps = {
    */
   height?: number;
   /**
-   * Padding between the SVG edge and the drawing area.
-   * A number applies uniformly; a partial object overrides individual sides.
+   * Extra padding between the SVG edge and the drawing area, added on top of
+   * a built-in overflow buffer that prevents content (labels, points, ticks)
+   * from being clipped. A number applies uniformly; a partial object sets
+   * individual sides (unset sides default to `0`).
    */
   inset?: number | Partial<ChartInset>;
   /**

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/utils.test.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/utils.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  OVERFLOW_BUFFER,
+  ZERO_PADDING,
+  resolveAxisPadding,
+  resolveInset,
+} from './utils';
+
+describe('resolveInset', () => {
+  it('should return DEFAULT_INSET when undefined', () => {
+    expect(resolveInset(undefined)).toEqual(OVERFLOW_BUFFER);
+  });
+
+  it('should add a uniform number to each default side', () => {
+    expect(resolveInset(10)).toEqual({
+      top: 10 + OVERFLOW_BUFFER.top,
+      right: 10 + OVERFLOW_BUFFER.right,
+      bottom: 10 + OVERFLOW_BUFFER.bottom,
+      left: 10 + OVERFLOW_BUFFER.left,
+    });
+  });
+
+  it('should handle zero as a uniform number', () => {
+    expect(resolveInset(0)).toEqual(OVERFLOW_BUFFER);
+  });
+
+  it('should handle negative uniform values', () => {
+    expect(resolveInset(-5)).toEqual({
+      top: -5 + OVERFLOW_BUFFER.top,
+      right: -5 + OVERFLOW_BUFFER.right,
+      bottom: -5 + OVERFLOW_BUFFER.bottom,
+      left: -5 + OVERFLOW_BUFFER.left,
+    });
+  });
+
+  it('should merge a full partial object with defaults', () => {
+    expect(resolveInset({ top: 10, right: 15, bottom: 20, left: 25 })).toEqual({
+      top: 10 + OVERFLOW_BUFFER.top,
+      right: 15 + OVERFLOW_BUFFER.right,
+      bottom: 20 + OVERFLOW_BUFFER.bottom,
+      left: 25 + OVERFLOW_BUFFER.left,
+    });
+  });
+
+  it('should treat missing sides as 0 when given a partial object', () => {
+    expect(resolveInset({ top: 10 })).toEqual({
+      top: 10 + OVERFLOW_BUFFER.top,
+      right: OVERFLOW_BUFFER.right,
+      bottom: OVERFLOW_BUFFER.bottom,
+      left: OVERFLOW_BUFFER.left,
+    });
+  });
+
+  it('should handle an empty object', () => {
+    expect(resolveInset({})).toEqual(OVERFLOW_BUFFER);
+  });
+});
+
+describe('resolveAxisPadding', () => {
+  it('should return ZERO_PADDING when undefined', () => {
+    expect(resolveAxisPadding(undefined)).toEqual(ZERO_PADDING);
+  });
+
+  it('should resolve a full padding object', () => {
+    expect(
+      resolveAxisPadding({ top: 5, right: 10, bottom: 15, left: 20 }),
+    ).toEqual({
+      top: 5,
+      right: 10,
+      bottom: 15,
+      left: 20,
+    });
+  });
+
+  it('should treat missing sides as 0', () => {
+    expect(resolveAxisPadding({ bottom: 30 })).toEqual({
+      top: 0,
+      right: 0,
+      bottom: 30,
+      left: 0,
+    });
+  });
+
+  it('should handle an empty object', () => {
+    expect(resolveAxisPadding({})).toEqual(ZERO_PADDING);
+  });
+});

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/utils.test.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it, expect } from '@jest/globals';
 
 import {
   OVERFLOW_BUFFER,

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/utils.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/utils.ts
@@ -1,0 +1,65 @@
+import type { ChartInset } from '../../utils/types';
+import type { CartesianChartProps } from './types';
+
+export const DEFAULT_HEIGHT = 160;
+
+/**
+ * Internal buffer that prevents SVG content (labels, points, ticks) from being
+ * clipped at the edge of the container. Compensated by negative margins on the
+ * wrapper so the chart's visual footprint stays unchanged.
+ */
+export const OVERFLOW_BUFFER: ChartInset = {
+  top: 30,
+  right: 20,
+  bottom: 30,
+  left: 20,
+};
+export const OVERFLOW_NEGATIVE_MARGIN = {
+  marginTop: -OVERFLOW_BUFFER.top,
+  marginRight: -OVERFLOW_BUFFER.right,
+  marginBottom: -OVERFLOW_BUFFER.bottom,
+  marginLeft: -OVERFLOW_BUFFER.left,
+};
+export const ZERO_PADDING: ChartInset = {
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+};
+
+export const resolveInset = (
+  inset: CartesianChartProps['inset'],
+): ChartInset => {
+  let consumer: ChartInset;
+  if (inset === undefined) {
+    consumer = ZERO_PADDING;
+  } else if (typeof inset === 'number') {
+    consumer = { top: inset, right: inset, bottom: inset, left: inset };
+  } else {
+    consumer = {
+      top: inset.top ?? 0,
+      right: inset.right ?? 0,
+      bottom: inset.bottom ?? 0,
+      left: inset.left ?? 0,
+    };
+  }
+
+  return {
+    top: consumer.top + OVERFLOW_BUFFER.top,
+    right: consumer.right + OVERFLOW_BUFFER.right,
+    bottom: consumer.bottom + OVERFLOW_BUFFER.bottom,
+    left: consumer.left + OVERFLOW_BUFFER.left,
+  };
+};
+
+export const resolveAxisPadding = (
+  padding: CartesianChartProps['axisPadding'],
+): ChartInset => {
+  if (padding === undefined) return ZERO_PADDING;
+  return {
+    top: padding.top ?? 0,
+    right: padding.right ?? 0,
+    bottom: padding.bottom ?? 0,
+    left: padding.left ?? 0,
+  };
+};

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { useCallback } from 'react';
 import { View } from 'react-native';
 import { StoryDecorator } from '../../../../.storybook/StoryDecorator.tsx';
 
+import { Point } from '../Point/Point';
 import { LineChart } from './LineChart';
 
 const meta = {
@@ -296,5 +298,43 @@ export const WithAreaMultipleSeries: Story = {
       showLine: true,
       domain: { min: 0, max: 100 },
     },
+  },
+};
+
+export const WithPoints: Story = {
+  parameters: {
+    layout: 'centered',
+    backgrounds: { default: 'light' },
+  },
+  render: () => {
+    const data = [10, 22, 29, 45, 98, 45, 22, 52, 21, 4, 68, 20, 21, 58];
+    const minPrice = Math.min(...data);
+    const maxPrice = Math.max(...data);
+
+    const minPriceIndex = data.indexOf(minPrice);
+    const maxPriceIndex = data.indexOf(maxPrice);
+
+    const formatPrice = useCallback((price: number) => {
+      return `$${price.toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })}`;
+    }, []);
+    return (
+      <LineChart showArea series={sampleSeries}>
+        <Point
+          dataX={minPriceIndex}
+          dataY={minPrice}
+          label={formatPrice(minPrice)}
+          labelPosition='bottom'
+        />
+        <Point
+          dataX={maxPriceIndex}
+          dataY={maxPrice}
+          label={formatPrice(maxPrice)}
+          labelPosition='top'
+        />
+      </LineChart>
+    );
   },
 };

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
@@ -1,9 +1,11 @@
+import { useTheme } from '@ledgerhq/lumen-ui-rnative';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { useCallback } from 'react';
 import { View } from 'react-native';
+import { G } from 'react-native-svg';
 import { StoryDecorator } from '../../../../.storybook/StoryDecorator.tsx';
 
-import { Point } from '../Point/Point';
+import { Point, PointLabel } from '../Point/Point';
 import { LineChart } from './LineChart';
 
 const meta = {
@@ -333,6 +335,52 @@ export const WithPoints: Story = {
           dataY={maxPrice}
           label={formatPrice(maxPrice)}
           labelPosition='top'
+        />
+      </LineChart>
+    );
+  },
+};
+
+export const WithCustomLabelComponent: Story = {
+  parameters: {
+    layout: 'centered',
+    backgrounds: { default: 'light' },
+  },
+  render: () => {
+    const { theme } = useTheme();
+    return (
+      <LineChart
+        series={sampleSeries}
+        height={250}
+        inset={{ top: 15 }}
+        showArea
+      >
+        <Point
+          dataX={9}
+          dataY={4}
+          label='$4.00'
+          color={theme.colors.bg.errorStrong}
+          labelPosition='bottom'
+          LabelComponent={({ children, ...props }) => (
+            <PointLabel {...props}>{children}</PointLabel>
+          )}
+        />
+        <Point
+          dataX={4}
+          dataY={98}
+          label='$98.00'
+          color={theme.colors.bg.successStrong}
+          labelPosition='top'
+          LabelComponent={({ x, y, children }) => (
+            <G>
+              <PointLabel x={x} y={y - 16}>
+                {children}
+              </PointLabel>
+              <PointLabel x={x} y={y} fontSize={10}>
+                +5.2%
+              </PointLabel>
+            </G>
+          )}
         />
       </LineChart>
     );

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
@@ -1,11 +1,7 @@
-import { useTheme } from '@ledgerhq/lumen-ui-rnative';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import { useCallback } from 'react';
 import { View } from 'react-native';
-import { G } from 'react-native-svg';
-import { StoryDecorator } from '../../../../.storybook/StoryDecorator.tsx';
 
-import { Point, PointLabel } from '../Point/Point';
+import { StoryDecorator } from '../../../../.storybook/StoryDecorator.tsx';
 import { LineChart } from './LineChart';
 
 const meta = {
@@ -300,89 +296,5 @@ export const WithAreaMultipleSeries: Story = {
       showLine: true,
       domain: { min: 0, max: 100 },
     },
-  },
-};
-
-export const WithPoints: Story = {
-  parameters: {
-    layout: 'centered',
-    backgrounds: { default: 'light' },
-  },
-  render: () => {
-    const data = [10, 22, 29, 45, 98, 45, 22, 52, 21, 4, 68, 20, 21, 58];
-    const minPrice = Math.min(...data);
-    const maxPrice = Math.max(...data);
-
-    const minPriceIndex = data.indexOf(minPrice);
-    const maxPriceIndex = data.indexOf(maxPrice);
-
-    const formatPrice = useCallback((price: number) => {
-      return `$${price.toLocaleString('en-US', {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })}`;
-    }, []);
-    return (
-      <LineChart showArea series={sampleSeries}>
-        <Point
-          dataX={minPriceIndex}
-          dataY={minPrice}
-          label={formatPrice(minPrice)}
-          labelPosition='bottom'
-        />
-        <Point
-          dataX={maxPriceIndex}
-          dataY={maxPrice}
-          label={formatPrice(maxPrice)}
-          labelPosition='top'
-        />
-      </LineChart>
-    );
-  },
-};
-
-export const WithCustomLabelComponent: Story = {
-  parameters: {
-    layout: 'centered',
-    backgrounds: { default: 'light' },
-  },
-  render: () => {
-    const { theme } = useTheme();
-    return (
-      <LineChart
-        series={sampleSeries}
-        height={250}
-        inset={{ top: 15 }}
-        showArea
-      >
-        <Point
-          dataX={9}
-          dataY={4}
-          label='$4.00'
-          color={theme.colors.bg.errorStrong}
-          labelPosition='bottom'
-          LabelComponent={({ children, ...props }) => (
-            <PointLabel {...props}>{children}</PointLabel>
-          )}
-        />
-        <Point
-          dataX={4}
-          dataY={98}
-          label='$98.00'
-          color={theme.colors.bg.successStrong}
-          labelPosition='top'
-          LabelComponent={({ x, y, children }) => (
-            <G>
-              <PointLabel x={x} y={y - 16}>
-                {children}
-              </PointLabel>
-              <PointLabel x={x} y={y} fontSize={10}>
-                +5.2%
-              </PointLabel>
-            </G>
-          )}
-        />
-      </LineChart>
-    );
   },
 };

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/Point.stories.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/Point.stories.tsx
@@ -1,0 +1,152 @@
+import { useTheme } from '@ledgerhq/lumen-ui-rnative';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { View } from 'react-native';
+import { G } from 'react-native-svg';
+
+import { StoryDecorator } from '../../../../.storybook/StoryDecorator.tsx';
+import { LineChart } from '../LineChart';
+import { Point, PointLabel } from './Point';
+
+const sampleSeries = [
+  {
+    id: 'prices',
+    stroke: '#7B61FF',
+    data: [10, 22, 29, 45, 98, 45, 22, 52, 21, 4, 68, 20, 21, 58],
+  },
+];
+
+const meta = {
+  component: Point,
+  title: 'Visualization/Point',
+  tags: ['experimental'],
+  decorators: [
+    (Story, context) => {
+      return (
+        <StoryDecorator context={context}>
+          <View style={{ width: 600, padding: 16 }}>
+            <Story />
+          </View>
+        </StoryDecorator>
+      );
+    },
+  ],
+} satisfies Meta<typeof Point>;
+
+export default meta;
+type Story = StoryObj<typeof Point>;
+
+export const Base: Story = {
+  parameters: {
+    layout: 'centered',
+    backgrounds: { default: 'light' },
+  },
+  render: () => {
+    const { theme } = useTheme();
+    return (
+      <LineChart series={sampleSeries} height={250} showArea>
+        <Point
+          dataX={9}
+          dataY={4}
+          label='$4.00'
+          color={theme.colors.bg.errorStrong}
+          labelPosition='bottom'
+        />
+        <Point
+          dataX={4}
+          dataY={98}
+          label='$98.00'
+          color={theme.colors.bg.successStrong}
+          labelPosition='top'
+        />
+      </LineChart>
+    );
+  },
+};
+
+export const WithCustomLabelComponent: Story = {
+  parameters: {
+    layout: 'centered',
+    backgrounds: { default: 'light' },
+  },
+  render: () => {
+    const { theme } = useTheme();
+    return (
+      <LineChart
+        series={sampleSeries}
+        height={250}
+        inset={{ top: 15 }}
+        showArea
+      >
+        <Point
+          dataX={9}
+          dataY={4}
+          label='$4.00'
+          color={theme.colors.bg.errorStrong}
+          labelPosition='bottom'
+          LabelComponent={({ children, ...props }) => (
+            <PointLabel {...props}>{children}</PointLabel>
+          )}
+        />
+        <Point
+          dataX={4}
+          dataY={98}
+          label='$98.00'
+          color={theme.colors.bg.successStrong}
+          labelPosition='top'
+          LabelComponent={({ x, y, children }) => (
+            <G>
+              <PointLabel x={x} y={y - 16}>
+                {children}
+              </PointLabel>
+              <PointLabel x={x} y={y} fontSize={10}>
+                +5.2%
+              </PointLabel>
+            </G>
+          )}
+        />
+      </LineChart>
+    );
+  },
+};
+
+export const NoPoint: Story = {
+  parameters: {
+    layout: 'centered',
+    backgrounds: { default: 'light' },
+  },
+  render: () => (
+    <LineChart series={sampleSeries} height={250} showArea>
+      <Point dataX={4} dataY={98} label='ATH' hidePoint />
+      <Point dataX={9} dataY={4} label='Low' hidePoint labelPosition='bottom' />
+    </LineChart>
+  ),
+};
+
+export const CustomSize: Story = {
+  parameters: {
+    layout: 'centered',
+    backgrounds: { default: 'light' },
+  },
+  render: () => {
+    const { theme } = useTheme();
+    return (
+      <LineChart series={sampleSeries} height={250} showArea>
+        <Point
+          dataX={4}
+          dataY={98}
+          size={16}
+          label={(i) => `Index ${i}`}
+          color={theme.colors.bg.successStrong}
+        />
+        <Point
+          dataX={9}
+          dataY={4}
+          size={6}
+          label='$4.00'
+          color={theme.colors.bg.errorStrong}
+          labelPosition='bottom'
+        />
+      </LineChart>
+    );
+  },
+};

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/Point.test.tsx
@@ -92,6 +92,21 @@ describe('Point', () => {
     expect(queryByTestId('point-label')).toBeNull();
   });
 
+  it('wraps labelComponent in a positioned group', () => {
+    const { getByTestId } = renderInChart(
+      <Point
+        dataX={2}
+        dataY={30}
+        labelComponent={<SvgText testID='custom-label'>Custom</SvgText>}
+      />,
+    );
+    const labelWrapper = getByTestId('point-label-wrapper');
+    expect(labelWrapper).toBeTruthy();
+    expect(labelWrapper.props.transform).toMatch(
+      /^translate\(\d+(\.\d+)?, \d+(\.\d+)?\)$/,
+    );
+  });
+
   it('hides the circle when hidePoint is true but shows label', () => {
     const { queryByTestId, getByTestId } = renderInChart(
       <Point dataX={2} dataY={30} hidePoint label='Still here' />,
@@ -129,7 +144,7 @@ describe('Point', () => {
 
   it('does not render arrow when showArrow is false', () => {
     const { queryByTestId } = renderInChart(
-      <Point dataX={2} dataY={30} label='Peak' showArrow={false} />,
+      <Point dataX={2} dataY={30} label='Peak' showLabelArrow={false} />,
     );
     expect(queryByTestId('point-arrow')).toBeNull();
   });

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/Point.test.tsx
@@ -63,56 +63,51 @@ describe('Point', () => {
   });
 
   it('renders a string label', () => {
-    const { getByTestId } = renderInChart(
+    const { getByText } = renderInChart(
       <Point dataX={2} dataY={30} label='Peak' />,
     );
-    const label = getByTestId('point-label');
-    expect(label).toBeTruthy();
-    expect(label.props.children).toBe('Peak');
+    expect(getByText('Peak')).toBeTruthy();
   });
 
   it('renders a label via function', () => {
-    const { getByTestId } = renderInChart(
+    const { getByText } = renderInChart(
       <Point dataX={2} dataY={30} label={(i) => `#${i}`} />,
     );
-    const label = getByTestId('point-label');
-    expect(label.props.children).toBe('#2');
+    expect(getByText('#2')).toBeTruthy();
   });
 
-  it('renders labelComponent when provided', () => {
-    const { getByTestId, queryByTestId } = renderInChart(
-      <Point
-        dataX={2}
-        dataY={30}
-        label='ignored'
-        labelComponent={<SvgText testID='custom-label'>Custom</SvgText>}
-      />,
+  it('renders custom LabelComponent', () => {
+    const CustomLabel = ({ x, y, children }: { x: number; y: number; children: string }) => (
+      <SvgText testID='custom-label' x={x} y={y}>
+        {children}
+      </SvgText>
     );
-    expect(getByTestId('custom-label')).toBeTruthy();
-    expect(queryByTestId('point-label')).toBeNull();
-  });
 
-  it('wraps labelComponent in a positioned group', () => {
     const { getByTestId } = renderInChart(
-      <Point
-        dataX={2}
-        dataY={30}
-        labelComponent={<SvgText testID='custom-label'>Custom</SvgText>}
-      />,
+      <Point dataX={2} dataY={30} label='Peak' LabelComponent={CustomLabel} />,
     );
-    const labelWrapper = getByTestId('point-label-wrapper');
-    expect(labelWrapper).toBeTruthy();
-    expect(labelWrapper.props.transform).toMatch(
-      /^translate\(\d+(\.\d+)?, \d+(\.\d+)?\)$/,
+
+    expect(getByTestId('custom-label')).toBeTruthy();
+  });
+
+  it('does not render LabelComponent when label is absent', () => {
+    const CustomLabel = ({ children }: { x: number; y: number; children: string }) => (
+      <SvgText testID='custom-label'>{children}</SvgText>
     );
+
+    const { queryByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} LabelComponent={CustomLabel} />,
+    );
+
+    expect(queryByTestId('custom-label')).toBeNull();
   });
 
   it('hides the circle when hidePoint is true but shows label', () => {
-    const { queryByTestId, getByTestId } = renderInChart(
+    const { queryByTestId, getByText } = renderInChart(
       <Point dataX={2} dataY={30} hidePoint label='Still here' />,
     );
     expect(queryByTestId('point-circle')).toBeNull();
-    expect(getByTestId('point-label')).toBeTruthy();
+    expect(getByText('Still here')).toBeTruthy();
   });
 
   it('returns null when point is outside drawing area', () => {

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/Point.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { ledgerLiveThemes } from '@ledgerhq/lumen-design-core';
+import { ThemeProvider } from '@ledgerhq/lumen-ui-rnative';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { Text as SvgText } from 'react-native-svg';
+
+import { CartesianChart } from '../CartesianChart';
+
+import { Point } from './Point';
+
+const sampleSeries = [{ id: 's1', stroke: '#000', data: [10, 20, 30, 40, 50] }];
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider themes={ledgerLiveThemes} colorScheme='light'>
+    {children}
+  </ThemeProvider>
+);
+
+const renderInChart = (
+  pointElement: React.ReactNode,
+  {
+    width = 400,
+    height = 200,
+    xAxis,
+    yAxis,
+  }: {
+    width?: number;
+    height?: number;
+    xAxis?: Parameters<typeof CartesianChart>[0]['xAxis'];
+    yAxis?: Parameters<typeof CartesianChart>[0]['yAxis'];
+  } = {},
+) =>
+  render(
+    <Wrapper>
+      <CartesianChart
+        series={sampleSeries}
+        width={width}
+        height={height}
+        xAxis={xAxis}
+        yAxis={yAxis}
+      >
+        {pointElement}
+      </CartesianChart>
+    </Wrapper>,
+  );
+
+describe('Point', () => {
+  it('renders a circle at the projected position', () => {
+    const { getByTestId } = renderInChart(<Point dataX={2} dataY={30} />);
+    const circle = getByTestId('point-circle');
+    expect(circle).toBeTruthy();
+    expect(circle.props.r).toBe(5);
+  });
+
+  it('renders with custom color and size', () => {
+    const { getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} color='#FF0000' size={16} />,
+    );
+    const circle = getByTestId('point-circle');
+    expect(circle.props.fill).toBe('#FF0000');
+    expect(circle.props.r).toBe(8);
+  });
+
+  it('renders a string label', () => {
+    const { getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} label='Peak' />,
+    );
+    const label = getByTestId('point-label');
+    expect(label).toBeTruthy();
+    expect(label.props.children).toBe('Peak');
+  });
+
+  it('renders a label via function', () => {
+    const { getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} label={(i) => `#${i}`} />,
+    );
+    const label = getByTestId('point-label');
+    expect(label.props.children).toBe('#2');
+  });
+
+  it('renders labelComponent when provided', () => {
+    const { getByTestId, queryByTestId } = renderInChart(
+      <Point
+        dataX={2}
+        dataY={30}
+        label='ignored'
+        labelComponent={<SvgText testID='custom-label'>Custom</SvgText>}
+      />,
+    );
+    expect(getByTestId('custom-label')).toBeTruthy();
+    expect(queryByTestId('point-label')).toBeNull();
+  });
+
+  it('hides the circle when hidePoint is true but shows label', () => {
+    const { queryByTestId, getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} hidePoint label='Still here' />,
+    );
+    expect(queryByTestId('point-circle')).toBeNull();
+    expect(getByTestId('point-label')).toBeTruthy();
+  });
+
+  it('returns null when point is outside drawing area', () => {
+    const { queryByTestId } = renderInChart(
+      <Point dataX={-100} dataY={-100} />,
+    );
+    expect(queryByTestId('point-group')).toBeNull();
+  });
+
+  it('works with band (categorical) x-axis scale', () => {
+    const { getByTestId } = renderInChart(<Point dataX={1} dataY={30} />, {
+      xAxis: { scaleType: 'band' },
+    });
+    const circle = getByTestId('point-circle');
+    expect(circle).toBeTruthy();
+  });
+
+  it('renders arrow when label is present and showArrow is true', () => {
+    const { getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} label='Peak' />,
+    );
+    expect(getByTestId('point-arrow')).toBeTruthy();
+  });
+
+  it('does not render arrow when no label is present', () => {
+    const { queryByTestId } = renderInChart(<Point dataX={2} dataY={30} />);
+    expect(queryByTestId('point-arrow')).toBeNull();
+  });
+
+  it('does not render arrow when showArrow is false', () => {
+    const { queryByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} label='Peak' showArrow={false} />,
+    );
+    expect(queryByTestId('point-arrow')).toBeNull();
+  });
+  it('calls onPress when the point is pressed', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} onPress={onPress} />,
+    );
+    fireEvent.press(getByTestId('point-group'));
+    expect(onPress).toHaveBeenCalled();
+  });
+});

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/Point.test.tsx
@@ -77,7 +77,15 @@ describe('Point', () => {
   });
 
   it('renders custom LabelComponent', () => {
-    const CustomLabel = ({ x, y, children }: { x: number; y: number; children: string }) => (
+    const CustomLabel = ({
+      x,
+      y,
+      children,
+    }: {
+      x: number;
+      y: number;
+      children: string;
+    }) => (
       <SvgText testID='custom-label' x={x} y={y}>
         {children}
       </SvgText>
@@ -91,9 +99,13 @@ describe('Point', () => {
   });
 
   it('does not render LabelComponent when label is absent', () => {
-    const CustomLabel = ({ children }: { x: number; y: number; children: string }) => (
-      <SvgText testID='custom-label'>{children}</SvgText>
-    );
+    const CustomLabel = ({
+      children,
+    }: {
+      x: number;
+      y: number;
+      children: string;
+    }) => <SvgText testID='custom-label'>{children}</SvgText>;
 
     const { queryByTestId } = renderInChart(
       <Point dataX={2} dataY={30} LabelComponent={CustomLabel} />,

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/Point.test.tsx
@@ -155,6 +155,37 @@ describe('Point', () => {
     );
     expect(queryByTestId('point-arrow')).toBeNull();
   });
+
+  it('renders label below the point when labelPosition is bottom', () => {
+    const topSpy = jest.fn(
+      ({ y }: { x: number; y: number; children: string }) => (
+        <SvgText>{y}</SvgText>
+      ),
+    );
+    const bottomSpy = jest.fn(
+      ({ y }: { x: number; y: number; children: string }) => (
+        <SvgText>{y}</SvgText>
+      ),
+    );
+
+    renderInChart(
+      <Point dataX={2} dataY={30} label='T' LabelComponent={topSpy} />,
+    );
+    renderInChart(
+      <Point
+        dataX={2}
+        dataY={30}
+        label='B'
+        labelPosition='bottom'
+        LabelComponent={bottomSpy}
+      />,
+    );
+
+    const topY = topSpy.mock.calls[0][0].y;
+    const bottomY = bottomSpy.mock.calls[0][0].y;
+    expect(bottomY).toBeGreaterThan(topY);
+  });
+
   it('calls onPress when the point is pressed', () => {
     const onPress = jest.fn();
     const { getByTestId } = renderInChart(

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/Point.tsx
@@ -1,0 +1,93 @@
+import { useTheme } from '@ledgerhq/lumen-ui-rnative';
+import { useMemo } from 'react';
+import { Circle, G, Polygon, Text as SvgText } from 'react-native-svg';
+
+import { projectPoint } from '../../utils/scales/scales';
+import { useCartesianChartContext } from '../CartesianChart/context';
+
+import type { PointProps } from './types';
+import {
+  buildArrowPoints,
+  computeLabelY,
+  DEFAULT_SIZE,
+  isWithinBounds,
+  LABEL_FONT_SIZE,
+  resolveLabel,
+  STROKE_WIDTH,
+} from './utils';
+
+export const Point = ({
+  dataX,
+  dataY,
+  color,
+  label,
+  labelComponent,
+  labelPosition = 'top',
+  hidePoint = false,
+  showArrow = true,
+  size = DEFAULT_SIZE,
+  onPress,
+}: PointProps) => {
+  const { getXScale, getYScale, drawingArea } = useCartesianChartContext();
+  const { theme } = useTheme();
+
+  const xScale = getXScale();
+  const yScale = getYScale();
+
+  const radius = size / 2;
+  const fill = color ?? theme.colors.bg.mutedStrong;
+  const stroke = theme.colors.bg.canvas;
+  const textColor = theme.colors.text.base;
+
+  const pixel = useMemo(() => {
+    if (!xScale || !yScale) return undefined;
+    return projectPoint(dataX, dataY, xScale, yScale);
+  }, [dataX, dataY, xScale, yScale]);
+
+  if (!pixel || !isWithinBounds(pixel.x, pixel.y, drawingArea)) {
+    return null;
+  }
+
+  const resolvedLabel = resolveLabel(label, dataX);
+  const hasLabel = labelComponent != null || resolvedLabel != null;
+  const renderArrow = showArrow && hasLabel;
+  const labelY = computeLabelY(pixel.y, radius, labelPosition, renderArrow);
+
+  return (
+    <G testID='point-group' onPress={onPress}>
+      {!hidePoint && (
+        <Circle
+          testID='point-circle'
+          cx={pixel.x}
+          cy={pixel.y}
+          r={radius}
+          fill={fill}
+          stroke={stroke}
+          strokeWidth={STROKE_WIDTH}
+        />
+      )}
+      {renderArrow && (
+        <Polygon
+          testID='point-arrow'
+          points={buildArrowPoints(pixel.x, pixel.y, radius, labelPosition)}
+          fill={textColor}
+        />
+      )}
+      {labelComponent}
+      {!labelComponent && resolvedLabel != null && (
+        <SvgText
+          testID='point-label'
+          x={pixel.x}
+          y={labelY}
+          textAnchor='middle'
+          fill={textColor}
+          fontSize={LABEL_FONT_SIZE}
+          fontWeight='500'
+          fontFamily='Inter'
+        >
+          {resolvedLabel}
+        </SvgText>
+      )}
+    </G>
+  );
+};

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/Point.tsx
@@ -5,7 +5,7 @@ import { Circle, G, Polygon, Text as SvgText } from 'react-native-svg';
 import { projectPoint } from '../../utils/scales/scales';
 import { useCartesianChartContext } from '../CartesianChart/context';
 
-import type { PointProps } from './types';
+import type { PointLabelProps, PointProps } from './types';
 import {
   buildArrowPoints,
   computeLabelY,
@@ -15,18 +15,36 @@ import {
   STROKE_WIDTH,
 } from './utils';
 
-export const Point = ({
+export function PointLabel({ x, y, children }: PointLabelProps) {
+  const { theme } = useTheme();
+
+  return (
+    <SvgText
+      x={x}
+      y={y}
+      textAnchor='middle'
+      fill={theme.colors.text.base}
+      fontSize={theme.typographies.body4.fontSize}
+      fontWeight={theme.typographies.body4.fontWeight}
+      fontFamily={theme.fontFamilies.sans}
+    >
+      {children}
+    </SvgText>
+  );
+}
+
+export function Point({
   dataX,
   dataY,
   color,
   label,
-  labelComponent,
+  LabelComponent,
   labelPosition = 'top',
   hidePoint = false,
   showLabelArrow = true,
   size = DEFAULT_SIZE,
   onPress,
-}: Readonly<PointProps>) => {
+}: Readonly<PointProps>) {
   const { getXScale, getYScale, drawingArea } = useCartesianChartContext();
   const { theme } = useTheme();
 
@@ -35,8 +53,6 @@ export const Point = ({
 
   const radius = size / 2;
   const fill = color ?? theme.colors.bg.mutedStrong;
-  const stroke = theme.colors.bg.canvas;
-  const textColor = theme.colors.text.base;
 
   const pixel = useMemo(() => {
     if (!xScale || !yScale) return undefined;
@@ -48,9 +64,11 @@ export const Point = ({
   }
 
   const resolvedLabel = resolveLabel(label, dataX);
-  const hasLabel = labelComponent != null || resolvedLabel != null;
+  const hasLabel = resolvedLabel != null;
   const renderArrow = showLabelArrow && hasLabel;
   const labelY = computeLabelY(pixel.y, radius, labelPosition, renderArrow);
+
+  const Label = LabelComponent ?? PointLabel;
 
   return (
     <G testID='point-group' onPress={onPress}>
@@ -61,7 +79,7 @@ export const Point = ({
           cy={pixel.y}
           r={radius}
           fill={fill}
-          stroke={stroke}
+          stroke={theme.colors.bg.canvas}
           strokeWidth={STROKE_WIDTH}
         />
       )}
@@ -69,31 +87,14 @@ export const Point = ({
         <Polygon
           testID='point-arrow'
           points={buildArrowPoints(pixel.x, pixel.y, radius, labelPosition)}
-          fill={textColor}
+          fill={theme.colors.text.base}
         />
       )}
-      {labelComponent && (
-        <G
-          testID='point-label-wrapper'
-          transform={`translate(${pixel.x}, ${labelY})`}
-        >
-          {labelComponent}
-        </G>
-      )}
-      {!labelComponent && resolvedLabel != null && (
-        <SvgText
-          testID='point-label'
-          x={pixel.x}
-          y={labelY}
-          textAnchor='middle'
-          fill={textColor}
-          fontSize={theme.typographies.body4.fontSize}
-          fontWeight={theme.typographies.body4.fontWeight}
-          fontFamily={theme.fontFamilies.sans}
-        >
+      {resolvedLabel != null && (
+        <Label x={pixel.x} y={labelY}>
           {resolvedLabel}
-        </SvgText>
+        </Label>
       )}
     </G>
   );
-};
+}

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/Point.tsx
@@ -11,7 +11,6 @@ import {
   computeLabelY,
   DEFAULT_SIZE,
   isWithinBounds,
-  LABEL_FONT_SIZE,
   resolveLabel,
   STROKE_WIDTH,
 } from './utils';
@@ -24,10 +23,10 @@ export const Point = ({
   labelComponent,
   labelPosition = 'top',
   hidePoint = false,
-  showArrow = true,
+  showLabelArrow = true,
   size = DEFAULT_SIZE,
   onPress,
-}: PointProps) => {
+}: Readonly<PointProps>) => {
   const { getXScale, getYScale, drawingArea } = useCartesianChartContext();
   const { theme } = useTheme();
 
@@ -50,7 +49,7 @@ export const Point = ({
 
   const resolvedLabel = resolveLabel(label, dataX);
   const hasLabel = labelComponent != null || resolvedLabel != null;
-  const renderArrow = showArrow && hasLabel;
+  const renderArrow = showLabelArrow && hasLabel;
   const labelY = computeLabelY(pixel.y, radius, labelPosition, renderArrow);
 
   return (
@@ -73,7 +72,14 @@ export const Point = ({
           fill={textColor}
         />
       )}
-      {labelComponent}
+      {labelComponent && (
+        <G
+          testID='point-label-wrapper'
+          transform={`translate(${pixel.x}, ${labelY})`}
+        >
+          {labelComponent}
+        </G>
+      )}
       {!labelComponent && resolvedLabel != null && (
         <SvgText
           testID='point-label'
@@ -81,9 +87,9 @@ export const Point = ({
           y={labelY}
           textAnchor='middle'
           fill={textColor}
-          fontSize={LABEL_FONT_SIZE}
-          fontWeight='500'
-          fontFamily='Inter'
+          fontSize={theme.typographies.body4.fontSize}
+          fontWeight={theme.typographies.body4.fontWeight}
+          fontFamily={theme.fontFamilies.sans}
         >
           {resolvedLabel}
         </SvgText>

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/Point.tsx
@@ -15,21 +15,21 @@ import {
   STROKE_WIDTH,
 } from './utils';
 
-export function PointLabel({ x, y, children }: PointLabelProps) {
+export function PointLabel({
+  textAnchor = 'middle',
+  ...props
+}: Readonly<PointLabelProps>) {
   const { theme } = useTheme();
 
   return (
     <SvgText
-      x={x}
-      y={y}
-      textAnchor='middle'
+      textAnchor={textAnchor}
       fill={theme.colors.text.base}
       fontSize={theme.typographies.body4.fontSize}
       fontWeight={theme.typographies.body4.fontWeight}
       fontFamily={theme.fontFamilies.sans}
-    >
-      {children}
-    </SvgText>
+      {...props}
+    />
   );
 }
 

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/index.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/index.ts
@@ -1,2 +1,2 @@
-export { Point } from './Point';
-export type { PointProps } from './types';
+export { Point, PointLabel } from './Point';
+export type { PointLabelComponent, PointLabelProps, PointProps } from './types';

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/index.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/index.ts
@@ -1,0 +1,2 @@
+export { Point } from './Point';
+export type { PointProps } from './types';

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/types.ts
@@ -1,5 +1,13 @@
-import type { ReactNode } from 'react';
+import type { ComponentType } from 'react';
 import type { GestureResponderEvent } from 'react-native';
+
+export type PointLabelProps = {
+  x: number;
+  y: number;
+  children: string;
+};
+
+export type PointLabelComponent = ComponentType<PointLabelProps>;
 
 export type PointProps = {
   /**
@@ -21,11 +29,12 @@ export type PointProps = {
    */
   label?: string | ((dataIndex: number) => string);
   /**
-   * Custom SVG element rendered instead of the default text label.
-   * Automatically translated so that `(0, 0)` is the label anchor point
-   * (horizontally centered on the point, vertically offset like the built-in label).
+   * Custom component rendered instead of the default `PointLabel`.
+   * Receives pixel coordinates (`x`, `y`) and the resolved label as
+   * `children`. Use `PointLabel` inside your component to retain
+   * theme styling while customising layout or appearance.
    */
-  labelComponent?: ReactNode;
+  LabelComponent?: PointLabelComponent;
   /**
    * Placement of the label relative to the point.
    * @default 'top'

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/types.ts
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react';
+import type { GestureResponderEvent } from 'react-native';
+
+export type PointProps = {
+  /**
+   * X coordinate in data space (index or explicit value).
+   */
+  dataX: number;
+  /**
+   * Y coordinate in data space.
+   */
+  dataY: number;
+  /**
+   * Fill color of the point circle.
+   */
+  color?: string;
+  /**
+   * Text label displayed near the point.
+   * A string is rendered directly; a function receives `dataX` and returns
+   * the label string, enabling index-based formatting.
+   */
+  label?: string | ((dataIndex: number) => string);
+  /**
+   * Custom component rendered instead of the default text label.
+   * Positioned at the same coordinates as the label would be.
+   */
+  labelComponent?: ReactNode;
+  /**
+   * Placement of the label relative to the point.
+   * @default 'top'
+   */
+  labelPosition?: 'top' | 'bottom';
+  /**
+   * When `true`, the point circle is hidden but the label (if any) is still rendered.
+   * @default false
+   */
+  hidePoint?: boolean;
+  /**
+   * Diameter of the point circle in pixels.
+   * Internally converted to an SVG radius (`size / 2`).
+   * @default 10
+   */
+  size?: number;
+  /**
+   * When `true`, an arrow is displayed pointing from the point to the label.
+   * @default true
+   */
+  showArrow?: boolean;
+  /**
+   * Called when the point is pressed.
+   */
+  onPress?: (event: GestureResponderEvent) => void;
+};

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/types.ts
@@ -21,8 +21,9 @@ export type PointProps = {
    */
   label?: string | ((dataIndex: number) => string);
   /**
-   * Custom component rendered instead of the default text label.
-   * Positioned at the same coordinates as the label would be.
+   * Custom SVG element rendered instead of the default text label.
+   * Automatically translated so that `(0, 0)` is the label anchor point
+   * (horizontally centered on the point, vertically offset like the built-in label).
    */
   labelComponent?: ReactNode;
   /**
@@ -45,7 +46,7 @@ export type PointProps = {
    * When `true`, an arrow is displayed pointing from the point to the label.
    * @default true
    */
-  showArrow?: boolean;
+  showLabelArrow?: boolean;
   /**
    * Called when the point is pressed.
    */

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/types.ts
@@ -21,6 +21,18 @@ export type PointProps = {
   dataY: number;
   /**
    * Fill color of the point circle.
+   * Defaults to `theme.colors.bg.mutedStrong`.
+   *
+   * Use the `useTheme` hook from `@ledgerhq/lumen-ui-rnative` to
+   * access design-token colors at runtime:
+   *
+   * @example
+   * ```tsx
+   * import { useTheme } from '@ledgerhq/lumen-ui-rnative';
+   *
+   * const { theme } = useTheme();
+   * <Point dataX={0} dataY={42} color={theme.colors.bg.errorStrong} />
+   * ```
    */
   color?: string;
   /**

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/types.ts
@@ -1,11 +1,12 @@
 import type { ComponentType } from 'react';
 import type { GestureResponderEvent } from 'react-native';
+import type { TextProps } from 'react-native-svg';
 
 export type PointLabelProps = {
   x: number;
   y: number;
   children: string;
-};
+} & Omit<TextProps, 'x' | 'y' | 'children'>;
 
 export type PointLabelComponent = ComponentType<PointLabelProps>;
 

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/utils.test.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/utils.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  ARROW_HEIGHT,
+  ARROW_WIDTH,
+  buildArrowPoints,
+  computeLabelY,
+  GAP,
+  isWithinBounds,
+  LABEL_FONT_SIZE,
+  resolveLabel,
+} from './utils';
+
+describe('isWithinBounds', () => {
+  const area = { x: 10, y: 20, width: 100, height: 50 };
+
+  it('returns true for a point inside the area', () => {
+    expect(isWithinBounds(50, 40, area)).toBe(true);
+  });
+
+  it('returns true on the top-left edge', () => {
+    expect(isWithinBounds(10, 20, area)).toBe(true);
+  });
+
+  it('returns true on the bottom-right edge', () => {
+    expect(isWithinBounds(110, 70, area)).toBe(true);
+  });
+
+  it('returns false when x is left of the area', () => {
+    expect(isWithinBounds(9, 40, area)).toBe(false);
+  });
+
+  it('returns false when x is right of the area', () => {
+    expect(isWithinBounds(111, 40, area)).toBe(false);
+  });
+
+  it('returns false when y is above the area', () => {
+    expect(isWithinBounds(50, 19, area)).toBe(false);
+  });
+
+  it('returns false when y is below the area', () => {
+    expect(isWithinBounds(50, 71, area)).toBe(false);
+  });
+});
+
+describe('buildArrowPoints', () => {
+  const cx = 100;
+  const cy = 200;
+  const radius = 5;
+  const halfW = ARROW_WIDTH / 2;
+
+  it('builds a downward-pointing arrow for top position', () => {
+    const result = buildArrowPoints(cx, cy, radius, 'top');
+    const tipY = cy - radius - GAP;
+    const baseY = tipY - ARROW_HEIGHT;
+    expect(result).toBe(
+      `${cx},${tipY} ${cx - halfW},${baseY} ${cx + halfW},${baseY}`,
+    );
+  });
+
+  it('builds an upward-pointing arrow for bottom position', () => {
+    const result = buildArrowPoints(cx, cy, radius, 'bottom');
+    const tipY = cy + radius + GAP;
+    const baseY = tipY + ARROW_HEIGHT;
+    expect(result).toBe(
+      `${cx},${tipY} ${cx - halfW},${baseY} ${cx + halfW},${baseY}`,
+    );
+  });
+});
+
+describe('resolveLabel', () => {
+  it('returns a string label as-is', () => {
+    expect(resolveLabel('Peak', 0)).toBe('Peak');
+  });
+
+  it('calls a function label with dataX', () => {
+    expect(resolveLabel((i) => `#${i}`, 3)).toBe('#3');
+  });
+
+  it('returns undefined for an undefined label', () => {
+    expect(resolveLabel(undefined, 0)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(resolveLabel('', 0)).toBeUndefined();
+  });
+
+  it('returns undefined when a function returns an empty string', () => {
+    expect(resolveLabel(() => '', 0)).toBeUndefined();
+  });
+});
+
+describe('computeLabelY', () => {
+  const pixelY = 100;
+  const radius = 5;
+
+  it('positions label above the point when labelPosition is top with arrow', () => {
+    const result = computeLabelY(pixelY, radius, 'top', true);
+    const arrowOffset = ARROW_HEIGHT + GAP;
+    expect(result).toBe(pixelY - radius - arrowOffset - GAP);
+  });
+
+  it('positions label above the point when labelPosition is top without arrow', () => {
+    const result = computeLabelY(pixelY, radius, 'top', false);
+    expect(result).toBe(pixelY - radius - GAP - GAP);
+  });
+
+  it('positions label below the point when labelPosition is bottom with arrow', () => {
+    const result = computeLabelY(pixelY, radius, 'bottom', true);
+    const arrowOffset = ARROW_HEIGHT + GAP;
+    expect(result).toBe(pixelY + radius + arrowOffset + GAP + LABEL_FONT_SIZE);
+  });
+
+  it('positions label below the point when labelPosition is bottom without arrow', () => {
+    const result = computeLabelY(pixelY, radius, 'bottom', false);
+    expect(result).toBe(pixelY + radius + GAP + GAP + LABEL_FONT_SIZE);
+  });
+});

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/utils.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/utils.ts
@@ -1,0 +1,68 @@
+export const DEFAULT_SIZE = 10;
+export const STROKE_WIDTH = 2;
+export const LABEL_FONT_SIZE = 10;
+export const ARROW_WIDTH = 6;
+export const ARROW_HEIGHT = 4;
+export const GAP = 4;
+
+export const isWithinBounds = (
+  px: number,
+  py: number,
+  area: { x: number; y: number; width: number; height: number },
+): boolean =>
+  px >= area.x &&
+  px <= area.x + area.width &&
+  py >= area.y &&
+  py <= area.y + area.height;
+
+/**
+ * Builds the three SVG points of the arrow triangle.
+ *
+ * `'top'`    → arrow sits below the label, tip pointing **down** toward the circle.
+ * `'bottom'` → arrow sits above the label, tip pointing **up** toward the circle.
+ */
+export const buildArrowPoints = (
+  cx: number,
+  cy: number,
+  radius: number,
+  position: 'top' | 'bottom',
+): string => {
+  const halfW = ARROW_WIDTH / 2;
+
+  if (position === 'top') {
+    const tipY = cy - radius - GAP;
+    const baseY = tipY - ARROW_HEIGHT;
+    return `${cx},${tipY} ${cx - halfW},${baseY} ${cx + halfW},${baseY}`;
+  }
+
+  const tipY = cy + radius + GAP;
+  const baseY = tipY + ARROW_HEIGHT;
+  return `${cx},${tipY} ${cx - halfW},${baseY} ${cx + halfW},${baseY}`;
+};
+
+/**
+ * Resolves the label prop to a string or undefined.
+ */
+export const resolveLabel = (
+  label: string | ((dataIndex: number) => string) | undefined,
+  dataX: number,
+): string | undefined => {
+  const resolved = typeof label === 'function' ? label(dataX) : label;
+  return resolved === '' ? undefined : resolved;
+};
+
+/**
+ * Computes the vertical position of the label text baseline.
+ */
+export const computeLabelY = (
+  pixelY: number,
+  radius: number,
+  labelPosition: 'top' | 'bottom',
+  renderArrow: boolean,
+): number => {
+  const arrowOffset = renderArrow ? ARROW_HEIGHT + GAP : GAP;
+
+  return labelPosition === 'top'
+    ? pixelY - radius - arrowOffset - GAP
+    : pixelY + radius + arrowOffset + GAP + LABEL_FONT_SIZE;
+};

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/utils.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/utils.ts
@@ -1,3 +1,5 @@
+import type { DrawingArea } from '../../utils/types';
+
 export const DEFAULT_SIZE = 10;
 export const STROKE_WIDTH = 2;
 export const LABEL_FONT_SIZE = 10;
@@ -8,7 +10,7 @@ export const GAP = 4;
 export const isWithinBounds = (
   px: number,
   py: number,
-  area: { x: number; y: number; width: number; height: number },
+  area: DrawingArea,
 ): boolean =>
   px >= area.x &&
   px <= area.x + area.width &&

--- a/libs/ui-rnative-visualization/src/lib/Components/index.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/index.ts
@@ -1,1 +1,2 @@
 export * from './LineChart';
+export * from './Point';

--- a/libs/ui-rnative-visualization/src/lib/utils/scales/scales.test.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/scales/scales.test.ts
@@ -6,6 +6,7 @@ import {
   isBandScaleType,
   isCategoricalScale,
   isNumericScale,
+  projectPoint,
 } from './scales';
 
 describe('getNumericScale', () => {
@@ -129,5 +130,58 @@ describe('isCategoricalScale / isNumericScale', () => {
   it('should identify a categorical scale', () => {
     expect(isCategoricalScale(bandScale)).toBe(true);
     expect(isNumericScale(bandScale)).toBe(false);
+  });
+});
+
+describe('projectPoint', () => {
+  it('should project using two linear scales', () => {
+    const xScale = getNumericScale({
+      scaleType: 'linear',
+      domain: { min: 0, max: 10 },
+      range: { min: 0, max: 500 },
+    });
+    const yScale = getNumericScale({
+      scaleType: 'linear',
+      domain: { min: 0, max: 100 },
+      range: { min: 300, max: 0 },
+    });
+
+    const pt = projectPoint(5, 50, xScale, yScale);
+    expect(pt.x).toBe(250);
+    expect(pt.y).toBe(150);
+  });
+
+  it('should center on band for a categorical x scale', () => {
+    const xScale = getCategoricalScale({
+      domain: { min: 0, max: 3 },
+      range: { min: 0, max: 400 },
+      padding: 0,
+    });
+    const yScale = getNumericScale({
+      scaleType: 'linear',
+      domain: { min: 0, max: 100 },
+      range: { min: 200, max: 0 },
+    });
+
+    const pt = projectPoint(1, 50, xScale, yScale);
+    const expectedX = (xScale(1) ?? 0) + xScale.bandwidth() / 2;
+    expect(pt.x).toBe(expectedX);
+    expect(pt.y).toBe(100);
+  });
+
+  it('should handle edge values at domain boundaries', () => {
+    const xScale = getNumericScale({
+      scaleType: 'linear',
+      domain: { min: 0, max: 10 },
+      range: { min: 0, max: 500 },
+    });
+    const yScale = getNumericScale({
+      scaleType: 'linear',
+      domain: { min: 0, max: 100 },
+      range: { min: 300, max: 0 },
+    });
+
+    expect(projectPoint(0, 0, xScale, yScale)).toEqual({ x: 0, y: 300 });
+    expect(projectPoint(10, 100, xScale, yScale)).toEqual({ x: 500, y: 0 });
   });
 });

--- a/libs/ui-rnative-visualization/src/lib/utils/scales/scales.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/scales/scales.ts
@@ -91,5 +91,5 @@ export const projectPoint = (
   const y = isCategoricalScale(yScale)
     ? (yScale(dataY) ?? 0) + yScale.bandwidth() / 2
     : yScale(dataY);
-  return { x: x as number, y };
+  return { x: x, y };
 };

--- a/libs/ui-rnative-visualization/src/lib/utils/scales/scales.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/scales/scales.ts
@@ -90,6 +90,6 @@ export const projectPoint = (
     : xScale(dataX);
   const y = isCategoricalScale(yScale)
     ? (yScale(dataY) ?? 0) + yScale.bandwidth() / 2
-    : (yScale as NumericScale)(dataY);
+    : yScale(dataY);
   return { x: x as number, y };
 };

--- a/libs/ui-rnative-visualization/src/lib/utils/scales/scales.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/scales/scales.ts
@@ -72,3 +72,24 @@ export const isNumericScale = (
 ): scale is NumericScale => {
   return !isCategoricalScale(scale);
 };
+
+/**
+ * Projects a single data-space coordinate pair to pixel-space
+ * using the provided x and y scale functions.
+ *
+ * For categorical (band) scales the point is anchored at the center of the band.
+ */
+export const projectPoint = (
+  dataX: number,
+  dataY: number,
+  xScale: ChartScaleFunction,
+  yScale: ChartScaleFunction,
+): { x: number; y: number } => {
+  const x = isCategoricalScale(xScale)
+    ? (xScale(dataX) ?? 0) + xScale.bandwidth() / 2
+    : xScale(dataX);
+  const y = isCategoricalScale(yScale)
+    ? (yScale(dataY) ?? 0) + yScale.bandwidth() / 2
+    : (yScale as NumericScale)(dataY);
+  return { x: x as number, y };
+};


### PR DESCRIPTION
## Overview

Introduce Point subcomponent, that allows to project a point onto a graph, supporting a label as a string or custom component.

---
<img width="1206" height="2622" alt="simulator_screenshot_41D093A3-DD8B-477F-9FF2-30478AC670D2" src="https://github.com/user-attachments/assets/36c61127-9d3c-4b07-b1c7-86983d24f4fe" />