### PR TITLE
fix(ui-rnative): fix header overlap with absolutely positioned gradient inside BottomSheet

### DIFF
--- a/.nx/version-plans/version-plan-1779214627173.md
+++ b/.nx/version-plans/version-plan-1779214627173.md
@@ -3,3 +3,8 @@
 ---
 
 fix(ui-rnative): fix header overlap with absolutely positioned gradient inside BottomSheet
+
+Adds two `BottomSheet` props:
+
+- `backgroundComponent`: render a custom background (e.g. a gradient) behind the sheet.
+- `hideHandle`: hide the top drag handle. Note that setting this prop does not disable the gesture to close, you may need to use `enablePanDownToClose` in conjunction.

--- a/.nx/version-plans/version-plan-1779214627173.md
+++ b/.nx/version-plans/version-plan-1779214627173.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+fix(ui-rnative): fix header overlap with absolutely positioned gradient inside BottomSheet

--- a/apps/app-sandbox-rnative/src/app/App.tsx
+++ b/apps/app-sandbox-rnative/src/app/App.tsx
@@ -21,6 +21,7 @@ import {
   Banners,
   BottomSheetDynamicSize,
   BottomSheetFlatLists,
+  BottomSheetWithGradient,
   BottomSheetsButton,
   Buttons,
   CardButtons,
@@ -95,6 +96,7 @@ const AppContent = ({
   const { theme } = useTheme();
   const bottomSheetFlatListsRef = useBottomSheetRef();
   const bottomSheetDynamicSizeRef = useBottomSheetRef();
+  const bottomSheetGradientBugRef = useBottomSheetRef();
   return (
     <SafeAreaView
       style={{
@@ -154,6 +156,9 @@ const AppContent = ({
                   />
                   <BottomSheetsButton
                     onPress={() => bottomSheetDynamicSizeRef.current?.present()}
+                  />
+                  <BottomSheetsButton
+                    onPress={() => bottomSheetGradientBugRef.current?.present()}
                   />
                 </SandboxBlock>
                 <SandboxBlock title='Buttons'>
@@ -280,6 +285,7 @@ const AppContent = ({
             </ScrollView>
             <BottomSheetFlatLists ref={bottomSheetFlatListsRef} />
             <BottomSheetDynamicSize ref={bottomSheetDynamicSizeRef} />
+            <BottomSheetWithGradient ref={bottomSheetGradientBugRef} />
             <GlobalTooltipBottomSheet />
             <GlobalSelectBottomSheet />
           </BottomSheetModalProvider>

--- a/apps/app-sandbox-rnative/src/app/blocks/BottomSheets.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/BottomSheets.tsx
@@ -82,7 +82,10 @@ const GradientBackground = ({
   >
     <LinearGradient
       direction='to-bottom'
-      stops={[{ color: 'accent' }, { color: 'accent', opacity: 0 }]}
+      stops={[
+        { color: 'accent', opacity: 0.3 },
+        { color: 'activeSubtle', opacity: 0 },
+      ]}
       style={{
         position: 'absolute',
         top: 0,
@@ -114,7 +117,7 @@ export const BottomSheetWithGradient = ({
           density='compact'
           description='Gradient spans the full sheet.'
         />
-        <Box lx={{ paddingHorizontal: 's16', gap: 's12' }}>
+        <Box lx={{ paddingHorizontal: 's4', gap: 's12' }}>
           <Text typography='body2' lx={{ color: 'base' }}>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. In non
             eleifend erat. Etiam ac justo luctus massa hendrerit pellentesque.
@@ -145,13 +148,12 @@ export const BottomSheetDynamicSize = ({ ref, ...props }: BottomSheetProps) => {
       maxDynamicContentSize='full'
       backdropPressBehavior='close'
     >
-      <BottomSheetView>
-        <BottomSheetHeader
-          title='Dynamic Sizing'
-          density='compact'
-          description='This bottom sheet adapts to its content height'
-        />
-      </BottomSheetView>
+      <BottomSheetHeader
+        spacing
+        title='Dynamic Sizing'
+        density='compact'
+        description='This bottom sheet adapts to its content height'
+      />
       <BottomSheetScrollView>
         <Box lx={{ flexDirection: 'column', gap: 's12' }}>
           {data.map((item) => (

--- a/apps/app-sandbox-rnative/src/app/blocks/BottomSheets.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/BottomSheets.tsx
@@ -87,10 +87,6 @@ const GradientBackground = ({
         { color: 'activeSubtle', opacity: 0 },
       ]}
       style={{
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
         height: 256,
       }}
     />

--- a/apps/app-sandbox-rnative/src/app/blocks/BottomSheets.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/BottomSheets.tsx
@@ -1,4 +1,7 @@
-import type { BottomSheetProps } from '@ledgerhq/lumen-ui-rnative';
+import type {
+  BottomSheetBackgroundProps,
+  BottomSheetProps,
+} from '@ledgerhq/lumen-ui-rnative';
 import {
   BottomSheet,
   BottomSheetHeader,
@@ -68,6 +71,29 @@ export const BottomSheetFlatLists = ({ ref, ...props }: BottomSheetProps) => {
   );
 };
 
+const GradientBackground = ({
+  style,
+  pointerEvents,
+}: BottomSheetBackgroundProps) => (
+  <Box
+    pointerEvents={pointerEvents}
+    style={style}
+    lx={{ backgroundColor: 'canvasSheet' }}
+  >
+    <LinearGradient
+      direction='to-bottom'
+      stops={[{ color: 'accent' }, { color: 'accent', opacity: 0 }]}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 256,
+      }}
+    />
+  </Box>
+);
+
 export const BottomSheetWithGradient = ({
   ref,
   ...props
@@ -80,25 +106,15 @@ export const BottomSheetWithGradient = ({
       enableDynamicSizing
       maxDynamicContentSize='full'
       backdropPressBehavior='close'
+      backgroundComponent={GradientBackground}
     >
       <BottomSheetView>
-        <LinearGradient
-          direction='to-bottom'
-          stops={[{ color: 'accent' }, { color: 'accent', opacity: 0 }]}
-          style={{
-            position: 'absolute',
-            top: -64,
-            left: 0,
-            right: 0,
-            height: 256,
-          }}
-        />
         <BottomSheetHeader
-          title='Gradient is behind the header'
+          title='Gradient reaches the handle'
           density='compact'
-          description='This is the original issue.'
+          description='Gradient spans the full sheet.'
         />
-        <Box lx={{ padding: 's16', gap: 's12' }}>
+        <Box lx={{ paddingHorizontal: 's16', gap: 's12' }}>
           <Text typography='body2' lx={{ color: 'base' }}>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. In non
             eleifend erat. Etiam ac justo luctus massa hendrerit pellentesque.

--- a/apps/app-sandbox-rnative/src/app/blocks/BottomSheets.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/BottomSheets.tsx
@@ -7,6 +7,7 @@ import {
   BottomSheetFlatList,
   BottomSheetScrollView,
   BottomSheetView,
+  LinearGradient,
   Text,
 } from '@ledgerhq/lumen-ui-rnative';
 
@@ -63,6 +64,49 @@ export const BottomSheetFlatLists = ({ ref, ...props }: BottomSheetProps) => {
           );
         }}
       />
+    </BottomSheet>
+  );
+};
+
+export const BottomSheetWithGradient = ({
+  ref,
+  ...props
+}: BottomSheetProps) => {
+  return (
+    <BottomSheet
+      {...props}
+      ref={ref}
+      snapPoints={null}
+      enableDynamicSizing
+      maxDynamicContentSize='full'
+      backdropPressBehavior='close'
+    >
+      <BottomSheetView>
+        <LinearGradient
+          direction='to-bottom'
+          stops={[{ color: 'accent' }, { color: 'accent', opacity: 0 }]}
+          style={{
+            position: 'absolute',
+            top: -64,
+            left: 0,
+            right: 0,
+            height: 256,
+          }}
+        />
+        <BottomSheetHeader
+          title='Gradient is behind the header'
+          density='compact'
+          description='This is the original issue.'
+        />
+        <Box lx={{ padding: 's16', gap: 's12' }}>
+          <Text typography='body2' lx={{ color: 'base' }}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. In non
+            eleifend erat. Etiam ac justo luctus massa hendrerit pellentesque.
+            Vestibulum a dolor mi. Etiam sollicitudin dui quam, quis ultricies
+            turpis efficitur sit amet.
+          </Text>
+        </Box>
+      </BottomSheetView>
     </BottomSheet>
   );
 };

--- a/libs/ui-rnative/jest.setup.ts
+++ b/libs/ui-rnative/jest.setup.ts
@@ -81,12 +81,16 @@ jest.mock('@gorhom/bottom-sheet', () => {
         ? 'true'
         : 'false',
       'data-has-background-style': props.backgroundStyle ? 'true' : 'false',
+      'data-has-handle-component': props.handleComponent ? 'true' : 'false',
       children: [
         props.backgroundComponent
           ? mockReact.createElement(props.backgroundComponent, {
               key: 'bg',
               style: {},
             })
+          : null,
+        props.handleComponent
+          ? mockReact.createElement(props.handleComponent, { key: 'handle' })
           : null,
         props.children,
       ],

--- a/libs/ui-rnative/jest.setup.ts
+++ b/libs/ui-rnative/jest.setup.ts
@@ -77,7 +77,19 @@ jest.mock('@gorhom/bottom-sheet', () => {
         props.enableHandlePanningGesture,
       ),
       'data-on-dismiss': props.onDismiss ? 'true' : 'false',
-      children: props.children,
+      'data-has-background-component': props.backgroundComponent
+        ? 'true'
+        : 'false',
+      'data-has-background-style': props.backgroundStyle ? 'true' : 'false',
+      children: [
+        props.backgroundComponent
+          ? mockReact.createElement(props.backgroundComponent, {
+              key: 'bg',
+              style: {},
+            })
+          : null,
+        props.children,
+      ],
     } as any);
   });
 

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { FC } from 'react';
 import { useState } from 'react';
 import { Button } from '../Button';
 import { SearchInput } from '../SearchInput';
-import { Box, Text } from '../Utility';
+import { Spot } from '../Spot';
+import { Box, RadialGradient, Text } from '../Utility';
 import { BottomSheet } from './BottomSheet';
 import { BottomSheetHeader } from './BottomSheetHeader';
 import {
@@ -11,6 +13,7 @@ import {
   BottomSheetView,
   BottomSheetVirtualizedList,
 } from './Scrollables';
+import type { BottomSheetBackgroundProps } from './types';
 import { useBottomSheetRef } from './useBottomSheetRef';
 
 const meta = {
@@ -649,6 +652,176 @@ export const VirtualizedList: Story = {
               );
             }}
           />
+        </BottomSheet>
+      </Box>
+    );
+  },
+};
+
+type StrongBackgroundColor = 'errorStrong' | 'successStrong' | 'mutedStrong';
+
+const createGradientBackground =
+  (color: StrongBackgroundColor): FC<BottomSheetBackgroundProps> =>
+  ({ style }) => (
+    <Box
+      style={style}
+      lx={{ backgroundColor: 'canvasSheet', overflow: 'hidden' }}
+    >
+      <RadialGradient
+        center={{ x: 0.5, y: 0 }}
+        stops={[
+          { color, offset: 0, opacity: 0.3 },
+          { color, offset: 1, opacity: 0 },
+        ]}
+        lx={{
+          position: 'absolute',
+          top: 's0',
+          left: 's0',
+          right: 's0',
+          height: 's320',
+        }}
+      />
+    </Box>
+  );
+
+const ErrorBackground = createGradientBackground('errorStrong');
+const SuccessBackground = createGradientBackground('successStrong');
+const MutedBackground = createGradientBackground('mutedStrong');
+
+export const InfoStateVariants: Story = {
+  args: {
+    snapPoints: 'full',
+    hideCloseButton: false,
+    onBack: undefined,
+    onClose: undefined,
+    enableHandlePanningGesture: true,
+    enablePanDownToClose: true,
+    enableBlurKeyboardOnGesture: true,
+    enableDynamicSizing: false,
+    detached: false,
+    backdropPressBehavior: 'close',
+    hideHandle: true,
+  },
+  render: (args) => {
+    const errorBottomSheetRef = useBottomSheetRef();
+    const successBottomSheetRef = useBottomSheetRef();
+    const mutedBottomSheetRef = useBottomSheetRef();
+
+    return (
+      <Box
+        lx={{
+          height: 's320',
+          width: 'full',
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingTop: 's32',
+          gap: 's12',
+        }}
+      >
+        <Button
+          size='sm'
+          onPress={() => errorBottomSheetRef.current?.present()}
+        >
+          Error
+        </Button>
+        <Button
+          size='sm'
+          onPress={() => successBottomSheetRef.current?.present()}
+        >
+          Success
+        </Button>
+        <Button
+          size='sm'
+          onPress={() => mutedBottomSheetRef.current?.present()}
+        >
+          Muted
+        </Button>
+
+        <BottomSheet
+          {...args}
+          ref={errorBottomSheetRef}
+          backgroundComponent={ErrorBackground}
+        >
+          <BottomSheetView>
+            <BottomSheetHeader density='compact' />
+            <Box lx={{ alignItems: 'center', gap: 's24' }}>
+              <Spot appearance='error' size={72} />
+              <Box lx={{ alignItems: 'center', gap: 's12' }}>
+                <Text typography='heading4SemiBold' lx={{ color: 'base' }}>
+                  Title
+                </Text>
+                <Text
+                  typography='body2'
+                  lx={{ color: 'muted', textAlign: 'center' }}
+                >
+                  Description
+                </Text>
+              </Box>
+            </Box>
+            <Box lx={{ marginTop: 's24' }}>
+              <Button appearance='base' size='lg' isFull>
+                Label
+              </Button>
+            </Box>
+          </BottomSheetView>
+        </BottomSheet>
+
+        <BottomSheet
+          {...args}
+          ref={successBottomSheetRef}
+          backgroundComponent={SuccessBackground}
+        >
+          <BottomSheetView>
+            <BottomSheetHeader density='compact' />
+            <Box lx={{ alignItems: 'center', gap: 's24' }}>
+              <Spot appearance='check' size={72} />
+              <Box lx={{ alignItems: 'center', gap: 's12' }}>
+                <Text typography='heading4SemiBold' lx={{ color: 'base' }}>
+                  Title
+                </Text>
+                <Text
+                  typography='body2'
+                  lx={{ color: 'muted', textAlign: 'center' }}
+                >
+                  Description
+                </Text>
+              </Box>
+            </Box>
+            <Box lx={{ marginTop: 's24' }}>
+              <Button appearance='base' size='lg' isFull>
+                Label
+              </Button>
+            </Box>
+          </BottomSheetView>
+        </BottomSheet>
+
+        <BottomSheet
+          {...args}
+          ref={mutedBottomSheetRef}
+          backgroundComponent={MutedBackground}
+        >
+          <BottomSheetView>
+            <BottomSheetHeader density='compact' />
+            <Box lx={{ alignItems: 'center', gap: 's24' }}>
+              <Spot appearance='info' size={72} />
+              <Box lx={{ alignItems: 'center', gap: 's12' }}>
+                <Text typography='heading4SemiBold' lx={{ color: 'base' }}>
+                  Title
+                </Text>
+                <Text
+                  typography='body2'
+                  lx={{ color: 'muted', textAlign: 'center' }}
+                >
+                  Description
+                </Text>
+              </Box>
+            </Box>
+            <Box lx={{ marginTop: 's24' }}>
+              <Button appearance='base' size='lg' isFull>
+                Label
+              </Button>
+            </Box>
+          </BottomSheetView>
         </BottomSheet>
       </Box>
     );

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.test.tsx
@@ -184,6 +184,41 @@ describe('BottomSheet', () => {
       expect(element.props['data-detached']).toBe('true');
     });
 
+    it('uses default background style when no backgroundComponent is provided', () => {
+      const { BottomSheet } = require('./BottomSheet');
+      const { getByTestId } = renderWithTheme(
+        <BottomSheet testID='bottom-sheet'>
+          <Text>Content</Text>
+        </BottomSheet>,
+      );
+
+      const element = getByTestId('bottom-sheet');
+      expect(element.props['data-has-background-component']).toBe('false');
+      expect(element.props['data-has-background-style']).toBe('true');
+    });
+
+    it('forwards backgroundComponent and skips default background style', () => {
+      const { BottomSheet } = require('./BottomSheet');
+      const CustomBackground = () => (
+        <View testID='custom-bg'>
+          <Text>BG</Text>
+        </View>
+      );
+      const { getByTestId } = renderWithTheme(
+        <BottomSheet
+          backgroundComponent={CustomBackground}
+          testID='bottom-sheet'
+        >
+          <Text>Content</Text>
+        </BottomSheet>,
+      );
+
+      const element = getByTestId('bottom-sheet');
+      expect(element.props['data-has-background-component']).toBe('true');
+      expect(element.props['data-has-background-style']).toBe('false');
+      expect(getByTestId('custom-bg')).toBeTruthy();
+    });
+
     it('respects enableHandlePanningGesture prop', () => {
       const { BottomSheet } = require('./BottomSheet');
       const { getByTestId } = renderWithTheme(

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.test.tsx
@@ -197,6 +197,30 @@ describe('BottomSheet', () => {
       expect(element.props['data-has-background-style']).toBe('true');
     });
 
+    it('renders the default handle when hideHandle is not set', () => {
+      const { BottomSheet } = require('./BottomSheet');
+      const { getByTestId, queryByTestId } = renderWithTheme(
+        <BottomSheet testID='bottom-sheet'>
+          <Text>Content</Text>
+        </BottomSheet>,
+      );
+
+      expect(getByTestId('bottom-sheet-handle')).toBeTruthy();
+      expect(queryByTestId('bottom-sheet-handle-hidden')).toBeNull();
+    });
+
+    it('renders the hidden handle placeholder when hideHandle is true', () => {
+      const { BottomSheet } = require('./BottomSheet');
+      const { getByTestId, queryByTestId } = renderWithTheme(
+        <BottomSheet hideHandle testID='bottom-sheet'>
+          <Text>Content</Text>
+        </BottomSheet>,
+      );
+
+      expect(getByTestId('bottom-sheet-handle-hidden')).toBeTruthy();
+      expect(queryByTestId('bottom-sheet-handle')).toBeNull();
+    });
+
     it('forwards backgroundComponent and skips default background style', () => {
       const { BottomSheet } = require('./BottomSheet');
       const CustomBackground = () => (

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.tsx
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.tsx
@@ -41,9 +41,6 @@ const useStyles = ({
           flex: 1,
           borderTopLeftRadius: t.borderRadius.xl,
           borderTopRightRadius: t.borderRadius.xl,
-          backgroundColor: hasCustomBackground
-            ? 'transparent'
-            : t.colors.bg.canvasSheet,
           overflow: 'hidden',
         },
         shadow && {

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.tsx
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.tsx
@@ -25,7 +25,13 @@ const MAX_DYNAMIC_CONTENT_SIZE = {
   fullWithOffset: FULL_WITH_OFFSET,
 };
 
-const useStyles = ({ shadow }: { shadow: boolean }) => {
+const useStyles = ({
+  shadow,
+  hasCustomBackground,
+}: {
+  shadow: boolean;
+  hasCustomBackground: boolean;
+}) => {
   return useStyleSheet(
     (t) => ({
       root: StyleSheet.flatten([
@@ -35,7 +41,10 @@ const useStyles = ({ shadow }: { shadow: boolean }) => {
           flex: 1,
           borderTopLeftRadius: t.borderRadius.xl,
           borderTopRightRadius: t.borderRadius.xl,
-          backgroundColor: t.colors.bg.canvasSheet,
+          backgroundColor: hasCustomBackground
+            ? 'transparent'
+            : t.colors.bg.canvasSheet,
+          overflow: 'hidden',
         },
         shadow && {
           boxShadow: t.shadows.lg,
@@ -46,7 +55,7 @@ const useStyles = ({ shadow }: { shadow: boolean }) => {
         backgroundColor: t.colors.bg.canvasSheet,
       },
     }),
-    [shadow],
+    [shadow, hasCustomBackground],
   );
 };
 
@@ -74,6 +83,7 @@ export const BottomSheet = ({
   onBackdropPress,
   onChange,
   snapPoints = 'fullWithOffset',
+  backgroundComponent,
   ref,
   ...props
 }: BottomSheetProps) => {
@@ -82,7 +92,10 @@ export const BottomSheet = ({
   const mergedRefs = useMergedRef<GorhomBottomSheetModal>(ref, innerRef);
   const [isOpen, setIsOpen] = useState(false);
 
-  const styles = useStyles({ shadow: hideBackdrop && isOpen });
+  const styles = useStyles({
+    shadow: hideBackdrop && isOpen,
+    hasCustomBackground: Boolean(backgroundComponent),
+  });
 
   /**
    * Match the snap points to the preset or the custom snap points array
@@ -163,7 +176,8 @@ export const BottomSheet = ({
       {...props}
       ref={mergedRefs}
       style={styles.root}
-      backgroundStyle={styles.background}
+      backgroundStyle={backgroundComponent ? undefined : styles.background}
+      backgroundComponent={backgroundComponent}
       onChange={handleChange}
       onAnimate={handleAnimate}
       /**

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.tsx
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheet.tsx
@@ -6,7 +6,7 @@ import { StyleSheet } from 'react-native';
 import { useStyleSheet } from '../../../styles';
 import { RuntimeConstants } from '../../utils';
 import { CustomBackdrop } from './CustomBackdrop';
-import { CustomHandle } from './CustomHandle';
+import { CustomHandle, HiddenHandle } from './CustomHandle';
 import type { BottomSheetProps } from './types';
 
 const OFFSET_TOP = 25;
@@ -84,6 +84,7 @@ export const BottomSheet = ({
   onChange,
   snapPoints = 'fullWithOffset',
   backgroundComponent,
+  hideHandle = false,
   ref,
   ...props
 }: BottomSheetProps) => {
@@ -202,7 +203,7 @@ export const BottomSheet = ({
       /**
        * Components
        */
-      handleComponent={CustomHandle}
+      handleComponent={hideHandle ? HiddenHandle : CustomHandle}
       backdropComponent={hideBackdrop ? undefined : renderBackdrop}
     >
       <BottomSheetProvider value={{ onBack, hideCloseButton }}>

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheetHeader.tsx
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/BottomSheetHeader.tsx
@@ -28,7 +28,7 @@ const useStyles = ({
         {
           position: 'relative',
           zIndex: Z_INDEX_DIALOG_CONTENT,
-          backgroundColor: t.colors.bg.canvasSheet,
+          backgroundColor: 'transparent',
           paddingBottom: t.spacings.s12,
         },
         spacing && {

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/CustomHandle.tsx
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/CustomHandle.tsx
@@ -12,7 +12,7 @@ const useStyles = () => {
         alignItems: 'center',
         justifyContent: 'center',
         alignSelf: 'center',
-        backgroundColor: t.colors.bg.canvasSheet,
+        backgroundColor: 'transparent',
       },
       handle: {
         height: t.spacings.s4,

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/CustomHandle.tsx
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/CustomHandle.tsx
@@ -1,5 +1,5 @@
 import type { BottomSheetVariables } from '@gorhom/bottom-sheet/lib/typescript/types';
-import type { Ref } from 'react';
+import type { ComponentRef, Ref } from 'react';
 import { View } from 'react-native';
 import { useStyleSheet } from '../../../styles';
 
@@ -18,7 +18,7 @@ const useStyles = () => {
         height: t.spacings.s4,
         width: t.sizes.s36,
         borderRadius: t.borderRadius.full,
-        backgroundColor: t.colors.bg.mutedPressed,
+        backgroundColor: t.colors.bg.mutedTransparent,
       },
     }),
     [],
@@ -28,12 +28,33 @@ const useStyles = () => {
 export const CustomHandle = ({
   ref,
   ...props
-}: BottomSheetVariables & { ref?: Ref<React.ElementRef<typeof View>> }) => {
+}: BottomSheetVariables & { ref?: Ref<ComponentRef<typeof View>> }) => {
   const styles = useStyles();
 
   return (
-    <View {...props} ref={ref} style={styles.container}>
+    <View
+      {...props}
+      ref={ref}
+      style={styles.container}
+      testID='bottom-sheet-handle'
+    >
       <View style={styles.handle} />
     </View>
+  );
+};
+
+export const HiddenHandle = ({
+  ref,
+  ...props
+}: BottomSheetVariables & { ref?: Ref<ComponentRef<typeof View>> }) => {
+  const styles = useStyles();
+
+  return (
+    <View
+      {...props}
+      ref={ref}
+      style={styles.container}
+      testID='bottom-sheet-handle-hidden'
+    />
   );
 };

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/CustomHandle.tsx
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/CustomHandle.tsx
@@ -18,7 +18,7 @@ const useStyles = () => {
         height: t.spacings.s4,
         width: t.sizes.s36,
         borderRadius: t.borderRadius.full,
-        backgroundColor: t.colors.bg.mutedTransparent,
+        backgroundColor: t.colors.bg.mutedTransparentPressed,
       },
     }),
     [],

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/types.ts
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/types.ts
@@ -5,10 +5,11 @@ import type {
   BottomSheetSectionList as GorhomBottomSheetSectionList,
   BottomSheetScrollView as GorhomBottomSheetScrollView,
   BottomSheetVirtualizedList as GorhomBottomSheetVirtualizedList,
+  BottomSheetBackgroundProps,
 } from '@gorhom/bottom-sheet';
-
 import type { Density } from '@ledgerhq/lumen-utils-shared';
-import type { PropsWithChildren, ReactNode, Ref } from 'react';
+import type { FC, PropsWithChildren, ReactNode, Ref } from 'react';
+
 import type { StyledViewProps } from '../../../styles';
 export type BottomSheetProps = PropsWithChildren & {
   /**
@@ -131,7 +132,16 @@ export type BottomSheetProps = PropsWithChildren & {
    * @default true
    */
   enableBlurKeyboardOnGesture?: boolean;
+  /**
+   * Custom background component rendered behind the sheet content and handle.
+   * Use to render gradients or other effects that should span the full sheet area,
+   * including the handle strip. When provided, the default sheet background is removed.
+   * @default undefined
+   */
+  backgroundComponent?: FC<BottomSheetBackgroundProps> | null;
 };
+
+export type { BottomSheetBackgroundProps };
 
 export type BottomSheetHeaderProps = {
   /**

--- a/libs/ui-rnative/src/lib/Components/BottomSheet/types.ts
+++ b/libs/ui-rnative/src/lib/Components/BottomSheet/types.ts
@@ -8,14 +8,20 @@ import type {
   BottomSheetBackgroundProps,
 } from '@gorhom/bottom-sheet';
 import type { Density } from '@ledgerhq/lumen-utils-shared';
-import type { FC, PropsWithChildren, ReactNode, Ref } from 'react';
+import type {
+  ComponentRef,
+  FC,
+  PropsWithChildren,
+  ReactNode,
+  Ref,
+} from 'react';
 
 import type { StyledViewProps } from '../../../styles';
 export type BottomSheetProps = PropsWithChildren & {
   /**
    * Ref to the bottom sheet component.
    */
-  ref?: Ref<React.ElementRef<typeof GorhomBottomSheetModal>>;
+  ref?: Ref<ComponentRef<typeof GorhomBottomSheetModal>>;
   /**
    * Used to locate this view in end-to-end tests.
    */
@@ -139,6 +145,11 @@ export type BottomSheetProps = PropsWithChildren & {
    * @default undefined
    */
   backgroundComponent?: FC<BottomSheetBackgroundProps> | null;
+  /**
+   * If true, the drag handle (grabber) at the top of the sheet is hidden.
+   * @default false
+   */
+  hideHandle?: boolean;
 };
 
 export type { BottomSheetBackgroundProps };

--- a/libs/ui-rnative/src/lib/Components/Card/Card.tsx
+++ b/libs/ui-rnative/src/lib/Components/Card/Card.tsx
@@ -3,7 +3,7 @@ import {
   DisabledProvider,
   isTextChildren,
 } from '@ledgerhq/lumen-utils-shared';
-import type { ReactNode, Ref } from 'react';
+import type { ComponentRef, ReactNode, Ref } from 'react';
 import { useCallback, useEffect, useMemo } from 'react';
 import type { LayoutChangeEvent, ViewStyle } from 'react-native';
 import { StyleSheet, View } from 'react-native';
@@ -486,7 +486,7 @@ export const CardContentTitle = ({
   if (isTextChildren(children)) {
     return (
       <Text
-        ref={ref as Ref<React.ElementRef<typeof Text>>}
+        ref={ref as Ref<ComponentRef<typeof Text>>}
         lx={lx}
         style={StyleSheet.flatten([styles.asText, style])}
         numberOfLines={1}
@@ -553,7 +553,7 @@ export const CardContentDescription = ({
   if (isTextChildren(children)) {
     return (
       <Text
-        ref={ref as Ref<React.ElementRef<typeof Text>>}
+        ref={ref as Ref<ComponentRef<typeof Text>>}
         lx={lx}
         style={StyleSheet.flatten([styles.asText, style])}
         numberOfLines={1}

--- a/libs/ui-rnative/src/lib/Components/ListItem/ListItem.tsx
+++ b/libs/ui-rnative/src/lib/Components/ListItem/ListItem.tsx
@@ -4,7 +4,7 @@ import {
   DisabledProvider,
   useDisabledContext,
 } from '@ledgerhq/lumen-utils-shared';
-import type { ElementRef, ReactNode, Ref } from 'react';
+import type { ComponentRef, ReactNode, Ref } from 'react';
 import type { ViewStyle } from 'react-native';
 import { StyleSheet, View } from 'react-native';
 import { useStyleSheet } from '../../../styles';
@@ -286,7 +286,7 @@ export const ListItemTitle = ({
   style,
   ref,
   ...props
-}: ListItemTitleProps & { ref?: Ref<ElementRef<typeof Text>> }) => {
+}: ListItemTitleProps & { ref?: Ref<ComponentRef<typeof Text>> }) => {
   const disabled = useDisabledContext({
     consumerName: 'ListItemTitle',
     contextRequired: true,
@@ -336,7 +336,7 @@ export const ListItemDescription = ({
   style,
   ref,
   ...props
-}: ListItemDescriptionProps & { ref?: Ref<ElementRef<typeof Text>> }) => {
+}: ListItemDescriptionProps & { ref?: Ref<ComponentRef<typeof Text>> }) => {
   const disabled = useDisabledContext({
     consumerName: 'ListItemDescription',
     contextRequired: true,

--- a/libs/ui-rnative/src/lib/Components/PageIndicator/PageIndicator.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/PageIndicator/PageIndicator.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import { ledgerLiveThemes } from '@ledgerhq/lumen-design-core';
 import { render, screen } from '@testing-library/react-native';
 
+import type { ComponentRef } from 'react';
 import { createRef } from 'react';
 import { ThemeProvider } from '../ThemeProvider/ThemeProvider';
 import { PageIndicator } from './PageIndicator';
@@ -162,7 +163,7 @@ describe('PageIndicator Component', () => {
 
   describe('Props', () => {
     it('should accept ref prop', () => {
-      const ref = createRef<React.ElementRef<typeof PageIndicator>>();
+      const ref = createRef<ComponentRef<typeof PageIndicator>>();
       renderWithProvider(
         <PageIndicator
           ref={ref}

--- a/libs/ui-rnative/src/lib/types/index.ts
+++ b/libs/ui-rnative/src/lib/types/index.ts
@@ -1,12 +1,12 @@
-import type { ElementType, ComponentPropsWithRef, ElementRef } from 'react';
+import type { ElementType, ComponentPropsWithRef, ComponentRef } from 'react';
 import type { Pressable, View } from 'react-native';
 
 type ComponentPropsWithAsChild<T extends ElementType<any>> =
   ComponentPropsWithRef<T> & { asChild?: boolean };
 
 type SlottableViewProps = ComponentPropsWithAsChild<typeof View>;
-type ViewRef = ElementRef<typeof View>;
-type PressableRef = ElementRef<typeof Pressable>;
+type ViewRef = ComponentRef<typeof View>;
+type PressableRef = ComponentRef<typeof Pressable>;
 
 type SlottablePressableProps = ComponentPropsWithAsChild<typeof Pressable> & {
   /**


### PR DESCRIPTION
Closes [DLS-711](https://ledgerhq.atlassian.net/browse/DLS-711).

Proposes exposing Gorhom's `backgroundComponent` prop to take in e.g., a gradient.
See https://gorhom.dev/react-native-bottom-sheet/custom-background.

Also adds a prop to hide the custom handle, replacing it with an invisible one to not cause layout shift.

```tsx
<BottomSheet
  {...props}
  { /** ... */ }
  backgroundComponent={<LinearGradient />} // <-- new prop
  hideHandle // <-- new prop
>
  <BottomSheetView>
    <BottomSheetHeader { /** ... */ } />
    <Box lx={{ padding: 's16' }}>
      <Text typography='body2' lx={{ color: 'base' }}>
        { /** ... */ }
      </Text>
    </Box>
  </BottomSheetView>
</BottomSheet>
```

## Also

* After syncing with Laurine, updated CustomHandle color to `mutedTransparentPressed` so it provides good contrast regardless of the background content.
* Took the liberty to migrate from `ElementRef` to `ComponentRef` following some deprecation warnings.

## Demo (iOS sandbox)

<img width="447" height="214" alt="image" src="https://github.com/user-attachments/assets/ebce1f0e-fdb5-4db7-89e3-2b99525f04be" />

## Considerations

This is the issue originally reported by Lucas. Absolutely positioning a node inside of the bottom sheet children results on the element being hidden behind the BottomSheetHeader.

<img width="448" height="295" alt="Screenshot 2026-05-19 at 16 26 11" src="https://github.com/user-attachments/assets/22efb417-a1fc-4e2b-8e3b-7a03f8e1295f" />

---

Also note that regardless of making the header's background transparent, the 16px row wrapping the CustomHandle takes precedence in rendering.

<img width="445" height="287" alt="Screenshot 2026-05-19 at 17 44 43" src="https://github.com/user-attachments/assets/e0b1e96d-835b-4d24-b475-7fad06159df1" />

---

Thus, there's no way of achieving [this intended look](https://www.figma.com/design/NJZI8sW7CTSZWJcZ95zEEj/Core-Device-Actions-%E2%80%A2-Wallet?node-id=7269-3701&m=dev) without exposing Gorhom's BottomSheet `backgroundComponent` prop.

<img width="460" height="467" alt="image" src="https://github.com/user-attachments/assets/a8428ca1-c166-432a-a96b-041e6b1a6d05" />

[DLS-711]: https://ledgerhq.atlassian.net/browse/DLS-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ