### PR TITLE
feat(ui-react/ui-rnative): add trailing content for SegmentedControl buttons

### DIFF
--- a/.nx/version-plans/version-plan-1778158270857-react.md
+++ b/.nx/version-plans/version-plan-1778158270857-react.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+feat(ui-react): add trailing content for SegmentedControl buttons

--- a/.nx/version-plans/version-plan-1778158270857-rnative.md
+++ b/.nx/version-plans/version-plan-1778158270857-rnative.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+feat(ui-rnative): add trailing content for SegmentedControl buttons

--- a/apps/app-sandbox-rnative/src/app/blocks/DotCounts.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/DotCounts.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   DotCount,
   Box,
   InteractiveIcon,
@@ -35,14 +34,6 @@ export function DotCounts() {
             alt='Bitcoin'
             size={40}
             shape='circle'
-          />
-        </DotCount>
-        <DotCount value={100} size='md'>
-          <Avatar
-            src={
-              'https://plus.unsplash.com/premium_photo-1689551670902-19b441a6afde?q=80&w=774&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
-            }
-            size='md'
           />
         </DotCount>
         <DotCount value={6} size='lg' disabled>

--- a/apps/app-sandbox-rnative/src/app/blocks/DotCounts.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/DotCounts.tsx
@@ -55,17 +55,11 @@ export function DotCounts() {
         tabLayout='fit'
         accessibilityLabel='Fit layout'
       >
-        <SegmentedControlButton value='preview'>
-          <>
-            Preview
-            <Box>
-              <DotCount
-                value={3}
-                size='md'
-                style={{ marginLeft: 8, marginBottom: -3 }}
-              />
-            </Box>
-          </>
+        <SegmentedControlButton
+          value='preview'
+          trailingContent={<DotCount value={3} size='md' />}
+        >
+          Preview
         </SegmentedControlButton>
         <SegmentedControlButton value='raw'>Raw</SegmentedControlButton>
         <SegmentedControlButton value='blame'>Blame</SegmentedControlButton>

--- a/apps/app-sandbox-rnative/src/app/blocks/DotIndicators.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/DotIndicators.tsx
@@ -1,4 +1,4 @@
-import { Button, DotIndicator, Box } from '@ledgerhq/lumen-ui-rnative';
+import { Button, DotIndicator, Box, Avatar } from '@ledgerhq/lumen-ui-rnative';
 
 export function DotIndicators() {
   return (
@@ -15,6 +15,7 @@ export function DotIndicators() {
         <DotIndicator disabled />
       </Box>
       <Box lx={{ gap: 's12', flexDirection: 'row', alignItems: 'center' }}>
+        <Avatar size='md' showNotification />
         <DotIndicator appearance='red'>
           <Button size='sm' disabled>
             Submit

--- a/apps/app-sandbox-rnative/src/app/blocks/SegmentedControls.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/SegmentedControls.tsx
@@ -1,16 +1,18 @@
 import {
   Box,
+  DotCount,
   SegmentedControl,
   SegmentedControlButton,
   Text,
 } from '@ledgerhq/lumen-ui-rnative';
 import { Code, Eye, EyeCross } from '@ledgerhq/lumen-ui-rnative/symbols';
-import React from 'react';
+import { useState } from 'react';
 
 export const SegmentedControls = () => {
-  const [fitState, setFitState] = React.useState('preview');
-  const [fixedState, setFixedState] = React.useState('preview');
-  const [iconsState, setIconsState] = React.useState('preview');
+  const [fitState, setFitState] = useState('preview');
+  const [fixedState, setFixedState] = useState('preview');
+  const [iconsState, setIconsState] = useState('preview');
+  const [trailingState, setTrailingState] = useState('preview');
 
   return (
     <Box lx={{ gap: 's24', width: 'full' }}>
@@ -58,6 +60,31 @@ export const SegmentedControls = () => {
           Raw
         </SegmentedControlButton>
         <SegmentedControlButton value='blame' icon={EyeCross}>
+          Blame
+        </SegmentedControlButton>
+      </SegmentedControl>
+
+      <Text typography='body2SemiBold' lx={{ color: 'muted' }}>
+        With trailing content (fit)
+      </Text>
+      <SegmentedControl
+        selectedValue={trailingState}
+        onSelectedChange={setTrailingState}
+        tabLayout='fit'
+        accessibilityLabel='With trailing content'
+      >
+        <SegmentedControlButton
+          value='preview'
+          trailingContent={<DotCount value={3} size='md' />}
+        >
+          Preview
+        </SegmentedControlButton>
+        <SegmentedControlButton value='raw'>Raw</SegmentedControlButton>
+
+        <SegmentedControlButton
+          value='blame'
+          trailingContent={<DotCount value={100} size='md' />}
+        >
           Blame
         </SegmentedControlButton>
       </SegmentedControl>

--- a/libs/ui-react/src/lib/Components/DotCount/DotCount.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DotCount/DotCount.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
-import { Avatar } from '../Avatar';
 import { MediaImage } from '../MediaImage';
 import { SegmentedControl, SegmentedControlButton } from '../SegmentedControl';
 import { DotCount } from './DotCount';
@@ -86,19 +85,13 @@ export const WithChildren: Story = {
 
     return (
       <div className='flex flex-col gap-24'>
-        <div className='flex items-center gap-12'>
+        <div className='flex items-center justify-center gap-12'>
           <DotCount value={5} size='md'>
             <MediaImage
               src='https://crypto-icons.ledger.com/BTC.png'
               alt='Bitcoin'
               size={40}
               shape='circle'
-            />
-          </DotCount>
-          <DotCount value={100} size='md'>
-            <Avatar
-              src='https://plus.unsplash.com/premium_photo-1689551670902-19b441a6afde?q=80&w=774&auto=format&fit=crop'
-              size='md'
             />
           </DotCount>
         </div>
@@ -108,11 +101,11 @@ export const WithChildren: Story = {
           tabLayout='fit'
           aria-label='Fit layout'
         >
-          <SegmentedControlButton value='preview'>
-            <span className='flex items-center gap-6'>
-              Preview
-              <DotCount value={3} size='md' />
-            </span>
+          <SegmentedControlButton
+            value='preview'
+            trailingContent={<DotCount value={3} size='md' />}
+          >
+            Preview
           </SegmentedControlButton>
           <SegmentedControlButton value='raw'>Raw</SegmentedControlButton>
           <SegmentedControlButton value='blame'>Blame</SegmentedControlButton>

--- a/libs/ui-react/src/lib/Components/DotIndicator/DotIndicator.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DotIndicator/DotIndicator.stories.tsx
@@ -66,9 +66,7 @@ export const WithChildren: Story = {
       <DotIndicator appearance='red'>
         <Button size='sm'>Submit</Button>
       </DotIndicator>
-      <DotIndicator appearance='red'>
-        <Avatar size='md' />
-      </DotIndicator>
+      <Avatar size='md' showNotification />
       <DotIndicator appearance='red'>
         <IconButton aria-label='Settings' icon={Settings} />
       </DotIndicator>

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.mdx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.mdx
@@ -24,6 +24,7 @@ SegmentedControl is a tab bar-style component for switching between mutually exc
 - **Segments**: Individual options the user can select.
 - **Selected state**: The active segment (sliding pill + semi-bold label).
 - **Optional icon**: Icon to the left of the label (from Symbols).
+- **Optional trailing content**: Any node (e.g. `DotCount`) rendered to the right of the label.
 - **Appearance**: Use `appearance="background"` (default) for a surface background, or `appearance="no-background"` for a transparent container.
 
 ## Properties
@@ -38,6 +39,12 @@ You can use segments with text only (Base), or add an icon to each button (WithI
 <Canvas of={SegmentedControlStories.Base} />
 
 <Canvas of={SegmentedControlStories.WithIcons} />
+
+### With trailing content
+
+Use `trailingContent` to render content (e.g. `DotCount`) to the right of the label.
+
+<Canvas of={SegmentedControlStories.WithTrailingContent} />
 
 ## Responsive Layout
 
@@ -79,6 +86,33 @@ export default function Example() {
 }
 ```
 
+## With trailing content
+
+Pass any node via `trailingContent` to render it to the right of the label. Use it for badges like `DotCount` to surface counts per segment.
+
+```tsx
+import { SegmentedControl, SegmentedControlButton, DotCount } from '@ledgerhq/lumen-ui-react';
+
+function Example() {
+  const [state, setState] = React.useState('tokens');
+  return (
+    <SegmentedControl
+      selectedValue={state}
+      onSelectedChange={setState}
+      aria-label='Asset section'
+    >
+      <SegmentedControlButton value='tokens' trailingContent={<DotCount value={3} />}>
+        Tokens
+      </SegmentedControlButton>
+      <SegmentedControlButton value='nfts' trailingContent={<DotCount value={12} />}>
+        NFTs
+      </SegmentedControlButton>
+      <SegmentedControlButton value='activity'>Activity</SegmentedControlButton>
+    </SegmentedControl>
+  );
+}
+```
+
 ## With icons
 
 Pass an icon from symbols to each button for a left-positioned icon. Use icons on all segments or none for consistency.
@@ -111,10 +145,6 @@ function Example() {
   );
 }
 ```
-
-<div className='flex flex-col gap-24'>
-  <CommonRulesDoAndDont />
-</div>
 
 </Tab>
 </CustomTabs>

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { Coins, Nft, TransferHorizontal, Settings } from '../../Symbols';
+import { DotCount } from '../DotCount/DotCount';
 import { SegmentedControl, SegmentedControlButton } from './SegmentedControl';
 
 const meta = {
@@ -135,4 +136,36 @@ export const Disabled: Story = {
       <SegmentedControlButton value='buy'>Buy</SegmentedControlButton>
     </SegmentedControl>
   ),
+};
+
+export const WithTrailingContent: Story = {
+  args: {} as React.ComponentProps<typeof SegmentedControl>,
+  render: (args) => {
+    const [state, setState] = useState('tokens');
+
+    return (
+      <SegmentedControl
+        {...args}
+        selectedValue={state}
+        onSelectedChange={setState}
+        aria-label='Asset section'
+      >
+        <SegmentedControlButton
+          value='tokens'
+          trailingContent={<DotCount value={3} />}
+        >
+          Tokens
+        </SegmentedControlButton>
+        <SegmentedControlButton
+          value='nfts'
+          trailingContent={<DotCount value={12} />}
+        >
+          NFTs
+        </SegmentedControlButton>
+        <SegmentedControlButton value='activity'>
+          Activity
+        </SegmentedControlButton>
+      </SegmentedControl>
+    );
+  },
 };

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { Coins, TransferHorizontal, Nft } from '../../Symbols';
-import { DotCount } from '../DotCount/DotCount';
+import { DotCount } from '../DotCount';
 import { SegmentedControl, SegmentedControlButton } from './SegmentedControl';
 
 const meta = {

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
-import { Coins, Nft, TransferHorizontal, Settings } from '../../Symbols';
+import { Coins, TransferHorizontal, Nft } from '../../Symbols';
 import { DotCount } from '../DotCount/DotCount';
 import { SegmentedControl, SegmentedControlButton } from './SegmentedControl';
 
@@ -66,11 +66,8 @@ export const WithIcons: Story = {
         <SegmentedControlButton value='nfts' icon={Nft}>
           NFTs
         </SegmentedControlButton>
-        <SegmentedControlButton value='activity' icon={TransferHorizontal}>
-          Activity
-        </SegmentedControlButton>
-        <SegmentedControlButton value='settings' icon={Settings}>
-          Settings
+        <SegmentedControlButton value='trade' icon={TransferHorizontal}>
+          Trade
         </SegmentedControlButton>
       </SegmentedControl>
     );
@@ -162,9 +159,7 @@ export const WithTrailingContent: Story = {
         >
           NFTs
         </SegmentedControlButton>
-        <SegmentedControlButton value='activity'>
-          Activity
-        </SegmentedControlButton>
+        <SegmentedControlButton value='trade'>Trade</SegmentedControlButton>
       </SegmentedControl>
     );
   },

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.test.tsx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
 
+import { DotCount } from '../DotCount';
 import { SegmentedControl, SegmentedControlButton } from './SegmentedControl';
 
 describe('SegmentedControl', () => {
@@ -38,5 +39,27 @@ describe('SegmentedControl', () => {
     fireEvent.click(screen.getByText('Receive'));
 
     expect(onSelectedChange).toHaveBeenCalledWith('receive');
+  });
+
+  it('renders trailingContent inside segment buttons', () => {
+    render(
+      <SegmentedControl
+        selectedValue='tokens'
+        onSelectedChange={() => {
+          /* empty */
+        }}
+        aria-label='Asset section'
+      >
+        <SegmentedControlButton
+          value='tokens'
+          trailingContent={<DotCount value={3} aria-label='3 tokens' />}
+        >
+          Tokens
+        </SegmentedControlButton>
+        <SegmentedControlButton value='nfts'>NFTs</SegmentedControlButton>
+      </SegmentedControl>,
+    );
+
+    expect(screen.getByLabelText('3 tokens')).toBeTruthy();
   });
 });

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.tsx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.tsx
@@ -68,6 +68,7 @@ export function SegmentedControlButton({
   value,
   children,
   icon: Icon,
+  trailingContent,
   onClick,
   className,
   ...props
@@ -99,6 +100,7 @@ export function SegmentedControlButton({
       <span className='inline-flex min-w-0 items-center justify-center gap-8'>
         {Icon && <Icon size={16} className='shrink-0' />}
         <span className='truncate'>{children}</span>
+        {trailingContent}
       </span>
     </button>
   );

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.tsx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.tsx
@@ -99,7 +99,7 @@ export function SegmentedControlButton({
     >
       <span className='inline-flex min-w-0 items-center justify-center gap-8'>
         {Icon && <Icon size={16} className='shrink-0' />}
-        <span className='truncate'>{children}</span>
+        <span className='min-w-0 truncate'>{children}</span>
         {trailingContent}
       </span>
     </button>

--- a/libs/ui-react/src/lib/Components/SegmentedControl/types.ts
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/types.ts
@@ -50,4 +50,8 @@ export type SegmentedControlButtonProps = {
    * Optional icon shown to the left of the label (from Symbols).
    */
   icon?: IconComponent;
+  /**
+   * Optional content shown to the right of the label (e.g. DotCount badge).
+   */
+  trailingContent?: ReactNode;
 } & Omit<ComponentPropsWithoutRef<'button'>, 'children'>;

--- a/libs/ui-rnative/src/lib/Components/DotCount/DotCount.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotCount/DotCount.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { useState } from 'react';
-import { Avatar } from '../Avatar/Avatar';
 import { MediaImage } from '../MediaImage/MediaImage';
 import {
   SegmentedControl,
@@ -89,19 +88,20 @@ export const WithChildren: Story = {
 
     return (
       <Box lx={{ gap: 's24' }}>
-        <Box lx={{ flexDirection: 'row', alignItems: 'center', gap: 's12' }}>
+        <Box
+          lx={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 's12',
+          }}
+        >
           <DotCount value={5} size='md'>
             <MediaImage
               src='https://crypto-icons.ledger.com/BTC.png'
               alt='Bitcoin'
               size={40}
               shape='circle'
-            />
-          </DotCount>
-          <DotCount value={100} size='md'>
-            <Avatar
-              src='https://plus.unsplash.com/premium_photo-1689551670902-19b441a6afde?q=80&w=774&auto=format&fit=crop'
-              size='md'
             />
           </DotCount>
         </Box>
@@ -111,9 +111,11 @@ export const WithChildren: Story = {
           tabLayout='fit'
           accessibilityLabel='Fit layout'
         >
-          <SegmentedControlButton value='preview'>
+          <SegmentedControlButton
+            value='preview'
+            trailingContent={<DotCount value={3} size='md' />}
+          >
             Preview
-            <DotCount value={3} size='md' style={{ marginLeft: 6 }} />
           </SegmentedControlButton>
           <SegmentedControlButton value='raw'>Raw</SegmentedControlButton>
           <SegmentedControlButton value='blame'>Blame</SegmentedControlButton>

--- a/libs/ui-rnative/src/lib/Components/DotIndicator/DotIndicator.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotIndicator/DotIndicator.stories.tsx
@@ -66,9 +66,7 @@ export const WithChildren: Story = {
       <DotIndicator appearance='red'>
         <Button size='sm'>Submit</Button>
       </DotIndicator>
-      <DotIndicator appearance='red'>
-        <Avatar size='md' />
-      </DotIndicator>
+      <Avatar size='md' showNotification />
       <DotIndicator appearance='red'>
         <IconButton accessibilityLabel='Settings' icon={Settings} />
       </DotIndicator>

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.mdx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.mdx
@@ -25,6 +25,7 @@ SegmentedControl is a tab bar–style component for switching between mutually e
 - **Segments**: Individual options the user can select.
 - **Selected state**: The active segment (sliding pill + semi-bold label).
 - **Optional icon**: Icon to the left of the label (from Symbols).
+- **Optional trailing content**: Any node (e.g. `DotCount`) rendered to the right of the label.
 - **Appearance**: Use `appearance="background"` (default) for a surface background, or `appearance="no-background"` for a transparent container.
 
 ## Properties
@@ -39,6 +40,12 @@ You can use segments with text only (Base), or add an icon to each button (WithI
 <Canvas of={SegmentedControlStories.Base} />
 
 <Canvas of={SegmentedControlStories.WithIcons} />
+
+### With trailing content
+
+Use `trailingContent` to render content (e.g. `DotCount`) to the right of the label.
+
+<Canvas of={SegmentedControlStories.WithTrailingContent} />
 
 ## Responsive Layout
 
@@ -80,6 +87,33 @@ export default function Example() {
 }
 ```
 
+## With trailing content
+
+Pass any node via `trailingContent` to render it to the right of the label. Use it for badges like `DotCount` to surface counts per segment.
+
+```tsx
+import { SegmentedControl, SegmentedControlButton, DotCount } from '@ledgerhq/lumen-ui-rnative';
+
+function Example() {
+  const [state, setState] = React.useState('tokens');
+  return (
+    <SegmentedControl
+      selectedValue={state}
+      onSelectedChange={setState}
+      accessibilityLabel='Asset section'
+    >
+      <SegmentedControlButton value='tokens' trailingContent={<DotCount value={3} />}>
+        Tokens
+      </SegmentedControlButton>
+      <SegmentedControlButton value='nfts' trailingContent={<DotCount value={12} />}>
+        NFTs
+      </SegmentedControlButton>
+      <SegmentedControlButton value='activity'>Activity</SegmentedControlButton>
+    </SegmentedControl>
+  );
+}
+```
+
 ## With icons
 
 Pass an icon from symbols to each button for a left-positioned icon. Use icons on all segments or none for consistency.
@@ -112,10 +146,6 @@ function Example() {
   );
 }
 ```
-
-<Box lx={{ flexDirection: 'column', gap: 's24' }}>
-  <CommonRulesDoAndDont />
-</Box>
 
 </Tab>
 </CustomTabs>

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { useState } from 'react';
-import { Coins, Nft, TransferHorizontal, Settings } from '../../Symbols';
+import { Coins, Nft, TransferHorizontal } from '../../Symbols';
 import { DotCount } from '../DotCount';
 import { Box } from '../Utility';
 import { SegmentedControl, SegmentedControlButton } from './SegmentedControl';
@@ -75,11 +75,8 @@ export const WithIcons: Story = {
         <SegmentedControlButton value='nfts' icon={Nft}>
           NFTs
         </SegmentedControlButton>
-        <SegmentedControlButton value='activity' icon={TransferHorizontal}>
-          Activity
-        </SegmentedControlButton>
-        <SegmentedControlButton value='settings' icon={Settings}>
-          Settings
+        <SegmentedControlButton value='trade' icon={TransferHorizontal}>
+          Trade
         </SegmentedControlButton>
       </SegmentedControl>
     );
@@ -168,9 +165,7 @@ export const WithTrailingContent: Story = {
         >
           NFTs
         </SegmentedControlButton>
-        <SegmentedControlButton value='activity'>
-          Activity
-        </SegmentedControlButton>
+        <SegmentedControlButton value='trade'>Trade</SegmentedControlButton>
       </SegmentedControl>
     );
   },

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { useState } from 'react';
 import { Coins, Nft, TransferHorizontal, Settings } from '../../Symbols';
+import { DotCount } from '../DotCount';
 import { Box } from '../Utility';
 import { SegmentedControl, SegmentedControlButton } from './SegmentedControl';
 
@@ -141,4 +142,36 @@ export const Disabled: Story = {
       <SegmentedControlButton value='buy'>Buy</SegmentedControlButton>
     </SegmentedControl>
   ),
+};
+
+export const WithTrailingContent: Story = {
+  args: {} as React.ComponentProps<typeof SegmentedControl>,
+  render: (args) => {
+    const [state, setState] = useState('tokens');
+
+    return (
+      <SegmentedControl
+        {...args}
+        selectedValue={state}
+        onSelectedChange={setState}
+        accessibilityLabel='Asset section'
+      >
+        <SegmentedControlButton
+          value='tokens'
+          trailingContent={<DotCount value={3} />}
+        >
+          Tokens
+        </SegmentedControlButton>
+        <SegmentedControlButton
+          value='nfts'
+          trailingContent={<DotCount value={12} />}
+        >
+          NFTs
+        </SegmentedControlButton>
+        <SegmentedControlButton value='activity'>
+          Activity
+        </SegmentedControlButton>
+      </SegmentedControl>
+    );
+  },
 };

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { ledgerLiveThemes } from '@ledgerhq/lumen-design-core';
 import { render, fireEvent } from '@testing-library/react-native';
+import { DotCount } from '../DotCount';
 import { ThemeProvider } from '../ThemeProvider/ThemeProvider';
 import { SegmentedControl, SegmentedControlButton } from './SegmentedControl';
 
@@ -52,5 +53,31 @@ describe('SegmentedControl', () => {
     fireEvent.press(getByText('Receive'));
 
     expect(onSelectedChange).toHaveBeenCalledWith('receive');
+  });
+
+  it('renders trailingContent inside segment buttons', () => {
+    const { getByLabelText } = render(
+      <TestWrapper>
+        <SegmentedControl
+          selectedValue='tokens'
+          onSelectedChange={() => {
+            /* empty */
+          }}
+          accessibilityLabel='Asset section'
+        >
+          <SegmentedControlButton
+            value='tokens'
+            trailingContent={
+              <DotCount value={3} accessibilityLabel='3 tokens' />
+            }
+          >
+            Tokens
+          </SegmentedControlButton>
+          <SegmentedControlButton value='nfts'>NFTs</SegmentedControlButton>
+        </SegmentedControl>
+      </TestWrapper>,
+    );
+
+    expect(getByLabelText('3 tokens')).toBeTruthy();
   });
 });

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.tsx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.tsx
@@ -21,6 +21,7 @@ export function SegmentedControlButton({
   value,
   children,
   icon: Icon,
+  trailingContent,
   onPress,
   ...props
 }: SegmentedControlButtonProps) {
@@ -71,6 +72,7 @@ export function SegmentedControlButton({
         >
           {children}
         </Text>
+        {trailingContent}
       </Box>
     </Pressable>
   );

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/types.ts
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/types.ts
@@ -57,6 +57,10 @@ export type SegmentedControlButtonProps = {
    */
   icon?: IconComponent;
   /**
+   * Optional content shown to the right of the label (e.g. DotCount badge).
+   */
+  trailingContent?: ReactNode;
+  /**
    * Optional callback when the button is pressed (in addition to onSelectedChange on the parent).
    */
   onPress?: () => void;


### PR DESCRIPTION
Closes [DLS-640](https://ledgerhq.atlassian.net/browse/DLS-640).

### Storybook demo

<img width="283" height="66" alt="image" src="https://github.com/user-attachments/assets/af659d10-0618-4c4a-be90-ed0e86982064" />

--- 

<img width="367" height="74" alt="image" src="https://github.com/user-attachments/assets/72e7bce2-125c-456d-bec6-8aad1e2d05cf" />

### Sandbox app demo

https://github.com/user-attachments/assets/e58fa0f2-a2a0-4979-b565-f2c9b5b1b2ec

### Also

* In Storybook, it no longer adds the DotCount/Indicator for components which already internally use it. For instance, avatar and page indicators were being added as children of DotCount/Indicator.

[DLS-640]: https://ledgerhq.atlassian.net/browse/DLS-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ