### PR TITLE
chore/add-cicd-to-publish-lib-on-pr

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,9 +6,9 @@ description: >-
 
 inputs:
   node-version:
-    description: Node.js version to install. Defaults to the workspace-wide pinned version.
+    description: Node.js version to install. Defaults to the version pinned in `.prototools`.
     required: false
-    default: '22.14.0'
+    default: '22.13.1'
   install:
     description: Whether to run `npm ci --legacy-peer-deps`.
     required: false
@@ -43,7 +43,7 @@ runs:
 
     - name: Restore Nx cache
       if: ${{ inputs.cache-nx == 'true' }}
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .nx/cache
         key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ github.sha }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,55 @@
+name: Setup
+description: >-
+  Set up Node.js, install workspace dependencies, restore the Nx local cache
+  and derive `nx affected` SHAs. Assumes the repository has already been
+  checked out (local composite actions cannot include `actions/checkout`).
+
+inputs:
+  node-version:
+    description: Node.js version to install. Defaults to the workspace-wide pinned version.
+    required: false
+    default: '22.14.0'
+  install:
+    description: Whether to run `npm ci --legacy-peer-deps`.
+    required: false
+    default: 'true'
+  cache-nx:
+    description: Whether to restore/save the local Nx cache (`.nx/cache`).
+    required: false
+    default: 'true'
+  set-shas:
+    description: Whether to derive base/head SHAs for `nx affected`.
+    required: false
+    default: 'true'
+  cache-key-prefix:
+    description: Optional prefix appended to the Nx cache key (useful when callers want isolated caches).
+    required: false
+    default: 'nx'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'npm'
+        cache-dependency-path: '**/package-lock.json'
+
+    - name: Install dependencies
+      if: ${{ inputs.install == 'true' }}
+      shell: bash
+      run: npm ci --legacy-peer-deps
+
+    - name: Restore Nx cache
+      if: ${{ inputs.cache-nx == 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: .nx/cache
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-
+
+    - name: Derive Nx affected SHAs
+      if: ${{ inputs.set-shas == 'true' }}
+      uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -30,23 +30,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: ./.github/actions/setup
         with:
-          node-version: 20
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+          set-shas: 'false'
 
       - name: Build ui-react library
         env:
           NX_NO_CLOUD: true
-        run: npx nx build @ledgerhq/lumen-ui-react --skip-nx-cache
+        run: npx nx build @ledgerhq/lumen-ui-react
 
       - name: Build Storybook
         env:
           NX_NO_CLOUD: true
           NODE_OPTIONS: '--max-old-space-size=6144'
-        run: npx nx run-many --target=build:storybook --parallel=3 --no-cloud --webpack-stats-json
+        run: npx nx run-many --target=build:storybook --parallel=3 --webpack-stats-json
 
       - name: Run Chromatic (ui-react)
         uses: chromaui/action@a8ce9c58f59be5cc7090cadfc8f130fb08fcf0c3 # v15.1.0

--- a/.github/workflows/figma-code-connect.yml
+++ b/.github/workflows/figma-code-connect.yml
@@ -33,13 +33,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: ./.github/actions/setup
         with:
-          node-version: '18'
-
-      - name: Install dependencies
-        run: npm ci
+          cache-nx: 'false'
+          set-shas: 'false'
 
       - name: Publish to Figma Code Connect
         run: npx figma connect publish --config ${{ matrix.config }} --exit-on-unreadable-files

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,17 +29,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
+      - uses: ./.github/actions/setup
 
       - run: npx nx run-many --targets=build-deps --all
       - run: npx nx affected -t lint typecheck
@@ -54,17 +44,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
+      - uses: ./.github/actions/setup
 
       - run: npx nx affected -t build
 
@@ -78,17 +58,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
+      - uses: ./.github/actions/setup
 
       - run: npx nx affected -t test:tree-shaking
 
@@ -102,17 +72,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
+      - uses: ./.github/actions/setup
 
       - run: npx nx affected -t test --passWithNoTests --coverage
 

--- a/.github/workflows/publish-dev-packages.yml
+++ b/.github/workflows/publish-dev-packages.yml
@@ -53,18 +53,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
-        with:
-          node-version: '22.14.0'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
-
-      - name: Derive appropriate SHAs for nx affected commands
-        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
+      - uses: ./.github/actions/setup
 
       - name: Determine affected libraries
         id: affected

--- a/.github/workflows/publish-dev-packages.yml
+++ b/.github/workflows/publish-dev-packages.yml
@@ -1,0 +1,206 @@
+name: Publish Dev Packages
+
+on:
+  pull_request:
+    types: [labeled, synchronize, closed]
+
+concurrency:
+  group: dev-packages-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  NX_NO_CLOUD: true
+
+permissions:
+  contents: write # Required to create/delete the dev packages pre-release and its tag
+  pull-requests: write
+
+jobs:
+  cleanup-dev-packages:
+    name: Cleanup dev packages release
+    if: >
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete dev packages release and tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          TAG="dev-pr-${PR_NUMBER}"
+          if gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+            gh release delete "${TAG}" \
+              --repo "${REPO}" \
+              --cleanup-tag --yes
+            echo "Deleted dev packages release ${TAG}"
+          else
+            echo "No dev packages release found for ${TAG}, nothing to clean up"
+          fi
+
+  publish-dev-packages:
+    name: Publish Dev Packages
+    if: >
+      github.event.action != 'closed' &&
+      contains(github.event.pull_request.labels.*.name, 'publish-dev-package') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: public-ledgerhq-shared-small
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: '22.14.0'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Derive appropriate SHAs for nx affected commands
+        uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
+
+      - name: Determine affected libraries
+        id: affected
+        run: |
+          AFFECTED=$(npx nx show projects --affected --projects='libs/*' 2>/dev/null || true)
+          if [ -z "$AFFECTED" ]; then
+            echo "No affected libraries found"
+            echo "has_affected=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_affected=true" >> "$GITHUB_OUTPUT"
+          echo "projects<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$AFFECTED" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          PROJECTS_CSV=$(echo "$AFFECTED" | paste -sd, -)
+          echo "projects_csv=${PROJECTS_CSV}" >> "$GITHUB_OUTPUT"
+
+      - name: Build affected libraries
+        if: steps.affected.outputs.has_affected == 'true'
+        run: npx nx run-many -t build --projects="${{ steps.affected.outputs.projects_csv }}"
+
+      - name: Patch versions and pack affected packages
+        if: steps.affected.outputs.has_affected == 'true'
+        id: pack
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          SHORT_SHA="${HEAD_SHA:0:7}"
+          TAG="dev-pr-${PR_NUMBER}"
+          TARBALL_DIR="${RUNNER_TEMP}/dev-package-tarballs"
+          COMMENT_FILE="${RUNNER_TEMP}/dev-packages-comment.md"
+          mkdir -p "${TARBALL_DIR}"
+          TABLE_ROWS=""
+
+          while IFS= read -r PROJECT; do
+            [ -z "$PROJECT" ] && continue
+
+            for lib_dir in libs/*/; do
+              PKG_JSON="${lib_dir}package.json"
+              [ -f "$PKG_JSON" ] || continue
+              PKG_NAME=$(node -p "require('./${PKG_JSON}').name")
+
+              if [ "$PKG_NAME" = "$PROJECT" ]; then
+                CURRENT_VERSION=$(node -p "require('./${PKG_JSON}').version")
+                DEV_VERSION="${CURRENT_VERSION}-pr.${PR_NUMBER}.${SHORT_SHA}"
+
+                node -e "
+                  const fs = require('fs');
+                  const pkg = JSON.parse(fs.readFileSync('${PKG_JSON}', 'utf8'));
+                  pkg.version = '${DEV_VERSION}';
+                  fs.writeFileSync('${PKG_JSON}', JSON.stringify(pkg, null, 2) + '\n');
+                "
+
+                echo "::group::Packing ${PKG_NAME}@${DEV_VERSION}"
+                TARBALL_FILENAME=$(npm pack "${lib_dir}" --pack-destination "${TARBALL_DIR}" --json \
+                  | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(0,'utf8'))[0].filename)")
+                echo "::endgroup::"
+
+                TARBALL_URL="https://github.com/${REPO}/releases/download/${TAG}/${TARBALL_FILENAME}"
+                TABLE_ROWS="${TABLE_ROWS}| \`${PKG_NAME}\` | \`${DEV_VERSION}\` | \`npm i ${TARBALL_URL}\` |"$'\n'
+                break
+              fi
+            done
+          done <<< "${{ steps.affected.outputs.projects }}"
+
+          {
+            echo '<!-- dev-packages-comment -->'
+            echo '### 📦 Dev packages published'
+            echo ''
+            echo 'Tarballs are hosted as assets on a per-PR GitHub pre-release and are deleted automatically when this PR is closed.'
+            echo ''
+            echo '| Package | Version | Install |'
+            echo '|---------|---------|---------|'
+            printf '%s' "$TABLE_ROWS"
+            echo ''
+            echo "> **Release:** [\`${TAG}\`](https://github.com/${REPO}/releases/tag/${TAG})"
+            echo "> **Commit:** \`${HEAD_SHA}\`"
+          } > "$COMMENT_FILE"
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "tarball_dir=${TARBALL_DIR}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish tarballs to GitHub pre-release
+        if: steps.affected.outputs.has_affected == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.pack.outputs.tag }}
+          TARBALL_DIR: ${{ steps.pack.outputs.tarball_dir }}
+          SHORT_SHA: ${{ steps.pack.outputs.short_sha }}
+        run: |
+          if gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+            gh release delete "${TAG}" \
+              --repo "${REPO}" \
+              --cleanup-tag --yes
+          fi
+
+          gh release create "${TAG}" \
+            --repo "${REPO}" \
+            --target "${HEAD_SHA}" \
+            --title "Dev packages for PR #${PR_NUMBER} (${SHORT_SHA})" \
+            --notes "Automated dev packages build for PR #${PR_NUMBER} at commit ${HEAD_SHA}. This pre-release is replaced on every push and deleted when the PR is closed." \
+            --prerelease
+
+          gh release upload "${TAG}" "${TARBALL_DIR}"/*.tgz \
+            --repo "${REPO}" \
+            --clobber
+
+      - name: Post or update PR comment
+        if: steps.affected.outputs.has_affected == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          COMMENT_FILE="${RUNNER_TEMP}/dev-packages-comment.md"
+          MARKER="<!-- dev-packages-comment -->"
+
+          EXISTING_COMMENT_ID=$(gh api \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+            2>/dev/null || true)
+
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
+              -F body=@"$COMMENT_FILE"
+          else
+            gh api \
+              --method POST \
+              "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -F body=@"$COMMENT_FILE"
+          fi

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -44,17 +44,13 @@ jobs:
       - name: Setup git user
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop # internal action. branch is fine.
 
-      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e #v4.3.0
+      - uses: ./.github/actions/setup
         with:
-          node-version: '22.14.0'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
+          set-shas: 'false'
 
-      - name: Install dependencies
+      - name: Audit npm signatures
         id: install-dependencies
-        run: |
-          npm ci --legacy-peer-deps
-          npm audit signatures
+        run: npm audit signatures
 
       - name: Release
         id: release

--- a/.github/workflows/sync-figma.yml
+++ b/.github/workflows/sync-figma.yml
@@ -31,14 +31,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: ./.github/actions/setup
         with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+          set-shas: 'false'
 
       - name: Export Design Tokens from Figma
         run: npx nx run @ledgerhq/lumen-design-core:figma-export
@@ -62,14 +57,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: ./.github/actions/setup
         with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+          set-shas: 'false'
 
       - name: Download SVGs from Figma
         run: npx nx run @ledgerhq/lumen-design-core:figma-download-svgs
@@ -95,14 +85,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: ./.github/actions/setup
         with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+          set-shas: 'false'
 
       - name: Download design tokens artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -130,14 +115,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: ./.github/actions/setup
         with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+          set-shas: 'false'
 
       - name: Download SVG artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -168,14 +148,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: ./.github/actions/setup
         with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+          set-shas: 'false'
 
       - name: Download SVG artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -1,0 +1,60 @@
+# Pull Requests
+
+## Dev Package Publishing
+
+Publish dev packages from a PR to test bug fixes or new features without releasing to production. Tarballs are hosted as assets on a per-PR GitHub pre-release, so any reviewer can install them with a single `npm install <url>` command.
+
+### How it works
+
+1. Add the `publish-dev-package` label to your PR
+2. The CI builds the affected libraries and runs `npm pack` on each one
+3. The resulting `.tgz` tarballs are uploaded as assets on a per-PR GitHub pre-release tagged `dev-pr-<PR_NUMBER>`
+4. A sticky comment on the PR shows the exact install commands for every affected package
+5. Each new commit pushed to the PR replaces the release with fresh tarballs and updates the comment
+6. Remove the label to stop publishing on subsequent commits
+7. When the PR is closed (merged or not), the pre-release and its git tag are deleted automatically
+
+### Version format
+
+Each tarball is stamped with a prerelease suffix based on the PR number and commit hash:
+
+```
+<current-version>-pr.<PR_NUMBER>.<SHORT_SHA>
+```
+
+For example, if `@ledgerhq/lumen-ui-react` is at version `0.1.33` and the PR number is `42`:
+
+```
+0.1.33-pr.42.a1b2c3d
+```
+
+Each commit produces a unique version. The PR number stays constant so consumers can identify all versions from a given PR.
+
+### How to consume
+
+1. Open the PR on GitHub and look for the **📦 Dev packages published** comment
+2. Copy the install command from the comment table, for example:
+
+```bash
+npm install https://github.com/LedgerHQ/ldls/releases/download/dev-pr-42/ledgerhq-lumen-ui-react-0.1.33-pr.42.a1b2c3d.tgz
+```
+
+`npm` accepts a tarball URL anywhere it accepts a version specifier, so you can also add it directly to a consumer's `package.json`:
+
+```json
+{
+  "dependencies": {
+    "@ledgerhq/lumen-ui-react": "https://github.com/LedgerHQ/ldls/releases/download/dev-pr-42/ledgerhq-lumen-ui-react-0.1.33-pr.42.a1b2c3d.tgz"
+  }
+}
+```
+
+The install URL is **immutable per commit** — pushing a new commit creates a new URL. Always copy the latest one from the PR comment to make sure you're installing the most recent build.
+
+### Important notes
+
+- Dev packages are for **testing only**, not for production use
+- Tarballs are hosted on GitHub Releases (no JFrog or external registry needed) and inherit the visibility of this repository
+- Only affected libraries (those with changes in the PR) are packed and published
+- The release is marked as a **pre-release** so it never shows up as "Latest" and does not appear in the main releases list view
+- Both the release and its git tag are wiped when the PR is closed, leaving no trace in the repo's history

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -2,59 +2,33 @@
 
 ## Dev Package Publishing
 
-Publish dev packages from a PR to test bug fixes or new features without releasing to production. Tarballs are hosted as assets on a per-PR GitHub pre-release, so any reviewer can install them with a single `npm install <url>` command.
+Publish dev packages from a PR so reviewers can install them with a single `npm install <url>`. Tarballs live on a per-PR GitHub pre-release and are deleted when the PR closes.
 
 ### How it works
 
-1. Add the `publish-dev-package` label to your PR
-2. The CI builds the affected libraries and runs `npm pack` on each one
-3. The resulting `.tgz` tarballs are uploaded as assets on a per-PR GitHub pre-release tagged `dev-pr-<PR_NUMBER>`
-4. A sticky comment on the PR shows the exact install commands for every affected package
-5. Each new commit pushed to the PR replaces the release with fresh tarballs and updates the comment
-6. Remove the label to stop publishing on subsequent commits
-7. When the PR is closed (merged or not), the pre-release and its git tag are deleted automatically
+1. Add the `publish-dev-package` label to your PR.
+2. CI builds the affected libraries, runs `npm pack`, and uploads each `.tgz` to a pre-release tagged `dev-pr-<PR_NUMBER>`.
+3. A sticky **📦 Dev packages published** comment lists the install command for every affected package.
+4. Each new commit refreshes the release and the comment. Closing the PR (merged or not) deletes both the release and its git tag.
+
+Remove the label to stop publishing on subsequent commits.
 
 ### Version format
 
-Each tarball is stamped with a prerelease suffix based on the PR number and commit hash:
+Each tarball is stamped with a prerelease suffix:
 
 ```
 <current-version>-pr.<PR_NUMBER>.<SHORT_SHA>
 ```
 
-For example, if `@ledgerhq/lumen-ui-react` is at version `0.1.33` and the PR number is `42`:
-
-```
-0.1.33-pr.42.a1b2c3d
-```
-
-Each commit produces a unique version. The PR number stays constant so consumers can identify all versions from a given PR.
+Every commit gets a unique URL; the PR number stays constant so all builds from one PR are identifiable.
 
 ### How to consume
 
-1. Open the PR on GitHub and look for the **📦 Dev packages published** comment
-2. Copy the install command from the comment table, for example:
+Copy the install command from the PR comment, e.g.:
 
 ```bash
-npm install https://github.com/LedgerHQ/ldls/releases/download/dev-pr-42/ledgerhq-lumen-ui-react-0.1.33-pr.42.a1b2c3d.tgz
+npm install https://github.com/LedgerHQ/lumen/releases/download/dev-pr-<PR_NUMBER>/ledgerhq-lumen-ui-react-0.1.33-pr.<PR_NUMBER>.<SHORT_SHA>.tgz
 ```
 
-`npm` accepts a tarball URL anywhere it accepts a version specifier, so you can also add it directly to a consumer's `package.json`:
-
-```json
-{
-  "dependencies": {
-    "@ledgerhq/lumen-ui-react": "https://github.com/LedgerHQ/ldls/releases/download/dev-pr-42/ledgerhq-lumen-ui-react-0.1.33-pr.42.a1b2c3d.tgz"
-  }
-}
-```
-
-The install URL is **immutable per commit** — pushing a new commit creates a new URL. Always copy the latest one from the PR comment to make sure you're installing the most recent build.
-
-### Important notes
-
-- Dev packages are for **testing only**, not for production use
-- Tarballs are hosted on GitHub Releases (no JFrog or external registry needed) and inherit the visibility of this repository
-- Only affected libraries (those with changes in the PR) are packed and published
-- The release is marked as a **pre-release** so it never shows up as "Latest" and does not appear in the main releases list view
-- Both the release and its git tag are wiped when the PR is closed, leaving no trace in the repo's history
+The same URL also works as a `package.json` dependency value — `npm` accepts tarball URLs as version specifiers. Install URLs are **immutable per commit**, so always copy the latest one from the PR comment.


### PR DESCRIPTION
# Updates CICD

## New PR package publish
Add CICD pipeline that can be triggered on pull-request with the label `publish-dev-package`.
This pipeline will serve the affected package as `.tgz` file served through the github repository as a release.
The release is cleaned when the PR is closed.

### Outcome 🎉 
This will streamline how we share library artifacts with consumers, meaningfully reducing the overhead involved.
Here is the documentation of [how it works](https://github.com/LedgerHQ/lumen/blob/23326150cd1cd80a4c9e2e4cde28a720a674096d/docs/pull-requests.md)

**Sidenote:** Added a `/docs` folder for internal documentation for our tooling, but maybe at some point the contributing guide and high-level guidelines. 

## Other improvements 
- Create github `actions/setup` that generalize some actions of the CICD and improve re-usability, consistency and maintenance
- Align node versions used in the monorepo (with prototool) + the one used in the CICD
- Small performance improvements using NX cache in the CICD