### PR TITLE
feat(ui-react): add `stickyHeader` prop to DataTable/Table

### DIFF
--- a/.nx/version-plans/version-plan-1778248211722.md
+++ b/.nx/version-plans/version-plan-1778248211722.md
@@ -2,4 +2,4 @@
 '@ledgerhq/lumen-ui-react': patch
 ---
 
-feat(ui-react): add `stickyHeader` prop to DataTable
+feat(ui-react): add `stickyHeader` prop to DataTable/Table

--- a/.nx/version-plans/version-plan-1778248211722.md
+++ b/.nx/version-plans/version-plan-1778248211722.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+feat(ui-react): add `stickyHeader` prop to DataTable

--- a/libs/ui-react/src/lib/Components/DataTable/DataTable.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DataTable/DataTable.stories.tsx
@@ -571,6 +571,63 @@ export const WithCustomHeader: Story = {
   },
 };
 
+export const WithoutStickyHeader: Story = {
+  args: {
+    appearance: 'no-background',
+    stickyHeader: false,
+  },
+  render: (args) => {
+    const table = useLumenDataTable({
+      data: largeData,
+      columns: [
+        {
+          accessorKey: 'name',
+          header: 'Asset',
+          enableSorting: false,
+          cell: ({ row }) => (
+            <TableCellContent
+              title={row.original.name}
+              description={row.original.symbol}
+              leadingContent={<Spot appearance='icon' icon={Android} />}
+            />
+          ),
+          meta: { className: 'w-224' },
+        },
+        {
+          accessorKey: 'symbol',
+          header: 'Symbol',
+          enableSorting: false,
+        },
+        {
+          accessorKey: 'price',
+          header: 'Price',
+          enableSorting: false,
+          meta: { align: 'end' },
+        },
+        {
+          accessorKey: 'change',
+          header: 'Performance',
+          enableSorting: false,
+          cell: ({ row }) => (
+            <TableCellContent
+              align='end'
+              title={row.original.price}
+              description={row.original.change}
+            />
+          ),
+          meta: { align: 'end', className: 'w-144' },
+        },
+      ],
+    });
+
+    return (
+      <DataTableRoot {...args} table={table}>
+        <DataTable className='max-h-400' />
+      </DataTableRoot>
+    );
+  },
+};
+
 export const WithSorting: Story = {
   render: (args) => {
     const [sorting, setSorting] = useState<SortingState>([

--- a/libs/ui-react/src/lib/Components/DataTable/DataTable.tsx
+++ b/libs/ui-react/src/lib/Components/DataTable/DataTable.tsx
@@ -37,6 +37,7 @@ const [DataTableProvider, useDataTableContext] = createSafeContext<{
   paginationMode: DataTableRootProps['paginationMode'];
   onScrollBottom: DataTableRootProps['onScrollBottom'];
   hideHeader: DataTableRootProps['hideHeader'];
+  stickyHeader: DataTableRootProps['stickyHeader'];
   onRowClick?: (row: Row<any>) => void;
   groupBy?: (row: Row<any>) => string;
   renderGroupHeader?: (info: { row: Row<any>; count: number }) => ReactNode;
@@ -62,6 +63,7 @@ export const DataTableRoot = <TData extends RowData>({
   groupBy,
   renderGroupHeader,
   hideHeader = false,
+  stickyHeader = false,
   children,
   className,
   ref,
@@ -71,6 +73,7 @@ export const DataTableRoot = <TData extends RowData>({
     <DataTableProvider
       value={{
         hideHeader,
+        stickyHeader,
         paginationMode,
         table,
         appearance,
@@ -97,7 +100,7 @@ const DataTableHeader = ({
   ref,
   ...props
 }: DataTableHeaderProps) => {
-  const { table } = useDataTableContext({
+  const { table, stickyHeader } = useDataTableContext({
     consumerName: 'DataTableHeader',
     contextRequired: true,
   });
@@ -105,7 +108,7 @@ const DataTableHeader = ({
   return (
     <TableHeader ref={ref} className={className} {...props}>
       {table.getHeaderGroups().map((headerGroup) => (
-        <TableHeaderRow key={headerGroup.id}>
+        <TableHeaderRow key={headerGroup.id} stickyHeader={stickyHeader}>
           {headerGroup.headers.map((header) => {
             const meta = header.column.columnDef.meta;
 

--- a/libs/ui-react/src/lib/Components/DataTable/DataTable.tsx
+++ b/libs/ui-react/src/lib/Components/DataTable/DataTable.tsx
@@ -63,7 +63,7 @@ export const DataTableRoot = <TData extends RowData>({
   groupBy,
   renderGroupHeader,
   hideHeader = false,
-  stickyHeader = false,
+  stickyHeader = true,
   children,
   className,
   ref,

--- a/libs/ui-react/src/lib/Components/DataTable/types.ts
+++ b/libs/ui-react/src/lib/Components/DataTable/types.ts
@@ -75,7 +75,7 @@ export type DataTableRootProps<TData extends RowData = RowData> = {
    * visible while scrolling. Sticks to the nearest scrolling ancestor:
    * the table container when the table itself scrolls, or the page when
    * the table is used inside a scrollable page.
-   * @default false
+   * @default true
    */
   stickyHeader?: boolean;
   /**

--- a/libs/ui-react/src/lib/Components/DataTable/types.ts
+++ b/libs/ui-react/src/lib/Components/DataTable/types.ts
@@ -71,6 +71,14 @@ export type DataTableRootProps<TData extends RowData = RowData> = {
    */
   hideHeader?: boolean;
   /**
+   * When true, applies sticky positioning to the header so it stays
+   * visible while scrolling. Sticks to the nearest scrolling ancestor:
+   * the table container when the table itself scrolls, or the page when
+   * the table is used inside a scrollable page.
+   * @default false
+   */
+  stickyHeader?: boolean;
+  /**
    * Callback fired when a row is clicked.
    * Return the data of the given row from the callback function.
    * @default undefined

--- a/libs/ui-react/src/lib/Components/Table/Table.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Table/Table.stories.tsx
@@ -341,6 +341,54 @@ export const WithInfiniteLoading: Story = {
   },
 };
 
+export const WithoutStickyHeader: Story = {
+  args: {
+    appearance: 'no-background',
+  },
+  render: (args) => (
+    <div className='w-3xl text-base'>
+      <TableRoot {...args} className='h-320'>
+        <Table>
+          <TableHeader>
+            <TableHeaderRow stickyHeader={false}>
+              <TableHeaderCell className='w-224'>Asset</TableHeaderCell>
+              <TableHeaderCell>Symbol</TableHeaderCell>
+              <TableHeaderCell align='end'>Price</TableHeaderCell>
+              <TableHeaderCell className='w-144' align='end'>
+                Performance
+              </TableHeaderCell>
+            </TableHeaderRow>
+          </TableHeader>
+          <TableBody>
+            {largeData.map((row) => (
+              <TableRow key={row.symbol}>
+                <TableCell className='w-224'>
+                  <TableCellContent
+                    title={row.name}
+                    description={row.symbol}
+                    leadingContent={
+                      <Spot size={40} appearance='icon' icon={Android} />
+                    }
+                  />
+                </TableCell>
+                <TableCell>{row.symbol}</TableCell>
+                <TableCell align='end'>{row.price}</TableCell>
+                <TableCell className='w-144' align='end'>
+                  <TableCellContent
+                    align='end'
+                    title={row.price}
+                    description={row.change}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableRoot>
+    </div>
+  ),
+};
+
 export const WithCustomHeader: Story = {
   render: (args) => {
     const [nameSortDirection, setNameSortDirection] =

--- a/libs/ui-react/src/lib/Components/Table/Table.tsx
+++ b/libs/ui-react/src/lib/Components/Table/Table.tsx
@@ -167,11 +167,15 @@ export const TableRow = ({
   );
 };
 
-const headerRowVariants = cva('sticky top-0 z-table-header', {
+const headerRowVariants = cva('', {
   variants: {
     appearance: {
       'no-background': 'bg-canvas',
       plain: 'bg-surface',
+    },
+    stickyHeader: {
+      true: 'sticky top-0 z-table-header',
+      false: '',
     },
   },
 });
@@ -182,6 +186,7 @@ const headerRowVariants = cva('sticky top-0 z-table-header', {
 export const TableHeaderRow = ({
   children,
   className,
+  stickyHeader = true,
   ref,
   ...props
 }: TableHeaderRowProps) => {
@@ -192,7 +197,7 @@ export const TableHeaderRow = ({
   return (
     <tr
       ref={ref}
-      className={headerRowVariants({ appearance, className })}
+      className={headerRowVariants({ appearance, stickyHeader, className })}
       {...props}
     >
       {children}

--- a/libs/ui-react/src/lib/Components/Table/types.ts
+++ b/libs/ui-react/src/lib/Components/Table/types.ts
@@ -139,6 +139,13 @@ export type TableHeaderRowProps = {
    * Custom classname
    */
   className?: string;
+  /**
+   * When true, applies sticky positioning to the header row so it stays
+   * visible while scrolling. Sticks to the nearest scrolling ancestor
+   * (the table container or the page when used inside a scrollable page).
+   * @default false
+   */
+  stickyHeader?: boolean;
 } & ComponentPropsWithRef<'tr'>;
 
 export type TableGroupHeaderRowProps = {

--- a/libs/ui-react/src/lib/Components/Table/types.ts
+++ b/libs/ui-react/src/lib/Components/Table/types.ts
@@ -143,7 +143,7 @@ export type TableHeaderRowProps = {
    * When true, applies sticky positioning to the header row so it stays
    * visible while scrolling. Sticks to the nearest scrolling ancestor
    * (the table container or the page when used inside a scrollable page).
-   * @default false
+   * @default true
    */
   stickyHeader?: boolean;
 } & ComponentPropsWithRef<'tr'>;


### PR DESCRIPTION
Closes [DLS-649](https://ledgerhq.atlassian.net/browse/DLS-649).

## Storybook

* [DataTable](https://ldls-git-dls-649-ledgerhq.vercel.app/?path=/story/data-datatable--without-sticky-header)
* [Table](https://ldls-git-dls-649-ledgerhq.vercel.app/?path=/story/data-table--without-sticky-header) 

[DLS-649]: https://ledgerhq.atlassian.net/browse/DLS-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ