### PR TITLE
feat(ui-react/ui-rnative): add `white` appearance for BaseTag

### DIFF
--- a/.nx/version-plans/version-plan-1778694462392-react.md
+++ b/.nx/version-plans/version-plan-1778694462392-react.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+feat(ui-react): add "white" appearance for BaseTag

--- a/.nx/version-plans/version-plan-1778694462392-rnative.md
+++ b/.nx/version-plans/version-plan-1778694462392-rnative.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+feat(ui-rnative): add "white" appearance for BaseTag

--- a/apps/app-sandbox-rnative/src/app/blocks/MediaTags.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/MediaTags.tsx
@@ -29,6 +29,7 @@ export const MediaTags = () => {
     'success',
     'error',
     'warning',
+    'white',
   ];
 
   return (

--- a/apps/app-sandbox-rnative/src/app/blocks/Tags.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/Tags.tsx
@@ -14,6 +14,7 @@ export const Tags = () => {
     'success',
     'error',
     'warning',
+    'white',
   ];
 
   return (

--- a/libs/ui-react/src/lib/Components/BaseTag/BaseTag.test.tsx
+++ b/libs/ui-react/src/lib/Components/BaseTag/BaseTag.test.tsx
@@ -52,6 +52,7 @@ describe('BaseTag', () => {
       ['success', 'bg-success'],
       ['error', 'bg-error'],
       ['warning', 'bg-warning'],
+      ['white', 'bg-white'],
     ];
 
     it.each(cases)(

--- a/libs/ui-react/src/lib/Components/BaseTag/BaseTag.tsx
+++ b/libs/ui-react/src/lib/Components/BaseTag/BaseTag.tsx
@@ -14,6 +14,7 @@ const baseTagVariants = cva(
         success: 'bg-success text-success',
         error: 'bg-error text-error',
         warning: 'bg-warning text-warning',
+        white: 'bg-white text-black',
       },
       size: {
         md: 'body-3',

--- a/libs/ui-react/src/lib/Components/MediaTag/MediaTag.figma.tsx
+++ b/libs/ui-react/src/lib/Components/MediaTag/MediaTag.figma.tsx
@@ -16,6 +16,7 @@ figma.connect(
         success: 'success',
         error: 'error',
         warning: 'warning',
+        white: 'white',
       }),
       size: figma.enum('size', {
         md: 'md',

--- a/libs/ui-react/src/lib/Components/MediaTag/MediaTag.stories.tsx
+++ b/libs/ui-react/src/lib/Components/MediaTag/MediaTag.stories.tsx
@@ -34,6 +34,7 @@ const meta: Meta<typeof MediaTag> = {
         'success',
         'error',
         'warning',
+        'white',
       ],
     },
     size: {
@@ -81,6 +82,7 @@ export const AppearanceShowcase: Story = {
         label='Warning'
         leadingContent={ETH_ICON}
       />
+      <MediaTag appearance='white' label='White' leadingContent={ETH_ICON} />
       <MediaTag label='Disabled' leadingContent={ETH_ICON} disabled />
     </div>
   ),

--- a/libs/ui-react/src/lib/Components/Menu/Menu.figma.tsx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.figma.tsx
@@ -12,7 +12,7 @@ import {
 // Menu Item Component
 figma.connect(
   MenuItem,
-  'https://www.figma.com/design/JxaLVMTWirCpU0rsbZ30k7?node-id=7983-5431',
+  'https://www.figma.com/design/JxaLVMTWirCpU0rsbZ30k7?node-id=7897-7037',
   {
     props: {
       children: figma.boolean('show-description', {
@@ -158,7 +158,7 @@ figma.connect(
 // Menu with Checkboxes and Radio
 figma.connect(
   Menu,
-  'https://www.figma.com/design/JxaLVMTWirCpU0rsbZ30k7?node-id=10211-1993',
+  'https://www.figma.com/design/JxaLVMTWirCpU0rsbZ30k7?node-id=7983-5431',
   {
     example: () => (
       <Menu>

--- a/libs/ui-react/src/lib/Components/Menu/Menu.figma.tsx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.figma.tsx
@@ -12,7 +12,7 @@ import {
 // Menu Item Component
 figma.connect(
   MenuItem,
-  'https://www.figma.com/design/JxaLVMTWirCpU0rsbZ30k7?node-id=7897-7037',
+  'https://www.figma.com/design/JxaLVMTWirCpU0rsbZ30k7?node-id=7983-5431',
   {
     props: {
       children: figma.boolean('show-description', {

--- a/libs/ui-react/src/lib/Components/Tag/Tag.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Tag/Tag.stories.tsx
@@ -38,6 +38,7 @@ export const Showcase: Story = {
         <Tag appearance='success' label='Success' />
         <Tag appearance='error' label='Error' />
         <Tag appearance='warning' label='Warning' />
+        <Tag appearance='white' label='White' />
         <Tag label='Disabled' disabled />
       </div>
       <div className='flex gap-4'>
@@ -48,6 +49,7 @@ export const Showcase: Story = {
         <Tag appearance='success' label='Success' icon={Check} />
         <Tag appearance='error' label='Error' icon={Check} />
         <Tag appearance='warning' label='Warning' icon={Check} />
+        <Tag appearance='white' label='White' icon={Check} />
         <Tag label='Disabled' icon={Check} disabled />
       </div>
     </div>

--- a/libs/ui-react/src/lib/Components/Tag/types.ts
+++ b/libs/ui-react/src/lib/Components/Tag/types.ts
@@ -13,7 +13,8 @@ export type TagProps = {
     | 'accent-subtle'
     | 'success'
     | 'error'
-    | 'warning';
+    | 'warning'
+    | 'white';
   /**
    * The size of the tag.
    * @default md

--- a/libs/ui-rnative/src/lib/Components/BaseTag/BaseTag.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/BaseTag/BaseTag.test.tsx
@@ -61,6 +61,7 @@ describe('BaseTag Component', () => {
       ['success', colors.bg.success],
       ['error', colors.bg.error],
       ['warning', colors.bg.warning],
+      ['white', colors.bg.white],
     ];
 
     it.each(cases)(

--- a/libs/ui-rnative/src/lib/Components/BaseTag/BaseTag.tsx
+++ b/libs/ui-rnative/src/lib/Components/BaseTag/BaseTag.tsx
@@ -29,6 +29,7 @@ const useBaseTagStyles = ({
         success: t.colors.bg.success,
         error: t.colors.bg.error,
         warning: t.colors.bg.warning,
+        white: t.colors.bg.white,
       };
 
       const textColors: Record<Appearance, string> = {
@@ -39,6 +40,7 @@ const useBaseTagStyles = ({
         success: t.colors.text.success,
         error: t.colors.text.error,
         warning: t.colors.text.warning,
+        white: t.colors.text.black,
       };
 
       const tagPadding = {

--- a/libs/ui-rnative/src/lib/Components/MediaTag/MediaTag.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/MediaTag/MediaTag.stories.tsx
@@ -26,6 +26,7 @@ const meta: Meta<typeof MediaTag> = {
         'success',
         'error',
         'warning',
+        'white',
       ],
     },
     size: {
@@ -73,6 +74,7 @@ export const AppearanceShowcase: Story = {
         label='Warning'
         leadingContent={ETH_ICON}
       />
+      <MediaTag appearance='white' label='White' leadingContent={ETH_ICON} />
       <MediaTag label='Disabled' leadingContent={ETH_ICON} disabled />
     </Box>
   ),

--- a/libs/ui-rnative/src/lib/Components/Tag/Tag.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/Tag/Tag.stories.tsx
@@ -17,6 +17,7 @@ const meta: Meta<typeof Tag> = {
         'success',
         'error',
         'warning',
+        'white',
       ],
     },
     size: {
@@ -59,6 +60,7 @@ export const AppearanceShowcase: Story = {
         <Tag appearance='success' label='Success' />
         <Tag appearance='error' label='Error' />
         <Tag appearance='warning' label='Warning' />
+        <Tag appearance='white' label='White' />
         <Tag label='Disabled' disabled />
       </Box>
       <Box lx={{ flexDirection: 'row', gap: 's4' }}>
@@ -69,6 +71,7 @@ export const AppearanceShowcase: Story = {
         <Tag appearance='success' label='Success' icon={Check} />
         <Tag appearance='error' label='Error' icon={Check} />
         <Tag appearance='warning' label='Warning' icon={Check} />
+        <Tag appearance='white' label='White' icon={Check} />
         <Tag label='Disabled' icon={Check} disabled />
       </Box>
     </Box>

--- a/libs/ui-rnative/src/lib/Components/Tag/types.ts
+++ b/libs/ui-rnative/src/lib/Components/Tag/types.ts
@@ -13,7 +13,8 @@ export type TagProps = {
     | 'accent-subtle'
     | 'success'
     | 'error'
-    | 'warning';
+    | 'warning'
+    | 'white';
   /**
    * The icon of the tag.
    */


### PR DESCRIPTION
Closes [DLS-729](https://ledgerhq.atlassian.net/browse/DLS-729).

## Demo (iOS sandbox)

### MediaTag

<img width="337" height="282" alt="image" src="https://github.com/user-attachments/assets/0ebd9425-c65d-41f8-8442-81ae28ef7fb3" />

### Tag

<img width="328" height="168" alt="image" src="https://github.com/user-attachments/assets/966a78e2-1de6-43eb-bfb2-f7a6b291eff0" />




[DLS-729]: https://ledgerhq.atlassian.net/browse/DLS-729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ