### PR TITLE
[D]DLS-706-feat(visualisation): Add Point subcomponent

### DIFF
--- a/.nx/version-plans/version-plan-1777468984499.md
+++ b/.nx/version-plans/version-plan-1777468984499.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react-visualization': patch
+---
+
+feat(Point): Introduce Point component

--- a/libs/ui-react-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
@@ -1,64 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ChartInset } from '../../utils/types';
 
 import { CartesianChartProvider, useBuildChartContext } from './context';
 import type { CartesianChartProps } from './types';
-
-const DEFAULT_HEIGHT = 160;
-
-/**
- * Internal buffer that prevents SVG content (labels, points, ticks) from being
- * clipped at the edge of the container. Compensated by negative margins on the
- * wrapper so the chart's visual footprint stays unchanged.
- */
-const OVERFLOW_BUFFER: ChartInset = {
-  top: 30,
-  right: 20,
-  bottom: 30,
-  left: 20,
-};
-const OVERFLOW_NEGATIVE_MARGIN = {
-  marginTop: -OVERFLOW_BUFFER.top,
-  marginRight: -OVERFLOW_BUFFER.right,
-  marginBottom: -OVERFLOW_BUFFER.bottom,
-  marginLeft: -OVERFLOW_BUFFER.left,
-};
-const ZERO_PADDING: ChartInset = { top: 0, right: 0, bottom: 0, left: 0 };
-
-const resolveInset = (inset: CartesianChartProps['inset']): ChartInset => {
-  let consumer: ChartInset;
-  if (inset === undefined) {
-    consumer = ZERO_PADDING;
-  } else if (typeof inset === 'number') {
-    consumer = { top: inset, right: inset, bottom: inset, left: inset };
-  } else {
-    consumer = {
-      top: inset.top ?? 0,
-      right: inset.right ?? 0,
-      bottom: inset.bottom ?? 0,
-      left: inset.left ?? 0,
-    };
-  }
-
-  return {
-    top: consumer.top + OVERFLOW_BUFFER.top,
-    right: consumer.right + OVERFLOW_BUFFER.right,
-    bottom: consumer.bottom + OVERFLOW_BUFFER.bottom,
-    left: consumer.left + OVERFLOW_BUFFER.left,
-  };
-};
-
-const resolveAxisPadding = (
-  padding: CartesianChartProps['axisPadding'],
-): ChartInset => {
-  if (padding === undefined) return ZERO_PADDING;
-  return {
-    top: padding.top ?? 0,
-    right: padding.right ?? 0,
-    bottom: padding.bottom ?? 0,
-    left: padding.left ?? 0,
-  };
-};
+import {
+  DEFAULT_HEIGHT,
+  OVERFLOW_NEGATIVE_MARGIN,
+  resolveAxisPadding,
+  resolveInset,
+} from './utils';
 
 export function CartesianChart({
   series,

--- a/libs/ui-react-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
@@ -6,23 +6,28 @@ import type { CartesianChartProps } from './types';
 
 const DEFAULT_HEIGHT = 160;
 const DEFAULT_INSET: ChartInset = {
-  top: 8,
-  right: 0,
-  bottom: 0,
-  left: 0,
+  top: 30,
+  right: 20,
+  bottom: 30,
+  left: 20,
 };
 const ZERO_PADDING: ChartInset = { top: 0, right: 0, bottom: 0, left: 0 };
 
 const resolveInset = (inset: CartesianChartProps['inset']): ChartInset => {
   if (inset === undefined) return DEFAULT_INSET;
   if (typeof inset === 'number') {
-    return { top: inset, right: inset, bottom: inset, left: inset };
+    return {
+      top: inset + DEFAULT_INSET.top,
+      right: inset + DEFAULT_INSET.right,
+      bottom: inset + DEFAULT_INSET.bottom,
+      left: inset + DEFAULT_INSET.left,
+    };
   }
   return {
-    top: inset.top ?? DEFAULT_INSET.top,
-    right: inset.right ?? DEFAULT_INSET.right,
-    bottom: inset.bottom ?? DEFAULT_INSET.bottom,
-    left: inset.left ?? DEFAULT_INSET.left,
+    top: (inset.top ?? 0) + DEFAULT_INSET.top,
+    right: (inset.right ?? 0) + DEFAULT_INSET.right,
+    bottom: (inset.bottom ?? 0) + DEFAULT_INSET.bottom,
+    left: (inset.left ?? 0) + DEFAULT_INSET.left,
   };
 };
 
@@ -116,12 +121,27 @@ export function CartesianChart({
       <div
         ref={containerRef}
         data-testid='chart-container'
-        style={{ width, height }}
+        style={{
+          width,
+          height,
+          margin: `${-DEFAULT_INSET.top}px ${-DEFAULT_INSET.right}px`,
+        }}
       >
         {measuredWidth !== undefined && svgContent}
       </div>
     );
   }
 
-  return svgContent;
+  return (
+    <div
+      data-testid='chart-container'
+      style={{
+        width: resolvedWidth,
+        height,
+        margin: `${-DEFAULT_INSET.top}px ${-DEFAULT_INSET.right}px`,
+      }}
+    >
+      {svgContent}
+    </div>
+  );
 }

--- a/libs/ui-react-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
@@ -5,29 +5,46 @@ import { CartesianChartProvider, useBuildChartContext } from './context';
 import type { CartesianChartProps } from './types';
 
 const DEFAULT_HEIGHT = 160;
-const DEFAULT_INSET: ChartInset = {
+
+/**
+ * Internal buffer that prevents SVG content (labels, points, ticks) from being
+ * clipped at the edge of the container. Compensated by negative margins on the
+ * wrapper so the chart's visual footprint stays unchanged.
+ */
+const OVERFLOW_BUFFER: ChartInset = {
   top: 30,
   right: 20,
   bottom: 30,
   left: 20,
 };
+const OVERFLOW_NEGATIVE_MARGIN = {
+  marginTop: -OVERFLOW_BUFFER.top,
+  marginRight: -OVERFLOW_BUFFER.right,
+  marginBottom: -OVERFLOW_BUFFER.bottom,
+  marginLeft: -OVERFLOW_BUFFER.left,
+};
 const ZERO_PADDING: ChartInset = { top: 0, right: 0, bottom: 0, left: 0 };
 
 const resolveInset = (inset: CartesianChartProps['inset']): ChartInset => {
-  if (inset === undefined) return DEFAULT_INSET;
-  if (typeof inset === 'number') {
-    return {
-      top: inset + DEFAULT_INSET.top,
-      right: inset + DEFAULT_INSET.right,
-      bottom: inset + DEFAULT_INSET.bottom,
-      left: inset + DEFAULT_INSET.left,
+  let consumer: ChartInset;
+  if (inset === undefined) {
+    consumer = ZERO_PADDING;
+  } else if (typeof inset === 'number') {
+    consumer = { top: inset, right: inset, bottom: inset, left: inset };
+  } else {
+    consumer = {
+      top: inset.top ?? 0,
+      right: inset.right ?? 0,
+      bottom: inset.bottom ?? 0,
+      left: inset.left ?? 0,
     };
   }
+
   return {
-    top: (inset.top ?? 0) + DEFAULT_INSET.top,
-    right: (inset.right ?? 0) + DEFAULT_INSET.right,
-    bottom: (inset.bottom ?? 0) + DEFAULT_INSET.bottom,
-    left: (inset.left ?? 0) + DEFAULT_INSET.left,
+    top: consumer.top + OVERFLOW_BUFFER.top,
+    right: consumer.right + OVERFLOW_BUFFER.right,
+    bottom: consumer.bottom + OVERFLOW_BUFFER.bottom,
+    left: consumer.left + OVERFLOW_BUFFER.left,
   };
 };
 
@@ -124,7 +141,7 @@ export function CartesianChart({
         style={{
           width,
           height,
-          margin: `${-DEFAULT_INSET.top}px ${-DEFAULT_INSET.right}px`,
+          ...OVERFLOW_NEGATIVE_MARGIN,
         }}
       >
         {measuredWidth !== undefined && svgContent}
@@ -138,7 +155,7 @@ export function CartesianChart({
       style={{
         width: resolvedWidth,
         height,
-        margin: `${-DEFAULT_INSET.top}px ${-DEFAULT_INSET.right}px`,
+        ...OVERFLOW_NEGATIVE_MARGIN,
       }}
     >
       {svgContent}

--- a/libs/ui-react-visualization/src/lib/Components/CartesianChart/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/CartesianChart/types.ts
@@ -28,8 +28,10 @@ export type CartesianChartProps = {
    */
   height?: number;
   /**
-   * Padding between the SVG edge and the drawing area.
-   * A number applies uniformly; a partial object overrides individual sides.
+   * Extra padding between the SVG edge and the drawing area, added on top of
+   * a built-in overflow buffer that prevents content (labels, points, ticks)
+   * from being clipped. A number applies uniformly; a partial object sets
+   * individual sides (unset sides default to `0`).
    */
   inset?: number | Partial<ChartInset>;
   /**

--- a/libs/ui-react-visualization/src/lib/Components/CartesianChart/utils.test.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/CartesianChart/utils.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  OVERFLOW_BUFFER,
+  ZERO_PADDING,
+  resolveAxisPadding,
+  resolveInset,
+} from './utils';
+
+describe('resolveInset', () => {
+  it('should return DEFAULT_INSET when undefined', () => {
+    expect(resolveInset(undefined)).toEqual(OVERFLOW_BUFFER);
+  });
+
+  it('should add a uniform number to each default side', () => {
+    expect(resolveInset(10)).toEqual({
+      top: 10 + OVERFLOW_BUFFER.top,
+      right: 10 + OVERFLOW_BUFFER.right,
+      bottom: 10 + OVERFLOW_BUFFER.bottom,
+      left: 10 + OVERFLOW_BUFFER.left,
+    });
+  });
+
+  it('should handle zero as a uniform number', () => {
+    expect(resolveInset(0)).toEqual(OVERFLOW_BUFFER);
+  });
+
+  it('should handle negative uniform values', () => {
+    expect(resolveInset(-5)).toEqual({
+      top: -5 + OVERFLOW_BUFFER.top,
+      right: -5 + OVERFLOW_BUFFER.right,
+      bottom: -5 + OVERFLOW_BUFFER.bottom,
+      left: -5 + OVERFLOW_BUFFER.left,
+    });
+  });
+
+  it('should merge a full partial object with defaults', () => {
+    expect(resolveInset({ top: 10, right: 15, bottom: 20, left: 25 })).toEqual({
+      top: 10 + OVERFLOW_BUFFER.top,
+      right: 15 + OVERFLOW_BUFFER.right,
+      bottom: 20 + OVERFLOW_BUFFER.bottom,
+      left: 25 + OVERFLOW_BUFFER.left,
+    });
+  });
+
+  it('should treat missing sides as 0 when given a partial object', () => {
+    expect(resolveInset({ top: 10 })).toEqual({
+      top: 10 + OVERFLOW_BUFFER.top,
+      right: OVERFLOW_BUFFER.right,
+      bottom: OVERFLOW_BUFFER.bottom,
+      left: OVERFLOW_BUFFER.left,
+    });
+  });
+
+  it('should handle an empty object', () => {
+    expect(resolveInset({})).toEqual(OVERFLOW_BUFFER);
+  });
+});
+
+describe('resolveAxisPadding', () => {
+  it('should return ZERO_PADDING when undefined', () => {
+    expect(resolveAxisPadding(undefined)).toEqual(ZERO_PADDING);
+  });
+
+  it('should resolve a full padding object', () => {
+    expect(
+      resolveAxisPadding({ top: 5, right: 10, bottom: 15, left: 20 }),
+    ).toEqual({
+      top: 5,
+      right: 10,
+      bottom: 15,
+      left: 20,
+    });
+  });
+
+  it('should treat missing sides as 0', () => {
+    expect(resolveAxisPadding({ bottom: 30 })).toEqual({
+      top: 0,
+      right: 0,
+      bottom: 30,
+      left: 0,
+    });
+  });
+
+  it('should handle an empty object', () => {
+    expect(resolveAxisPadding({})).toEqual(ZERO_PADDING);
+  });
+});

--- a/libs/ui-react-visualization/src/lib/Components/CartesianChart/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/CartesianChart/utils.ts
@@ -1,0 +1,65 @@
+import type { ChartInset } from '../../utils/types';
+import type { CartesianChartProps } from './types';
+
+export const DEFAULT_HEIGHT = 160;
+
+/**
+ * Internal buffer that prevents SVG content (labels, points, ticks) from being
+ * clipped at the edge of the container. Compensated by negative margins on the
+ * wrapper so the chart's visual footprint stays unchanged.
+ */
+export const OVERFLOW_BUFFER: ChartInset = {
+  top: 30,
+  right: 20,
+  bottom: 30,
+  left: 20,
+};
+export const OVERFLOW_NEGATIVE_MARGIN = {
+  marginTop: -OVERFLOW_BUFFER.top,
+  marginRight: -OVERFLOW_BUFFER.right,
+  marginBottom: -OVERFLOW_BUFFER.bottom,
+  marginLeft: -OVERFLOW_BUFFER.left,
+};
+export const ZERO_PADDING: ChartInset = {
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+};
+
+export const resolveInset = (
+  inset: CartesianChartProps['inset'],
+): ChartInset => {
+  let consumer: ChartInset;
+  if (inset === undefined) {
+    consumer = ZERO_PADDING;
+  } else if (typeof inset === 'number') {
+    consumer = { top: inset, right: inset, bottom: inset, left: inset };
+  } else {
+    consumer = {
+      top: inset.top ?? 0,
+      right: inset.right ?? 0,
+      bottom: inset.bottom ?? 0,
+      left: inset.left ?? 0,
+    };
+  }
+
+  return {
+    top: consumer.top + OVERFLOW_BUFFER.top,
+    right: consumer.right + OVERFLOW_BUFFER.right,
+    bottom: consumer.bottom + OVERFLOW_BUFFER.bottom,
+    left: consumer.left + OVERFLOW_BUFFER.left,
+  };
+};
+
+export const resolveAxisPadding = (
+  padding: CartesianChartProps['axisPadding'],
+): ChartInset => {
+  if (padding === undefined) return ZERO_PADDING;
+  return {
+    top: padding.top ?? 0,
+    right: padding.right ?? 0,
+    bottom: padding.bottom ?? 0,
+    left: padding.left ?? 0,
+  };
+};

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { StoryDecorator } from '../../../../.storybook/StoryDecorator';
-import { Point } from '../Point/Point';
+import { Point, PointLabel } from '../Point/Point';
 import { LineChart } from './LineChart';
 
 const meta: Meta<typeof LineChart> = {
@@ -255,6 +255,81 @@ export const WithPoints: Story = {
         label='$98.00'
         color='#47883A'
         labelPosition='top'
+      />
+    </LineChart>
+  ),
+};
+
+export const WithCustomLabelComponent: Story = {
+  render: () => (
+    <LineChart series={sampleSeries} height={250} showArea>
+      <Point
+        dataX={9}
+        dataY={4}
+        label='$4.00'
+        color='#C24244'
+        labelPosition='bottom'
+        LabelComponent={({ children, ...props }) => (
+          <PointLabel {...props}>{children}</PointLabel>
+        )}
+      />
+      <Point
+        dataX={4}
+        dataY={98}
+        label='$98'
+        color='#47883A'
+        labelPosition='top'
+        showLabelArrow={false}
+        LabelComponent={({ x, y, children }) => (
+          <g>
+            <rect
+              x={x - 28}
+              y={y - 14}
+              width={56}
+              height={20}
+              rx={4}
+              fill='#47883A'
+            />
+            <PointLabel
+              x={x}
+              y={y}
+              style={{ fill: '#fff', fontSize: 11, fontWeight: 500 }}
+            >
+              {children}
+            </PointLabel>
+          </g>
+        )}
+      />
+      <Point
+        dataX={12}
+        dataY={21}
+        label='Low'
+        color='#C24244'
+        labelPosition='bottom'
+        showLabelArrow={false}
+        LabelComponent={({ x, y, children }) => (
+          <g>
+            <rect
+              x={x - 24}
+              y={y}
+              width={48}
+              height={22}
+              rx={6}
+              fill='#C24244'
+            />
+            <polygon
+              points={`${x - 4},${y} ${x},${y - 5} ${x + 4},${y}`}
+              fill='#C24244'
+            />
+            <PointLabel
+              x={x}
+              y={y + 14}
+              style={{ fill: '#fff', fontSize: 11, fontWeight: 600 }}
+            >
+              {children}
+            </PointLabel>
+          </g>
+        )}
       />
     </LineChart>
   ),

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { StoryDecorator } from '../../../../.storybook/StoryDecorator';
+import { Point } from '../Point/Point';
 import { LineChart } from './LineChart';
 
 const meta: Meta<typeof LineChart> = {
@@ -236,4 +237,25 @@ export const WithAreaMultipleSeries: Story = {
       domain: { min: 0, max: 100 },
     },
   },
+};
+
+export const WithPoints: Story = {
+  render: () => (
+    <LineChart series={sampleSeries} height={250} showArea>
+      <Point
+        dataX={9}
+        dataY={4}
+        label='$4.00'
+        color='#C24244'
+        labelPosition='bottom'
+      />
+      <Point
+        dataX={4}
+        dataY={98}
+        label='$98.00'
+        color='#47883A'
+        labelPosition='top'
+      />
+    </LineChart>
+  ),
 };

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
@@ -1,10 +1,11 @@
+import { cssVar } from '@ledgerhq/lumen-design-core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { StoryDecorator } from '../../../../.storybook/StoryDecorator';
 import { Point, PointLabel } from '../Point/Point';
 import { LineChart } from './LineChart';
 
-const meta: Meta<typeof LineChart> = {
+const meta = {
   component: LineChart,
   title: 'Visualization/LineChart',
   tags: ['experimental'],
@@ -19,7 +20,7 @@ const meta: Meta<typeof LineChart> = {
       );
     },
   ],
-};
+} satisfies Meta<typeof LineChart>;
 
 export default meta;
 type Story = StoryObj<typeof LineChart>;
@@ -246,14 +247,14 @@ export const WithPoints: Story = {
         dataX={9}
         dataY={4}
         label='$4.00'
-        color='#C24244'
+        color={cssVar('var(--background-error-strong)')}
         labelPosition='bottom'
       />
       <Point
         dataX={4}
         dataY={98}
         label='$98.00'
-        color='#47883A'
+        color={cssVar('var(--background-success-strong)')}
         labelPosition='top'
       />
     </LineChart>
@@ -262,12 +263,12 @@ export const WithPoints: Story = {
 
 export const WithCustomLabelComponent: Story = {
   render: () => (
-    <LineChart series={sampleSeries} height={250} showArea>
+    <LineChart series={sampleSeries} height={250} inset={{ top: 15 }} showArea>
       <Point
         dataX={9}
         dataY={4}
         label='$4.00'
-        color='#C24244'
+        color={cssVar('var(--background-error-strong)')}
         labelPosition='bottom'
         LabelComponent={({ children, ...props }) => (
           <PointLabel {...props}>{children}</PointLabel>
@@ -276,57 +277,16 @@ export const WithCustomLabelComponent: Story = {
       <Point
         dataX={4}
         dataY={98}
-        label='$98'
-        color='#47883A'
+        label='$98.00'
+        color={cssVar('var(--background-success-strong)')}
         labelPosition='top'
-        showLabelArrow={false}
         LabelComponent={({ x, y, children }) => (
           <g>
-            <rect
-              x={x - 28}
-              y={y - 14}
-              width={56}
-              height={20}
-              rx={4}
-              fill='#47883A'
-            />
-            <PointLabel
-              x={x}
-              y={y}
-              style={{ fill: '#fff', fontSize: 11, fontWeight: 500 }}
-            >
+            <PointLabel x={x} y={y - 16}>
               {children}
             </PointLabel>
-          </g>
-        )}
-      />
-      <Point
-        dataX={12}
-        dataY={21}
-        label='Low'
-        color='#C24244'
-        labelPosition='bottom'
-        showLabelArrow={false}
-        LabelComponent={({ x, y, children }) => (
-          <g>
-            <rect
-              x={x - 24}
-              y={y}
-              width={48}
-              height={22}
-              rx={6}
-              fill='#C24244'
-            />
-            <polygon
-              points={`${x - 4},${y} ${x},${y - 5} ${x + 4},${y}`}
-              fill='#C24244'
-            />
-            <PointLabel
-              x={x}
-              y={y + 14}
-              style={{ fill: '#fff', fontSize: 11, fontWeight: 600 }}
-            >
-              {children}
+            <PointLabel x={x} y={y} style={{ fontSize: 10 }}>
+              +5.2%
             </PointLabel>
           </g>
         )}

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
@@ -46,7 +46,7 @@ const multiSeries = [
   },
 ];
 
-export const Basic: Story = {
+export const Base: Story = {
   args: {
     series: sampleSeries,
     height: 250,

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
@@ -1,8 +1,6 @@
-import { cssVar } from '@ledgerhq/lumen-design-core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { StoryDecorator } from '../../../../.storybook/StoryDecorator';
-import { Point, PointLabel } from '../Point/Point';
 import { LineChart } from './LineChart';
 
 const meta = {
@@ -238,59 +236,4 @@ export const WithAreaMultipleSeries: Story = {
       domain: { min: 0, max: 100 },
     },
   },
-};
-
-export const WithPoints: Story = {
-  render: () => (
-    <LineChart series={sampleSeries} height={250} showArea>
-      <Point
-        dataX={9}
-        dataY={4}
-        label='$4.00'
-        color={cssVar('var(--background-error-strong)')}
-        labelPosition='bottom'
-      />
-      <Point
-        dataX={4}
-        dataY={98}
-        label='$98.00'
-        color={cssVar('var(--background-success-strong)')}
-        labelPosition='top'
-      />
-    </LineChart>
-  ),
-};
-
-export const WithCustomLabelComponent: Story = {
-  render: () => (
-    <LineChart series={sampleSeries} height={250} inset={{ top: 15 }} showArea>
-      <Point
-        dataX={9}
-        dataY={4}
-        label='$4.00'
-        color={cssVar('var(--background-error-strong)')}
-        labelPosition='bottom'
-        LabelComponent={({ children, ...props }) => (
-          <PointLabel {...props}>{children}</PointLabel>
-        )}
-      />
-      <Point
-        dataX={4}
-        dataY={98}
-        label='$98.00'
-        color={cssVar('var(--background-success-strong)')}
-        labelPosition='top'
-        LabelComponent={({ x, y, children }) => (
-          <g>
-            <PointLabel x={x} y={y - 16}>
-              {children}
-            </PointLabel>
-            <PointLabel x={x} y={y} style={{ fontSize: 10 }}>
-              +5.2%
-            </PointLabel>
-          </g>
-        )}
-      />
-    </LineChart>
-  ),
 };

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.stories.tsx
@@ -1,0 +1,127 @@
+import { cssVar } from '@ledgerhq/lumen-design-core';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { StoryDecorator } from '../../../../.storybook/StoryDecorator';
+import { LineChart } from '../LineChart';
+import { Point, PointLabel } from './Point';
+
+const sampleSeries = [
+  {
+    id: 'prices',
+    stroke: '#7B61FF',
+    data: [10, 22, 29, 45, 98, 45, 22, 52, 21, 4, 68, 20, 21, 58],
+  },
+];
+
+const meta = {
+  component: Point,
+  title: 'Visualization/Point',
+  tags: ['experimental'],
+  decorators: [
+    (Story, context) => {
+      return (
+        <StoryDecorator context={context}>
+          <div style={{ width: 600, padding: 16 }}>
+            <Story />
+          </div>
+        </StoryDecorator>
+      );
+    },
+  ],
+} satisfies Meta<typeof Point>;
+
+export default meta;
+type Story = StoryObj<typeof Point>;
+
+export const Default: Story = {
+  render: () => (
+    <LineChart series={sampleSeries} height={250} showArea>
+      <Point
+        dataX={9}
+        dataY={4}
+        label='$4.00'
+        color={cssVar('var(--background-error-strong)')}
+        labelPosition='bottom'
+      />
+      <Point
+        dataX={4}
+        dataY={98}
+        label='$98.00'
+        color={cssVar('var(--background-success-strong)')}
+        labelPosition='top'
+      />
+    </LineChart>
+  ),
+};
+
+export const WithCustomLabelComponent: Story = {
+  render: () => (
+    <LineChart series={sampleSeries} height={250} inset={{ top: 20 }} showArea>
+      <Point
+        dataX={9}
+        dataY={4}
+        label='$4.00'
+        color={cssVar('var(--background-error-strong)')}
+        labelPosition='bottom'
+        LabelComponent={({ children, ...props }) => (
+          <PointLabel {...props}>{children}</PointLabel>
+        )}
+      />
+      <Point
+        dataX={4}
+        dataY={98}
+        label='$98.00'
+        color={cssVar('var(--background-success-strong)')}
+        labelPosition='top'
+        LabelComponent={({ x, y, children }) => (
+          <g>
+            <PointLabel x={x} y={y - 16}>
+              {children}
+            </PointLabel>
+            <PointLabel
+              x={x}
+              y={y}
+              style={{
+                fontSize: 10,
+                fill: cssVar('var(--text-success)'),
+              }}
+            >
+              +5.2%
+            </PointLabel>
+          </g>
+        )}
+      />
+    </LineChart>
+  ),
+};
+
+export const NoPoint: Story = {
+  render: () => (
+    <LineChart series={sampleSeries} height={250} showArea>
+      <Point dataX={4} dataY={98} label='ATH' hidePoint />
+      <Point dataX={9} dataY={4} label='Low' hidePoint labelPosition='bottom' />
+    </LineChart>
+  ),
+};
+
+export const CustomSize: Story = {
+  render: () => (
+    <LineChart series={sampleSeries} height={250} showArea>
+      <Point
+        dataX={4}
+        dataY={98}
+        size={16}
+        label={(i) => `Index ${i}`}
+        color={cssVar('var(--background-success-strong)')}
+      />
+      <Point
+        dataX={9}
+        dataY={4}
+        size={6}
+        label='$4.00'
+        color={cssVar('var(--background-error-strong)')}
+        labelPosition='bottom'
+      />
+    </LineChart>
+  ),
+};

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.stories.tsx
@@ -33,7 +33,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof Point>;
 
-export const Default: Story = {
+export const Base: Story = {
   render: () => (
     <LineChart series={sampleSeries} height={250} showArea>
       <Point

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
@@ -1,5 +1,3 @@
-import { ledgerLiveThemes } from '@ledgerhq/lumen-design-core';
-import { ThemeProvider } from '@ledgerhq/lumen-ui-react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
@@ -10,10 +8,6 @@ import { CartesianChart } from '../CartesianChart';
 import { Point } from './Point';
 
 const sampleSeries = [{ id: 's1', stroke: '#000', data: [10, 20, 30, 40, 50] }];
-
-const Wrapper = ({ children }: { children: ReactNode }) => (
-  <ThemeProvider themes={ledgerLiveThemes}>{children}</ThemeProvider>
-);
 
 const renderInChart = (
   pointElement: ReactNode,
@@ -30,17 +24,15 @@ const renderInChart = (
   } = {},
 ) =>
   render(
-    <Wrapper>
-      <CartesianChart
-        series={sampleSeries}
-        width={width}
-        height={height}
-        xAxis={xAxis}
-        yAxis={yAxis}
-      >
-        {pointElement}
-      </CartesianChart>
-    </Wrapper>,
+    <CartesianChart
+      series={sampleSeries}
+      width={width}
+      height={height}
+      xAxis={xAxis}
+      yAxis={yAxis}
+    >
+      {pointElement}
+    </CartesianChart>,
   );
 
 describe('Point', () => {
@@ -56,7 +48,7 @@ describe('Point', () => {
       <Point dataX={2} dataY={30} color='#FF0000' size={16} />,
     );
     const circle = getByTestId('point-circle');
-    expect(circle.getAttribute('fill')).toBe('#FF0000');
+    expect(circle.style.fill).toBe('#FF0000');
     expect(circle.getAttribute('r')).toBe('8');
   });
 
@@ -147,12 +139,12 @@ describe('Point', () => {
     expect(queryByTestId('point-arrow')).toBeNull();
   });
 
-  it('calls onClick when the point is clicked', () => {
+  it('calls onClick when the point is clicked', async () => {
     const onClick = vi.fn();
     const { getByTestId } = renderInChart(
       <Point dataX={2} dataY={30} onClick={onClick} />,
     );
-    userEvent.click(getByTestId('point-group'));
+    await userEvent.click(getByTestId('point-group'));
     expect(onClick).toHaveBeenCalled();
   });
 

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
@@ -120,7 +120,7 @@ describe('Point', () => {
     expect(circle).toBeTruthy();
   });
 
-  it('renders arrow when label is present and showArrow is true', () => {
+  it('renders arrow when label is present and showLabelArrow is true', () => {
     const { getByTestId } = renderInChart(
       <Point dataX={2} dataY={30} label='Peak' />,
     );
@@ -132,9 +132,9 @@ describe('Point', () => {
     expect(queryByTestId('point-arrow')).toBeNull();
   });
 
-  it('does not render arrow when showArrow is false', () => {
+  it('does not render arrow when showLabelArrow is false', () => {
     const { queryByTestId } = renderInChart(
-      <Point dataX={2} dataY={30} label='Peak' showArrow={false} />,
+      <Point dataX={2} dataY={30} label='Peak' showLabelArrow={false} />,
     );
     expect(queryByTestId('point-arrow')).toBeNull();
   });

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
@@ -1,6 +1,7 @@
 import { ledgerLiveThemes } from '@ledgerhq/lumen-design-core';
 import { ThemeProvider } from '@ledgerhq/lumen-ui-react';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -89,6 +90,21 @@ describe('Point', () => {
     expect(queryByTestId('point-label')).toBeNull();
   });
 
+  it('wraps labelComponent in a positioned group', () => {
+    const { getByTestId } = renderInChart(
+      <Point
+        dataX={2}
+        dataY={30}
+        labelComponent={<text data-testid='custom-label'>Custom</text>}
+      />,
+    );
+    const wrapper = getByTestId('custom-label').parentElement;
+    expect(wrapper?.tagName.toLowerCase()).toBe('g');
+    expect(wrapper?.getAttribute('transform')).toMatch(
+      /^translate\(\d+(\.\d+)?,\d+(\.\d+)?\)$/,
+    );
+  });
+
   it('hides the circle when hidePoint is true but shows label', () => {
     const { queryByTestId, getByTestId } = renderInChart(
       <Point dataX={2} dataY={30} hidePoint label='Still here' />,
@@ -136,7 +152,7 @@ describe('Point', () => {
     const { getByTestId } = renderInChart(
       <Point dataX={2} dataY={30} onClick={onClick} />,
     );
-    fireEvent.click(getByTestId('point-group'));
+    userEvent.click(getByTestId('point-group'));
     expect(onClick).toHaveBeenCalled();
   });
 

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
@@ -1,0 +1,150 @@
+import { ledgerLiveThemes } from '@ledgerhq/lumen-design-core';
+import { ThemeProvider } from '@ledgerhq/lumen-ui-react';
+import { fireEvent, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CartesianChart } from '../CartesianChart';
+
+import { Point } from './Point';
+
+const sampleSeries = [{ id: 's1', stroke: '#000', data: [10, 20, 30, 40, 50] }];
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <ThemeProvider themes={ledgerLiveThemes}>{children}</ThemeProvider>
+);
+
+const renderInChart = (
+  pointElement: ReactNode,
+  {
+    width = 400,
+    height = 200,
+    xAxis,
+    yAxis,
+  }: {
+    width?: number;
+    height?: number;
+    xAxis?: Parameters<typeof CartesianChart>[0]['xAxis'];
+    yAxis?: Parameters<typeof CartesianChart>[0]['yAxis'];
+  } = {},
+) =>
+  render(
+    <Wrapper>
+      <CartesianChart
+        series={sampleSeries}
+        width={width}
+        height={height}
+        xAxis={xAxis}
+        yAxis={yAxis}
+      >
+        {pointElement}
+      </CartesianChart>
+    </Wrapper>,
+  );
+
+describe('Point', () => {
+  it('renders a circle at the projected position', () => {
+    const { getByTestId } = renderInChart(<Point dataX={2} dataY={30} />);
+    const circle = getByTestId('point-circle');
+    expect(circle).toBeTruthy();
+    expect(circle.getAttribute('r')).toBe('5');
+  });
+
+  it('renders with custom color and size', () => {
+    const { getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} color='#FF0000' size={16} />,
+    );
+    const circle = getByTestId('point-circle');
+    expect(circle.getAttribute('fill')).toBe('#FF0000');
+    expect(circle.getAttribute('r')).toBe('8');
+  });
+
+  it('renders a string label', () => {
+    const { getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} label='Peak' />,
+    );
+    const label = getByTestId('point-label');
+    expect(label).toBeTruthy();
+    expect(label.textContent).toBe('Peak');
+  });
+
+  it('renders a label via function', () => {
+    const { getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} label={(i) => `#${i}`} />,
+    );
+    const label = getByTestId('point-label');
+    expect(label.textContent).toBe('#2');
+  });
+
+  it('renders labelComponent when provided', () => {
+    const { getByTestId, queryByTestId } = renderInChart(
+      <Point
+        dataX={2}
+        dataY={30}
+        label='ignored'
+        labelComponent={<text data-testid='custom-label'>Custom</text>}
+      />,
+    );
+    expect(getByTestId('custom-label')).toBeTruthy();
+    expect(queryByTestId('point-label')).toBeNull();
+  });
+
+  it('hides the circle when hidePoint is true but shows label', () => {
+    const { queryByTestId, getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} hidePoint label='Still here' />,
+    );
+    expect(queryByTestId('point-circle')).toBeNull();
+    expect(getByTestId('point-label')).toBeTruthy();
+  });
+
+  it('returns null when point is outside drawing area', () => {
+    const { queryByTestId } = renderInChart(
+      <Point dataX={-100} dataY={-100} />,
+    );
+    expect(queryByTestId('point-group')).toBeNull();
+  });
+
+  it('works with band (categorical) x-axis scale', () => {
+    const { getByTestId } = renderInChart(<Point dataX={1} dataY={30} />, {
+      xAxis: { scaleType: 'band' },
+    });
+    const circle = getByTestId('point-circle');
+    expect(circle).toBeTruthy();
+  });
+
+  it('renders arrow when label is present and showArrow is true', () => {
+    const { getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} label='Peak' />,
+    );
+    expect(getByTestId('point-arrow')).toBeTruthy();
+  });
+
+  it('does not render arrow when no label is present', () => {
+    const { queryByTestId } = renderInChart(<Point dataX={2} dataY={30} />);
+    expect(queryByTestId('point-arrow')).toBeNull();
+  });
+
+  it('does not render arrow when showArrow is false', () => {
+    const { queryByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} label='Peak' showArrow={false} />,
+    );
+    expect(queryByTestId('point-arrow')).toBeNull();
+  });
+
+  it('calls onClick when the point is clicked', () => {
+    const onClick = vi.fn();
+    const { getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} onClick={onClick} />,
+    );
+    fireEvent.click(getByTestId('point-group'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('sets cursor pointer when onClick is provided', () => {
+    const { getByTestId } = renderInChart(
+      <Point dataX={2} dataY={30} onClick={vi.fn()} />,
+    );
+    const group = getByTestId('point-group');
+    expect(group.style.cursor).toBe('pointer');
+  });
+});

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { CartesianChart } from '../CartesianChart';
 
 import { Point } from './Point';
+import type { PointLabelProps } from './types';
 
 const sampleSeries = [{ id: 's1', stroke: '#000', data: [10, 20, 30, 40, 50] }];
 
@@ -53,56 +54,55 @@ describe('Point', () => {
   });
 
   it('renders a string label', () => {
-    const { getByTestId } = renderInChart(
+    const { getByText } = renderInChart(
       <Point dataX={2} dataY={30} label='Peak' />,
     );
-    const label = getByTestId('point-label');
-    expect(label).toBeTruthy();
-    expect(label.textContent).toBe('Peak');
+    expect(getByText('Peak')).toBeTruthy();
   });
 
   it('renders a label via function', () => {
-    const { getByTestId } = renderInChart(
+    const { getByText } = renderInChart(
       <Point dataX={2} dataY={30} label={(i) => `#${i}`} />,
     );
-    const label = getByTestId('point-label');
-    expect(label.textContent).toBe('#2');
+    expect(getByText('#2')).toBeTruthy();
   });
 
-  it('renders labelComponent when provided', () => {
-    const { getByTestId, queryByTestId } = renderInChart(
-      <Point
-        dataX={2}
-        dataY={30}
-        label='ignored'
-        labelComponent={<text data-testid='custom-label'>Custom</text>}
-      />,
-    );
-    expect(getByTestId('custom-label')).toBeTruthy();
-    expect(queryByTestId('point-label')).toBeNull();
-  });
+  it('passes props to custom LabelComponent', () => {
+    const labelSpy = vi.fn(({ x, y, children }: PointLabelProps) => (
+      <text data-testid='custom-label' x={x} y={y}>
+        {children}
+      </text>
+    ));
 
-  it('wraps labelComponent in a positioned group', () => {
     const { getByTestId } = renderInChart(
-      <Point
-        dataX={2}
-        dataY={30}
-        labelComponent={<text data-testid='custom-label'>Custom</text>}
-      />,
+      <Point dataX={2} dataY={30} label='Peak' LabelComponent={labelSpy} />,
     );
-    const wrapper = getByTestId('custom-label').parentElement;
-    expect(wrapper?.tagName.toLowerCase()).toBe('g');
-    expect(wrapper?.getAttribute('transform')).toMatch(
-      /^translate\(\d+(\.\d+)?,\d+(\.\d+)?\)$/,
+
+    expect(getByTestId('custom-label')).toBeTruthy();
+    expect(labelSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        x: expect.any(Number),
+        y: expect.any(Number),
+        children: 'Peak',
+      }),
+      undefined,
     );
+  });
+
+  it('does not render LabelComponent when label is absent', () => {
+    const labelSpy = vi.fn(() => <text>should not appear</text>);
+
+    renderInChart(<Point dataX={2} dataY={30} LabelComponent={labelSpy} />);
+
+    expect(labelSpy).not.toHaveBeenCalled();
   });
 
   it('hides the circle when hidePoint is true but shows label', () => {
-    const { queryByTestId, getByTestId } = renderInChart(
+    const { queryByTestId, getByText } = renderInChart(
       <Point dataX={2} dataY={30} hidePoint label='Still here' />,
     );
     expect(queryByTestId('point-circle')).toBeNull();
-    expect(getByTestId('point-label')).toBeTruthy();
+    expect(getByText('Still here')).toBeTruthy();
   });
 
   it('returns null when point is outside drawing area', () => {
@@ -130,6 +130,28 @@ describe('Point', () => {
   it('does not render arrow when no label is present', () => {
     const { queryByTestId } = renderInChart(<Point dataX={2} dataY={30} />);
     expect(queryByTestId('point-arrow')).toBeNull();
+  });
+
+  it('renders label below the point when labelPosition is bottom', () => {
+    const topSpy = vi.fn(({ y }: PointLabelProps) => <text>{y}</text>);
+    const bottomSpy = vi.fn(({ y }: PointLabelProps) => <text>{y}</text>);
+
+    renderInChart(
+      <Point dataX={2} dataY={30} label='T' LabelComponent={topSpy} />,
+    );
+    renderInChart(
+      <Point
+        dataX={2}
+        dataY={30}
+        label='B'
+        labelPosition='bottom'
+        LabelComponent={bottomSpy}
+      />,
+    );
+
+    const topY = topSpy.mock.calls[0][0].y;
+    const bottomY = bottomSpy.mock.calls[0][0].y;
+    expect(bottomY).toBeGreaterThan(topY);
   });
 
   it('does not render arrow when showLabelArrow is false', () => {

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { projectPoint } from '../../utils/scales/scales';
 import { useCartesianChartContext } from '../CartesianChart/context';
 
-import type { PointProps } from './types';
+import type { PointLabelProps, PointProps } from './types';
 import {
   buildArrowPoints,
   computeLabelY,
@@ -14,12 +14,34 @@ import {
   STROKE_WIDTH,
 } from './utils';
 
+export function PointLabel({
+  style,
+  textAnchor = 'middle',
+  dominantBaseline = 'auto',
+  ...props
+}: PointLabelProps) {
+  return (
+    <text
+      textAnchor={textAnchor}
+      dominantBaseline={dominantBaseline}
+      style={{
+        fill: cssVar('var(--text-base)'),
+        fontSize: cssVar('var(--font-style-body-4-size)'),
+        fontWeight: cssVar('var(--font-style-body-4-weight-medium)'),
+        fontFamily: cssVar('var(--font-family-font)'),
+        ...style,
+      }}
+      {...props}
+    />
+  );
+}
+
 export function Point({
   dataX,
   dataY,
   color,
   label,
-  labelComponent,
+  LabelComponent,
   labelPosition = 'top',
   hidePoint = false,
   showLabelArrow = true,
@@ -44,9 +66,11 @@ export function Point({
   }
 
   const resolvedLabel = resolveLabel(label, dataX);
-  const hasLabel = labelComponent != null || resolvedLabel != null;
+  const hasLabel = resolvedLabel != null;
   const renderArrow = showLabelArrow && hasLabel;
   const labelY = computeLabelY(pixel.y, radius, labelPosition, renderArrow);
+
+  const Label = LabelComponent ?? PointLabel;
 
   return (
     <g
@@ -74,25 +98,10 @@ export function Point({
           style={{ fill: cssVar('var(--text-base)') }}
         />
       )}
-      {labelComponent && (
-        <g transform={`translate(${pixel.x},${labelY})`}>{labelComponent}</g>
-      )}
-      {!labelComponent && resolvedLabel != null && (
-        <text
-          data-testid='point-label'
-          x={pixel.x}
-          y={labelY}
-          textAnchor='middle'
-          dominantBaseline='auto'
-          style={{
-            fill: cssVar('var(--text-base)'),
-            fontSize: cssVar('var(--font-style-body-4-size)'),
-            fontWeight: cssVar('var(--font-style-body-4-weight-medium)'),
-            fontFamily: cssVar('var(--font-family-font)'),
-          }}
-        >
+      {resolvedLabel != null && (
+        <Label x={pixel.x} y={labelY}>
           {resolvedLabel}
-        </text>
+        </Label>
       )}
     </g>
   );

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -1,0 +1,96 @@
+import { useTheme } from '@ledgerhq/lumen-ui-react';
+import { useMemo } from 'react';
+
+import { projectPoint } from '../../utils/scales/scales';
+import { useCartesianChartContext } from '../CartesianChart/context';
+
+import type { PointProps } from './types';
+import {
+  buildArrowPoints,
+  computeLabelY,
+  DEFAULT_SIZE,
+  isWithinBounds,
+  resolveLabel,
+  STROKE_WIDTH,
+} from './utils';
+
+export function Point({
+  dataX,
+  dataY,
+  color,
+  label,
+  labelComponent,
+  labelPosition = 'top',
+  hidePoint = false,
+  showArrow = true,
+  size = DEFAULT_SIZE,
+  onClick,
+}: PointProps) {
+  const { getXScale, getYScale, drawingArea } = useCartesianChartContext();
+  const { theme } = useTheme();
+
+  const xScale = getXScale();
+  const yScale = getYScale();
+
+  const radius = size / 2;
+  const fill = color ?? theme.colors.bg.mutedStrong;
+  const stroke = theme.colors.bg.canvas;
+  const textColor = theme.colors.text.base;
+
+  const pixel = useMemo(() => {
+    if (!xScale || !yScale) return undefined;
+    return projectPoint(dataX, dataY, xScale, yScale);
+  }, [dataX, dataY, xScale, yScale]);
+
+  if (!pixel || !isWithinBounds(pixel.x, pixel.y, drawingArea)) {
+    return null;
+  }
+
+  const resolvedLabel = resolveLabel(label, dataX);
+  const hasLabel = labelComponent != null || resolvedLabel != null;
+  const renderArrow = showArrow && hasLabel;
+  const labelY = computeLabelY(pixel.y, radius, labelPosition, renderArrow);
+
+  return (
+    <g
+      data-testid='point-group'
+      onClick={onClick}
+      style={onClick ? { cursor: 'pointer' } : undefined}
+    >
+      {!hidePoint && (
+        <circle
+          data-testid='point-circle'
+          cx={pixel.x}
+          cy={pixel.y}
+          r={radius}
+          fill={fill}
+          stroke={stroke}
+          strokeWidth={STROKE_WIDTH}
+        />
+      )}
+      {renderArrow && (
+        <polygon
+          data-testid='point-arrow'
+          points={buildArrowPoints(pixel.x, pixel.y, radius, labelPosition)}
+          fill={textColor}
+        />
+      )}
+      {labelComponent}
+      {!labelComponent && resolvedLabel != null && (
+        <text
+          data-testid='point-label'
+          x={pixel.x}
+          y={labelY}
+          textAnchor='middle'
+          dominantBaseline='auto'
+          fill={textColor}
+          fontSize={theme.typographies.xs.body.body4.fontSize}
+          fontWeight={theme.typographies.xs.body.body4.fontWeight}
+          fontFamily={theme.fontFamilies.sans}
+        >
+          {resolvedLabel}
+        </text>
+      )}
+    </g>
+  );
+}

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from '@ledgerhq/lumen-ui-react';
+import { cssVar } from '@ledgerhq/lumen-design-core';
 import { useMemo } from 'react';
 
 import { projectPoint } from '../../utils/scales/scales';
@@ -27,15 +27,12 @@ export function Point({
   onClick,
 }: PointProps) {
   const { getXScale, getYScale, drawingArea } = useCartesianChartContext();
-  const { theme } = useTheme();
 
   const xScale = getXScale();
   const yScale = getYScale();
 
   const radius = size / 2;
-  const fill = color ?? theme.colors.bg.mutedStrong;
-  const stroke = theme.colors.bg.canvas;
-  const textColor = theme.colors.text.base;
+  const fill = color ?? cssVar('var(--background-muted-strong)');
 
   const pixel = useMemo(() => {
     if (!xScale || !yScale) return undefined;
@@ -46,17 +43,10 @@ export function Point({
     return null;
   }
 
-  const fontSize = theme.typographies.xs.body.body4.fontSize;
   const resolvedLabel = resolveLabel(label, dataX);
   const hasLabel = labelComponent != null || resolvedLabel != null;
   const renderArrow = showArrow && hasLabel;
-  const labelY = computeLabelY(
-    pixel.y,
-    radius,
-    labelPosition,
-    renderArrow,
-    fontSize,
-  );
+  const labelY = computeLabelY(pixel.y, radius, labelPosition, renderArrow);
 
   return (
     <g
@@ -70,8 +60,10 @@ export function Point({
           cx={pixel.x}
           cy={pixel.y}
           r={radius}
-          fill={fill}
-          stroke={stroke}
+          style={{
+            fill,
+            stroke: cssVar('var(--background-canvas)'),
+          }}
           strokeWidth={STROKE_WIDTH}
         />
       )}
@@ -79,7 +71,7 @@ export function Point({
         <polygon
           data-testid='point-arrow'
           points={buildArrowPoints(pixel.x, pixel.y, radius, labelPosition)}
-          fill={textColor}
+          style={{ fill: cssVar('var(--text-base)') }}
         />
       )}
       {labelComponent && (
@@ -92,10 +84,12 @@ export function Point({
           y={labelY}
           textAnchor='middle'
           dominantBaseline='auto'
-          fill={textColor}
-          fontSize={theme.typographies.xs.body.body4.fontSize}
-          fontWeight={theme.typographies.xs.body.body4.fontWeight}
-          fontFamily={theme.fontFamilies.sans}
+          style={{
+            fill: cssVar('var(--text-base)'),
+            fontSize: cssVar('var(--font-style-body-4-size)'),
+            fontWeight: cssVar('var(--font-style-body-4-weight-medium)'),
+            fontFamily: cssVar('var(--font-family-font)'),
+          }}
         >
           {resolvedLabel}
         </text>

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -75,7 +75,9 @@ export function Point({
           fill={textColor}
         />
       )}
-      {labelComponent}
+      {labelComponent && (
+        <g transform={`translate(${pixel.x},${labelY})`}>{labelComponent}</g>
+      )}
       {!labelComponent && resolvedLabel != null && (
         <text
           data-testid='point-label'

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -22,7 +22,7 @@ export function Point({
   labelComponent,
   labelPosition = 'top',
   hidePoint = false,
-  showArrow = true,
+  showLabelArrow = true,
   size = DEFAULT_SIZE,
   onClick,
 }: Readonly<PointProps>) {
@@ -45,7 +45,7 @@ export function Point({
 
   const resolvedLabel = resolveLabel(label, dataX);
   const hasLabel = labelComponent != null || resolvedLabel != null;
-  const renderArrow = showArrow && hasLabel;
+  const renderArrow = showLabelArrow && hasLabel;
   const labelY = computeLabelY(pixel.y, radius, labelPosition, renderArrow);
 
   return (

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -25,7 +25,7 @@ export function Point({
   showArrow = true,
   size = DEFAULT_SIZE,
   onClick,
-}: PointProps) {
+}: Readonly<PointProps>) {
   const { getXScale, getYScale, drawingArea } = useCartesianChartContext();
 
   const xScale = getXScale();

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -46,10 +46,17 @@ export function Point({
     return null;
   }
 
+  const fontSize = theme.typographies.xs.body.body4.fontSize;
   const resolvedLabel = resolveLabel(label, dataX);
   const hasLabel = labelComponent != null || resolvedLabel != null;
   const renderArrow = showArrow && hasLabel;
-  const labelY = computeLabelY(pixel.y, radius, labelPosition, renderArrow);
+  const labelY = computeLabelY(
+    pixel.y,
+    radius,
+    labelPosition,
+    renderArrow,
+    fontSize,
+  );
 
   return (
     <g

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -19,7 +19,7 @@ export function PointLabel({
   textAnchor = 'middle',
   dominantBaseline = 'auto',
   ...props
-}: PointLabelProps) {
+}: Readonly<PointLabelProps>) {
   return (
     <text
       textAnchor={textAnchor}

--- a/libs/ui-react-visualization/src/lib/Components/Point/index.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/index.ts
@@ -1,2 +1,2 @@
-export { Point } from './Point';
-export type { PointProps } from './types';
+export { Point, PointLabel } from './Point';
+export type { PointLabelComponent, PointLabelProps, PointProps } from './types';

--- a/libs/ui-react-visualization/src/lib/Components/Point/index.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/index.ts
@@ -1,0 +1,2 @@
+export { Point } from './Point';
+export type { PointProps } from './types';

--- a/libs/ui-react-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/types.ts
@@ -1,4 +1,12 @@
-import type { MouseEvent, ReactNode } from 'react';
+import type { ComponentType, MouseEvent, SVGProps } from 'react';
+
+export type PointLabelProps = {
+  x: number;
+  y: number;
+  children: string;
+} & Omit<SVGProps<SVGTextElement>, 'x' | 'y' | 'children'>;
+
+export type PointLabelComponent = ComponentType<PointLabelProps>;
 
 export type PointProps = {
   /**
@@ -20,11 +28,12 @@ export type PointProps = {
    */
   label?: string | ((dataIndex: number) => string);
   /**
-   * Custom SVG element rendered instead of the default text label.
-   * Automatically translated so that `(0, 0)` is the label anchor point
-   * (horizontally centered on the point, vertically offset like the built-in label).
+   * Custom component rendered instead of the default `PointLabel`.
+   * Receives pixel coordinates (`x`, `y`) and the resolved label as
+   * `children`. Use `PointLabel` inside your component to retain
+   * design-token styling while customising layout or appearance.
    */
-  labelComponent?: ReactNode;
+  LabelComponent?: PointLabelComponent;
   /**
    * Placement of the label relative to the point.
    * @default 'top'

--- a/libs/ui-react-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/types.ts
@@ -20,8 +20,9 @@ export type PointProps = {
    */
   label?: string | ((dataIndex: number) => string);
   /**
-   * Custom component rendered instead of the default text label.
-   * Positioned at the same coordinates as the label would be.
+   * Custom SVG element rendered instead of the default text label.
+   * Automatically translated so that `(0, 0)` is the label anchor point
+   * (horizontally centered on the point, vertically offset like the built-in label).
    */
   labelComponent?: ReactNode;
   /**

--- a/libs/ui-react-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/types.ts
@@ -1,0 +1,52 @@
+import type { MouseEvent, ReactNode } from 'react';
+
+export type PointProps = {
+  /**
+   * X coordinate in data space (index or explicit value).
+   */
+  dataX: number;
+  /**
+   * Y coordinate in data space.
+   */
+  dataY: number;
+  /**
+   * Fill color of the point circle.
+   */
+  color?: string;
+  /**
+   * Text label displayed near the point.
+   * A string is rendered directly; a function receives `dataX` and returns
+   * the label string, enabling index-based formatting.
+   */
+  label?: string | ((dataIndex: number) => string);
+  /**
+   * Custom component rendered instead of the default text label.
+   * Positioned at the same coordinates as the label would be.
+   */
+  labelComponent?: ReactNode;
+  /**
+   * Placement of the label relative to the point.
+   * @default 'top'
+   */
+  labelPosition?: 'top' | 'bottom';
+  /**
+   * When `true`, the point circle is hidden but the label (if any) is still rendered.
+   * @default false
+   */
+  hidePoint?: boolean;
+  /**
+   * Diameter of the point circle in pixels.
+   * Internally converted to an SVG radius (`size / 2`).
+   * @default 10
+   */
+  size?: number;
+  /**
+   * When `true`, an arrow is displayed pointing from the point to the label.
+   * @default true
+   */
+  showArrow?: boolean;
+  /**
+   * Called when the point is clicked.
+   */
+  onClick?: (event: MouseEvent<SVGGElement>) => void;
+};

--- a/libs/ui-react-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/types.ts
@@ -45,7 +45,7 @@ export type PointProps = {
    * When `true`, an arrow is displayed pointing from the point to the label.
    * @default true
    */
-  showArrow?: boolean;
+  showLabelArrow?: boolean;
   /**
    * Called when the point is clicked.
    */

--- a/libs/ui-react-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/types.ts
@@ -19,6 +19,17 @@ export type PointProps = {
   dataY: number;
   /**
    * Fill color of the point circle.
+   * Defaults to `var(--background-muted-strong)`.
+   *
+   * Use the `cssVar` helper from `@ledgerhq/lumen-design-core` to
+   * resolve a design-token CSS variable at runtime:
+   *
+   * @example
+   * ```tsx
+   * import { cssVar } from '@ledgerhq/lumen-design-core';
+   *
+   * <Point dataX={0} dataY={42} color={cssVar('var(--background-error-strong)')} />
+   * ```
    */
   color?: string;
   /**

--- a/libs/ui-react-visualization/src/lib/Components/Point/utils.test.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/utils.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ARROW_HEIGHT,
+  ARROW_WIDTH,
+  buildArrowPoints,
+  computeLabelY,
+  GAP,
+  isWithinBounds,
+  LABEL_FONT_SIZE,
+  resolveLabel,
+} from './utils';
+
+describe('isWithinBounds', () => {
+  const area = { x: 10, y: 20, width: 100, height: 50 };
+
+  it('returns true for a point inside the area', () => {
+    expect(isWithinBounds(50, 40, area)).toBe(true);
+  });
+
+  it('returns true on the top-left edge', () => {
+    expect(isWithinBounds(10, 20, area)).toBe(true);
+  });
+
+  it('returns true on the bottom-right edge', () => {
+    expect(isWithinBounds(110, 70, area)).toBe(true);
+  });
+
+  it('returns false when x is left of the area', () => {
+    expect(isWithinBounds(9, 40, area)).toBe(false);
+  });
+
+  it('returns false when x is right of the area', () => {
+    expect(isWithinBounds(111, 40, area)).toBe(false);
+  });
+
+  it('returns false when y is above the area', () => {
+    expect(isWithinBounds(50, 19, area)).toBe(false);
+  });
+
+  it('returns false when y is below the area', () => {
+    expect(isWithinBounds(50, 71, area)).toBe(false);
+  });
+});
+
+describe('buildArrowPoints', () => {
+  const cx = 100;
+  const cy = 200;
+  const radius = 5;
+  const halfW = ARROW_WIDTH / 2;
+
+  it('builds a downward-pointing arrow for top position', () => {
+    const result = buildArrowPoints(cx, cy, radius, 'top');
+    const tipY = cy - radius - GAP;
+    const baseY = tipY - ARROW_HEIGHT;
+    expect(result).toBe(
+      `${cx},${tipY} ${cx - halfW},${baseY} ${cx + halfW},${baseY}`,
+    );
+  });
+
+  it('builds an upward-pointing arrow for bottom position', () => {
+    const result = buildArrowPoints(cx, cy, radius, 'bottom');
+    const tipY = cy + radius + GAP;
+    const baseY = tipY + ARROW_HEIGHT;
+    expect(result).toBe(
+      `${cx},${tipY} ${cx - halfW},${baseY} ${cx + halfW},${baseY}`,
+    );
+  });
+});
+
+describe('resolveLabel', () => {
+  it('returns a string label as-is', () => {
+    expect(resolveLabel('Peak', 0)).toBe('Peak');
+  });
+
+  it('calls a function label with dataX', () => {
+    expect(resolveLabel((i) => `#${i}`, 3)).toBe('#3');
+  });
+
+  it('returns undefined for an undefined label', () => {
+    expect(resolveLabel(undefined, 0)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(resolveLabel('', 0)).toBeUndefined();
+  });
+
+  it('returns undefined when a function returns an empty string', () => {
+    expect(resolveLabel(() => '', 0)).toBeUndefined();
+  });
+});
+
+describe('computeLabelY', () => {
+  const pixelY = 100;
+  const radius = 5;
+
+  it('positions label above the point when labelPosition is top with arrow', () => {
+    const result = computeLabelY(pixelY, radius, 'top', true);
+    const arrowOffset = ARROW_HEIGHT + GAP;
+    expect(result).toBe(pixelY - radius - arrowOffset - GAP);
+  });
+
+  it('positions label above the point when labelPosition is top without arrow', () => {
+    const result = computeLabelY(pixelY, radius, 'top', false);
+    expect(result).toBe(pixelY - radius - GAP - GAP);
+  });
+
+  it('positions label below the point when labelPosition is bottom with arrow', () => {
+    const result = computeLabelY(pixelY, radius, 'bottom', true);
+    const arrowOffset = ARROW_HEIGHT + GAP;
+    expect(result).toBe(pixelY + radius + arrowOffset + GAP + LABEL_FONT_SIZE);
+  });
+
+  it('positions label below the point when labelPosition is bottom without arrow', () => {
+    const result = computeLabelY(pixelY, radius, 'bottom', false);
+    expect(result).toBe(pixelY + radius + GAP + GAP + LABEL_FONT_SIZE);
+  });
+});

--- a/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
@@ -3,6 +3,7 @@ export const STROKE_WIDTH = 2;
 export const ARROW_WIDTH = 6;
 export const ARROW_HEIGHT = 4;
 export const GAP = 4;
+export const LABEL_FONT_SIZE = 10;
 
 export const isWithinBounds = (
   px: number,
@@ -58,11 +59,10 @@ export const computeLabelY = (
   radius: number,
   labelPosition: 'top' | 'bottom',
   renderArrow: boolean,
-  fontSize: number,
 ): number => {
   const arrowOffset = renderArrow ? ARROW_HEIGHT + GAP : GAP;
 
   return labelPosition === 'top'
     ? pixelY - radius - arrowOffset - GAP
-    : pixelY + radius + arrowOffset + GAP + fontSize;
+    : pixelY + radius + arrowOffset + GAP + LABEL_FONT_SIZE;
 };

--- a/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
@@ -1,0 +1,68 @@
+export const DEFAULT_SIZE = 10;
+export const STROKE_WIDTH = 2;
+export const LABEL_FONT_SIZE = 10;
+export const ARROW_WIDTH = 6;
+export const ARROW_HEIGHT = 4;
+export const GAP = 4;
+
+export const isWithinBounds = (
+  px: number,
+  py: number,
+  area: { x: number; y: number; width: number; height: number },
+): boolean =>
+  px >= area.x &&
+  px <= area.x + area.width &&
+  py >= area.y &&
+  py <= area.y + area.height;
+
+/**
+ * Builds the three SVG points of the arrow triangle.
+ *
+ * `'top'`  → arrow sits below the label, tip pointing **down** toward the circle.
+ * `'bottom'` → arrow sits above the label, tip pointing **up** toward the circle.
+ */
+export const buildArrowPoints = (
+  cx: number,
+  cy: number,
+  radius: number,
+  position: 'top' | 'bottom',
+): string => {
+  const halfW = ARROW_WIDTH / 2;
+
+  if (position === 'top') {
+    const tipY = cy - radius - GAP;
+    const baseY = tipY - ARROW_HEIGHT;
+    return `${cx},${tipY} ${cx - halfW},${baseY} ${cx + halfW},${baseY}`;
+  }
+
+  const tipY = cy + radius + GAP;
+  const baseY = tipY + ARROW_HEIGHT;
+  return `${cx},${tipY} ${cx - halfW},${baseY} ${cx + halfW},${baseY}`;
+};
+
+/**
+ * Resolves the label prop to a string or undefined.
+ */
+export const resolveLabel = (
+  label: string | ((dataIndex: number) => string) | undefined,
+  dataX: number,
+): string | undefined => {
+  const resolved = typeof label === 'function' ? label(dataX) : label;
+  return resolved === '' ? undefined : resolved;
+};
+
+/**
+ * Computes the vertical position of the label text baseline.
+ */
+export const computeLabelY = (
+  pixelY: number,
+  radius: number,
+  labelPosition: 'top' | 'bottom',
+  renderArrow: boolean,
+): number => {
+  const arrowOffset = renderArrow ? ARROW_HEIGHT + GAP : GAP;
+
+  return labelPosition === 'top'
+    ? pixelY - radius - arrowOffset - GAP
+    : pixelY + radius + arrowOffset + GAP + LABEL_FONT_SIZE;
+};

--- a/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
@@ -1,6 +1,5 @@
 export const DEFAULT_SIZE = 10;
 export const STROKE_WIDTH = 2;
-export const LABEL_FONT_SIZE = 10;
 export const ARROW_WIDTH = 6;
 export const ARROW_HEIGHT = 4;
 export const GAP = 4;
@@ -59,10 +58,11 @@ export const computeLabelY = (
   radius: number,
   labelPosition: 'top' | 'bottom',
   renderArrow: boolean,
+  fontSize: number,
 ): number => {
   const arrowOffset = renderArrow ? ARROW_HEIGHT + GAP : GAP;
 
   return labelPosition === 'top'
     ? pixelY - radius - arrowOffset - GAP
-    : pixelY + radius + arrowOffset + GAP + LABEL_FONT_SIZE;
+    : pixelY + radius + arrowOffset + GAP + fontSize;
 };

--- a/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
@@ -1,3 +1,5 @@
+import type { DrawingArea } from '../../utils/types';
+
 export const DEFAULT_SIZE = 10;
 export const STROKE_WIDTH = 2;
 export const ARROW_WIDTH = 6;
@@ -8,7 +10,7 @@ export const LABEL_FONT_SIZE = 10;
 export const isWithinBounds = (
   px: number,
   py: number,
-  area: { x: number; y: number; width: number; height: number },
+  area: DrawingArea,
 ): boolean =>
   px >= area.x &&
   px <= area.x + area.width &&

--- a/libs/ui-react-visualization/src/lib/Components/index.ts
+++ b/libs/ui-react-visualization/src/lib/Components/index.ts
@@ -1,1 +1,2 @@
 export * from './LineChart';
+export * from './Point';

--- a/libs/ui-react-visualization/src/lib/utils/scales/scales.test.ts
+++ b/libs/ui-react-visualization/src/lib/utils/scales/scales.test.ts
@@ -6,6 +6,7 @@ import {
   isBandScaleType,
   isCategoricalScale,
   isNumericScale,
+  projectPoint,
 } from './scales';
 
 describe('getNumericScale', () => {
@@ -129,5 +130,40 @@ describe('isCategoricalScale / isNumericScale', () => {
   it('should identify a categorical scale', () => {
     expect(isCategoricalScale(bandScale)).toBe(true);
     expect(isNumericScale(bandScale)).toBe(false);
+  });
+});
+
+describe('projectPoint', () => {
+  it('should project data coordinates to pixel coordinates with linear scales', () => {
+    const xScale = getNumericScale({
+      scaleType: 'linear',
+      domain: { min: 0, max: 10 },
+      range: { min: 0, max: 400 },
+    });
+    const yScale = getNumericScale({
+      scaleType: 'linear',
+      domain: { min: 0, max: 100 },
+      range: { min: 200, max: 0 },
+    });
+    const result = projectPoint(5, 50, xScale, yScale);
+    expect(result.x).toBe(200);
+    expect(result.y).toBe(100);
+  });
+
+  it('should center on band for categorical x-scale', () => {
+    const xScale = getCategoricalScale({
+      domain: { min: 0, max: 3 },
+      range: { min: 0, max: 400 },
+      padding: 0,
+    });
+    const yScale = getNumericScale({
+      scaleType: 'linear',
+      domain: { min: 0, max: 100 },
+      range: { min: 200, max: 0 },
+    });
+    const result = projectPoint(1, 50, xScale, yScale);
+    const expectedX = (xScale(1) ?? 0) + xScale.bandwidth() / 2;
+    expect(result.x).toBe(expectedX);
+    expect(result.y).toBe(100);
   });
 });

--- a/libs/ui-react-visualization/src/lib/utils/scales/scales.ts
+++ b/libs/ui-react-visualization/src/lib/utils/scales/scales.ts
@@ -72,3 +72,22 @@ export const isNumericScale = (
 ): scale is NumericScale => {
   return !isCategoricalScale(scale);
 };
+
+/**
+ * Projects a single data-space coordinate pair into pixel-space.
+ * Handles centering for categorical (band) scales.
+ */
+export const projectPoint = (
+  dataX: number,
+  dataY: number,
+  xScale: ChartScaleFunction,
+  yScale: ChartScaleFunction,
+): { x: number; y: number } => {
+  const x = isCategoricalScale(xScale)
+    ? (xScale(dataX) ?? 0) + xScale.bandwidth() / 2
+    : xScale(dataX);
+  const y = isCategoricalScale(yScale)
+    ? (yScale(dataY) ?? 0) + yScale.bandwidth() / 2
+    : (yScale as NumericScale)(dataY);
+  return { x: x as number, y };
+};

--- a/libs/ui-react-visualization/src/lib/utils/scales/scales.ts
+++ b/libs/ui-react-visualization/src/lib/utils/scales/scales.ts
@@ -88,6 +88,6 @@ export const projectPoint = (
     : xScale(dataX);
   const y = isCategoricalScale(yScale)
     ? (yScale(dataY) ?? 0) + yScale.bandwidth() / 2
-    : (yScale as NumericScale)(dataY);
-  return { x: x as number, y };
+    : yScale(dataY);
+  return { x: x, y };
 };


### PR DESCRIPTION
## Overview

Introduce Point subcomponent, that allows to project a point onto a graph, supporting a label as a string or custom component.

---
<img width="631" height="327" alt="Screenshot 2026-04-28 at 16 54 19" src="https://github.com/user-attachments/assets/a3627f80-e188-4719-b6df-80622b60be34" />
