### PR TITLE
feat(ui-react/ui-rnative): support disabled state for MediaImage + DotSymbol + DotIcon

### DIFF
--- a/.nx/version-plans/version-plan-1779708860611-react.md
+++ b/.nx/version-plans/version-plan-1779708860611-react.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+feat(ui-react): support disabled state for MediaImage + DotSymbol + DotIcon

--- a/.nx/version-plans/version-plan-1779708860611-rnative.md
+++ b/.nx/version-plans/version-plan-1779708860611-rnative.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+feat(ui-rnative): support disabled state for MediaImage + DotSymbol + DotIcon

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.mdx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.mdx
@@ -1,15 +1,19 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as DotIconStories from './DotIcon.stories';
+import { CustomTabs, Tab } from '../../../../.storybook/components';
 
 <Meta title='Communication/DotIcon' of={DotIconStories} />
 
 # DotIcon
 
+<CustomTabs>
+  <Tab label="Overview">
+
 ## Introduction
 
 DotIcon positions a small icon indicator at a configurable corner of a child element such as MediaImage or Spot. The dot background uses a semantic color (`success`, `muted`, or `error`) to convey meaning at a glance.
-> View in [Figma](https://www.figma.com/design/zSkvGGiqcnhywp2l3HTHxA/1.-Symbol-Library?node-id=6159-1866).
 
+> View in [Figma](https://www.figma.com/design/zSkvGGiqcnhywp2l3HTHxA/1.-Symbol-Library?node-id=6159-1866).
 
 ## Anatomy
 
@@ -55,3 +59,86 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 - The icon is purely decorative; the child element should carry its own accessibility label.
 - Pair semantic appearances with meaningful icons so the state can be understood without relying on color alone.
+
+</Tab>
+<Tab label="Implementation">
+
+```bash
+npm install @ledgerhq/lumen-ui-react
+```
+
+> **Note**: `@ledgerhq/lumen-design-core` and other peer dependencies (`react`, `tailwindcss`, `clsx`, etc.) are required. See our [Setup Guide →](?path=/docs/getting-started-setup-tailwind--docs#1-tailwind-config) for complete installation and Tailwind configuration.
+
+## Basic Usage
+
+```tsx
+import { DotIcon, MediaImage } from '@ledgerhq/lumen-ui-react';
+import { ArrowDown } from '@ledgerhq/lumen-ui-react/symbols';
+
+function MyComponent() {
+  return (
+    <DotIcon appearance='success' icon={ArrowDown}>
+      <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+    </DotIcon>
+  );
+}
+```
+
+### Pin Placement
+
+Position the dot at any of the four corners of the child:
+
+```tsx
+<DotIcon appearance='success' icon={ArrowDown} pin='top-end'>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotIcon>
+```
+
+### Shapes
+
+Use `shape='square'` to match a square child element:
+
+```tsx
+<DotIcon appearance='muted' icon={ArrowDown} shape='square'>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} shape='square' />
+</DotIcon>
+```
+
+### Appearances
+
+Pick a semantic color via `appearance`:
+
+```tsx
+<DotIcon appearance='success' icon={ArrowDown}>...</DotIcon>
+<DotIcon appearance='muted' icon={ArrowUp}>...</DotIcon>
+<DotIcon appearance='error' icon={Close}>...</DotIcon>
+```
+
+### Sizing
+
+The dot size is driven by the parent's size via the mapping helpers:
+
+```tsx
+import { DotIcon, mediaImageDotIconSizeMap, MediaImage } from '@ledgerhq/lumen-ui-react';
+
+<DotIcon
+  appearance='success'
+  icon={ArrowDown}
+  size={mediaImageDotIconSizeMap[48]}
+>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotIcon>;
+```
+
+### Disabled State
+
+When `disabled` is `true`, the wrapper is dimmed and the disabled state is propagated to the child via context:
+
+```tsx
+<DotIcon appearance='success' icon={ArrowDown} disabled>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotIcon>
+```
+
+</Tab>
+</CustomTabs>

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.mdx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.mdx
@@ -57,9 +57,9 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 ### Disabled
 
-<Canvas of={DotIconStories.DisabledShowcase} />
-
 Only set `disabled` on `DotIcon`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
+
+<Canvas of={DotIconStories.DisabledShowcase} />
 
 ## Accessibility
 

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.mdx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.mdx
@@ -55,6 +55,12 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 <Canvas of={DotIconStories.SizeShowcase} />
 
+### Disabled
+
+<Canvas of={DotIconStories.DisabledShowcase} />
+
+Only set `disabled` on `DotIcon`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
+
 ## Accessibility
 
 - The icon is purely decorative; the child element should carry its own accessibility label.
@@ -132,7 +138,7 @@ import { DotIcon, mediaImageDotIconSizeMap, MediaImage } from '@ledgerhq/lumen-u
 
 ### Disabled State
 
-When `disabled` is `true`, the wrapper is dimmed and the disabled state is propagated to the child via context:
+Only set `disabled` on `DotIcon`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
 
 ```tsx
 <DotIcon appearance='success' icon={ArrowDown} disabled>

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.stories.tsx
@@ -120,6 +120,41 @@ export const AppearanceShowcase: Story = {
   ),
 };
 
+export const DisabledShowcase: Story = {
+  args: { appearance: 'success', icon: ArrowDown },
+  render: () => (
+    <div className='flex items-center gap-32'>
+      <DotIcon
+        appearance='success'
+        icon={ArrowDown}
+        size={mediaImageDotIconSizeMap[48]}
+        pin='bottom-end'
+        disabled
+      >
+        <MediaImage src={parentSrc} size={48} shape='circle' />
+      </DotIcon>
+      <DotIcon
+        appearance='muted'
+        icon={ArrowUp}
+        size={mediaImageDotIconSizeMap[48]}
+        pin='bottom-end'
+        disabled
+      >
+        <MediaImage src={parentSrc} size={48} shape='circle' />
+      </DotIcon>
+      <DotIcon
+        appearance='error'
+        icon={Close}
+        size={mediaImageDotIconSizeMap[48]}
+        pin='bottom-end'
+        disabled
+      >
+        <MediaImage src={parentSrc} size={48} shape='circle' />
+      </DotIcon>
+    </div>
+  ),
+};
+
 export const SizeShowcase: Story = {
   args: { appearance: 'muted', icon: Link },
   render: () => (

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
@@ -32,10 +32,6 @@ const dotVariants = cva(
         muted: 'bg-muted-strong',
         error: 'bg-error-strong',
       },
-      disabled: {
-        true: 'opacity-30',
-        false: '',
-      },
     },
     compoundVariants: [
       { size: 16, shape: 'square', className: 'rounded-[5px]' },
@@ -111,17 +107,19 @@ export const DotIcon = ({
   });
 
   return (
-    <DisabledProvider value={{ disabled }}>
+    <DisabledProvider value={{ disabled: false }}>
       <div
         ref={ref}
-        className={cn('relative inline-flex w-fit', className)}
+        className={cn(
+          'relative inline-flex w-fit',
+          disabled && 'opacity-30',
+          className,
+        )}
         {...rest}
       >
         <div className='inline-flex'>{children}</div>
         <div
-          className={cn(
-            dotVariants({ size, shape, pin, appearance, disabled }),
-          )}
+          className={cn(dotVariants({ size, shape, pin, appearance }))}
           style={style}
         >
           <Icon size={dotIconSizeMap[size]} className='text-on-interactive' />

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
@@ -8,6 +8,15 @@ import { useMemo } from 'react';
 import type { IconSize } from '../Icon';
 import type { DotIconPin, DotIconProps, DotIconSize } from './types';
 
+const rootVariants = cva('relative inline-flex w-fit', {
+  variants: {
+    disabled: {
+      true: 'opacity-30',
+      false: '',
+    },
+  },
+});
+
 const dotVariants = cva(
   'absolute z-10 box-content flex items-center justify-center overflow-hidden border-base-inverted',
   {
@@ -110,11 +119,7 @@ export const DotIcon = ({
     <DisabledProvider value={{ disabled: false }}>
       <div
         ref={ref}
-        className={cn(
-          'relative inline-flex w-fit',
-          disabled && 'opacity-30',
-          className,
-        )}
+        className={cn(rootVariants({ disabled, className }))}
         {...rest}
       >
         <div className='inline-flex'>{children}</div>

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
@@ -115,7 +115,6 @@ export const DotIcon = ({
       <div
         ref={ref}
         className={cn('relative inline-flex w-fit', className)}
-        data-disabled={disabled || undefined}
         {...rest}
       >
         <div className='inline-flex'>{children}</div>

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
@@ -1,4 +1,8 @@
-import { cn } from '@ledgerhq/lumen-utils-shared';
+import {
+  cn,
+  DisabledProvider,
+  useDisabledContext,
+} from '@ledgerhq/lumen-utils-shared';
 import { cva } from 'class-variance-authority';
 import { useMemo } from 'react';
 import type { IconSize } from '../Icon';
@@ -27,6 +31,10 @@ const dotVariants = cva(
         success: 'bg-success-strong',
         muted: 'bg-muted-strong',
         error: 'bg-error-strong',
+      },
+      disabled: {
+        true: 'opacity-30',
+        false: '',
       },
     },
     compoundVariants: [
@@ -92,25 +100,35 @@ export const DotIcon = ({
   size = 20,
   shape = 'circle',
   className,
+  disabled: disabledProp = false,
   ref,
   ...rest
 }: DotIconProps) => {
   const style = useMemo(() => getPinOffset(pin), [pin]);
+  const disabled = useDisabledContext({
+    consumerName: 'DotIcon',
+    mergeWith: { disabled: disabledProp },
+  });
 
   return (
-    <div
-      ref={ref}
-      className={cn('relative inline-flex w-fit', className)}
-      {...rest}
-    >
-      <div className='inline-flex'>{children}</div>
+    <DisabledProvider value={{ disabled }}>
       <div
-        className={cn(dotVariants({ size, shape, pin, appearance }))}
-        style={style}
+        ref={ref}
+        className={cn('relative inline-flex w-fit', className)}
+        data-disabled={disabled || undefined}
+        {...rest}
       >
-        <Icon size={dotIconSizeMap[size]} className='text-on-interactive' />
+        <div className='inline-flex'>{children}</div>
+        <div
+          className={cn(
+            dotVariants({ size, shape, pin, appearance, disabled }),
+          )}
+          style={style}
+        >
+          <Icon size={dotIconSizeMap[size]} className='text-on-interactive' />
+        </div>
       </div>
-    </div>
+    </DisabledProvider>
   );
 };
 

--- a/libs/ui-react/src/lib/Components/DotIcon/types.ts
+++ b/libs/ui-react/src/lib/Components/DotIcon/types.ts
@@ -40,6 +40,12 @@ export type DotIconProps = {
    */
   className?: string;
   /**
+   * Shows a disabled appearance.
+   * @optional
+   * @default false
+   */
+  disabled?: boolean;
+  /**
    * The wrapped component (e.g. MediaImage or Spot).
    */
   children?: ReactNode;

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.mdx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.mdx
@@ -51,9 +51,9 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 ### Disabled
 
-<Canvas of={DotSymbolStories.DisabledShowcase} />
-
 Only set `disabled` on `DotSymbol`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
+
+<Canvas of={DotSymbolStories.DisabledShowcase} />
 
 ## Accessibility
 

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.mdx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.mdx
@@ -1,9 +1,13 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as DotSymbolStories from './DotSymbol.stories';
+import { CustomTabs, Tab } from '../../../../.storybook/components';
 
 <Meta title='Communication/DotSymbol' of={DotSymbolStories} />
 
 # DotSymbol
+
+<CustomTabs>
+  <Tab label="Overview">
 
 ## Introduction
 
@@ -49,3 +53,75 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 - Always provide a meaningful `alt` prop on the DotSymbol so the indicator image is announced by screen readers.
 - The child element should carry its own accessibility label independently.
+
+</Tab>
+<Tab label="Implementation">
+
+```bash
+npm install @ledgerhq/lumen-ui-react
+```
+
+> **Note**: `@ledgerhq/lumen-design-core` and other peer dependencies (`react`, `tailwindcss`, `clsx`, etc.) are required. See our [Setup Guide →](?path=/docs/getting-started-setup-tailwind--docs#1-tailwind-config) for complete installation and Tailwind configuration.
+
+## Basic Usage
+
+```tsx
+import { DotSymbol, MediaImage } from '@ledgerhq/lumen-ui-react';
+
+function MyComponent() {
+  return (
+    <DotSymbol src='https://example.com/btc.png' alt='Bitcoin network'>
+      <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+    </DotSymbol>
+  );
+}
+```
+
+### Pin Placement
+
+Position the dot at any of the four corners of the child:
+
+```tsx
+<DotSymbol src='https://example.com/btc.png' alt='Bitcoin' pin='top-end'>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotSymbol>
+```
+
+### Shapes
+
+Use `shape='square'` to match a square child element:
+
+```tsx
+<DotSymbol src='https://example.com/btc.png' alt='Bitcoin' shape='square'>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} shape='square' />
+</DotSymbol>
+```
+
+### Sizing
+
+The dot size is driven by the parent's size via the mapping helpers:
+
+```tsx
+import { DotSymbol, mediaImageDotSizeMap, MediaImage } from '@ledgerhq/lumen-ui-react';
+
+<DotSymbol
+  src='https://example.com/btc.png'
+  alt='Bitcoin'
+  size={mediaImageDotSizeMap[48]}
+>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotSymbol>;
+```
+
+### Disabled State
+
+When `disabled` is `true`, the wrapper is dimmed and the disabled state is propagated to the child via context:
+
+```tsx
+<DotSymbol src='https://example.com/btc.png' alt='Bitcoin' disabled>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotSymbol>
+```
+
+</Tab>
+</CustomTabs>

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.mdx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.mdx
@@ -49,6 +49,12 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 <Canvas of={DotSymbolStories.SizeShowcase} />
 
+### Disabled
+
+<Canvas of={DotSymbolStories.DisabledShowcase} />
+
+Only set `disabled` on `DotSymbol`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
+
 ## Accessibility
 
 - Always provide a meaningful `alt` prop on the DotSymbol so the indicator image is announced by screen readers.
@@ -115,7 +121,7 @@ import { DotSymbol, mediaImageDotSizeMap, MediaImage } from '@ledgerhq/lumen-ui-
 
 ### Disabled State
 
-When `disabled` is `true`, the wrapper is dimmed and the disabled state is propagated to the child via context:
+Only set `disabled` on `DotSymbol`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
 
 ```tsx
 <DotSymbol src='https://example.com/btc.png' alt='Bitcoin' disabled>

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.mdx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.mdx
@@ -9,6 +9,8 @@ import * as DotSymbolStories from './DotSymbol.stories';
 
 DotSymbol positions a small image indicator at a configurable corner of a child element such as MediaImage or Spot. It is commonly used to show a network badge or secondary icon overlapping a primary symbol.
 
+> View in [Figma](https://www.figma.com/design/zSkvGGiqcnhywp2l3HTHxA/1.-Symbol-Library?node-id=8602-380&m=dev).
+
 ## Anatomy
 
 <Canvas of={DotSymbolStories.Base} />

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.stories.tsx
@@ -102,6 +102,23 @@ export const ShapeShowcase: Story = {
   ),
 };
 
+export const DisabledShowcase: Story = {
+  args: { src: dotSrc, alt: 'Disabled showcase' },
+  render: () => (
+    <div className='flex items-center gap-32'>
+      <DotSymbol src={dotSrc} pin='bottom-end' disabled>
+        <MediaImage src={parentSrc} size={48} shape='circle' />
+      </DotSymbol>
+      <DotSymbol src={dotSrc} pin='bottom-end' shape='square' disabled>
+        <MediaImage src={parentSrc} size={48} shape='square' />
+      </DotSymbol>
+      <DotSymbol src={dotSrc} pin='bottom-end' disabled>
+        <Spot appearance='icon' icon={CoinAlert} />
+      </DotSymbol>
+    </div>
+  ),
+};
+
 export const SizeShowcase: Story = {
   args: { src: dotSrc, alt: 'Size showcase' },
   render: () => (

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
@@ -1,4 +1,8 @@
-import { cn } from '@ledgerhq/lumen-utils-shared';
+import {
+  cn,
+  DisabledProvider,
+  useDisabledContext,
+} from '@ledgerhq/lumen-utils-shared';
 import { cva } from 'class-variance-authority';
 import { useEffect, useMemo, useState } from 'react';
 import type { MediaImageSize } from '../MediaImage';
@@ -26,6 +30,10 @@ const dotVariants = cva(
         'top-end': '',
         'bottom-start': '',
         'bottom-end': '',
+      },
+      disabled: {
+        true: 'opacity-30',
+        false: '',
       },
     },
     compoundVariants: [
@@ -109,35 +117,46 @@ export const DotSymbol = ({
   shape = 'circle',
   imgLoading = 'eager',
   className,
+  disabled: disabledProp = false,
   ref,
   ...rest
 }: DotSymbolProps) => {
   const style = useMemo(() => getPinOffset(pin, size), [pin, size]);
   const [error, setError] = useState(false);
+  const disabled = useDisabledContext({
+    consumerName: 'DotSymbol',
+    mergeWith: { disabled: disabledProp },
+  });
 
   useEffect(() => {
     setError(false);
   }, [src]);
 
   return (
-    <div
-      ref={ref}
-      className={cn('relative inline-flex w-fit', className)}
-      {...rest}
-    >
-      <div className='inline-flex'>{children}</div>
-      <div className={dotVariants({ size, shape, pin })} style={style}>
-        {!error && (
-          <img
-            alt={alt}
-            src={src}
-            loading={imgLoading}
-            aria-hidden='true'
-            onError={() => setError(true)}
-          />
-        )}
+    <DisabledProvider value={{ disabled }}>
+      <div
+        ref={ref}
+        className={cn('relative inline-flex w-fit', className)}
+        data-disabled={disabled || undefined}
+        {...rest}
+      >
+        <div className='inline-flex'>{children}</div>
+        <div
+          className={dotVariants({ size, shape, pin, disabled })}
+          style={style}
+        >
+          {!error && (
+            <img
+              alt={alt}
+              src={src}
+              loading={imgLoading}
+              aria-hidden='true'
+              onError={() => setError(true)}
+            />
+          )}
+        </div>
       </div>
-    </div>
+    </DisabledProvider>
   );
 };
 

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
@@ -137,7 +137,6 @@ export const DotSymbol = ({
       <div
         ref={ref}
         className={cn('relative inline-flex w-fit', className)}
-        data-disabled={disabled || undefined}
         {...rest}
       >
         <div className='inline-flex'>{children}</div>

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
@@ -31,10 +31,6 @@ const dotVariants = cva(
         'bottom-start': '',
         'bottom-end': '',
       },
-      disabled: {
-        true: 'opacity-30',
-        false: '',
-      },
     },
     compoundVariants: [
       /**
@@ -133,17 +129,18 @@ export const DotSymbol = ({
   }, [src]);
 
   return (
-    <DisabledProvider value={{ disabled }}>
+    <DisabledProvider value={{ disabled: false }}>
       <div
         ref={ref}
-        className={cn('relative inline-flex w-fit', className)}
+        className={cn(
+          'relative inline-flex w-fit',
+          disabled && 'opacity-30',
+          className,
+        )}
         {...rest}
       >
         <div className='inline-flex'>{children}</div>
-        <div
-          className={dotVariants({ size, shape, pin, disabled })}
-          style={style}
-        >
+        <div className={dotVariants({ size, shape, pin })} style={style}>
           {!error && (
             <img
               alt={alt}

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
@@ -9,6 +9,15 @@ import type { MediaImageSize } from '../MediaImage';
 import type { SpotSize } from '../Spot';
 import type { DotSymbolPin, DotSymbolProps, DotSymbolSize } from './types';
 
+const rootVariants = cva('relative inline-flex w-fit', {
+  variants: {
+    disabled: {
+      true: 'opacity-30',
+      false: '',
+    },
+  },
+});
+
 const dotVariants = cva(
   'absolute z-10 box-content overflow-hidden border-base-inverted bg-muted',
   {
@@ -132,11 +141,7 @@ export const DotSymbol = ({
     <DisabledProvider value={{ disabled: false }}>
       <div
         ref={ref}
-        className={cn(
-          'relative inline-flex w-fit',
-          disabled && 'opacity-30',
-          className,
-        )}
+        className={cn(rootVariants({ disabled, className }))}
         {...rest}
       >
         <div className='inline-flex'>{children}</div>

--- a/libs/ui-react/src/lib/Components/DotSymbol/types.ts
+++ b/libs/ui-react/src/lib/Components/DotSymbol/types.ts
@@ -45,6 +45,12 @@ export type DotSymbolProps = {
    */
   className?: string;
   /**
+   * Shows a disabled appearance.
+   * @optional
+   * @default false
+   */
+  disabled?: boolean;
+  /**
    * The wrapped component (e.g. MediaImage or Spot).
    */
   children?: ReactNode;

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
@@ -90,7 +90,6 @@ export const MediaButton = ({
         triggerVariants({ size, iconType: effectiveIconType }),
         className,
       )}
-      data-disabled={disabled || undefined}
       disabled={disabled}
       {...props}
     >

--- a/libs/ui-react/src/lib/Components/MediaImage/MediaImage.stories.tsx
+++ b/libs/ui-react/src/lib/Components/MediaImage/MediaImage.stories.tsx
@@ -89,3 +89,24 @@ export const LoadingShowcase: Story = {
     </div>
   ),
 };
+
+export const DisabledShowcase: Story = {
+  args: { alt: 'Disabled showcase' },
+  render: () => (
+    <div className='flex flex-col gap-24'>
+      <div className='inline-flex items-end gap-16'>
+        <MediaImage src={exampleSrc} alt='Cardano' size={32} disabled />
+        <MediaImage src={exampleSrc} alt='Cardano' size={48} disabled />
+        <MediaImage
+          src={exampleSrc}
+          alt='Cardano'
+          size={48}
+          shape='circle'
+          disabled
+        />
+        <MediaImage fallback='Bitcoin' alt='Bitcoin' size={48} disabled />
+        <MediaImage alt='Empty' size={48} disabled />
+      </div>
+    </div>
+  ),
+};

--- a/libs/ui-react/src/lib/Components/MediaImage/MediaImage.tsx
+++ b/libs/ui-react/src/lib/Components/MediaImage/MediaImage.tsx
@@ -94,7 +94,6 @@ export const MediaImage = ({
       )}
       role='img'
       aria-label={alt}
-      data-disabled={disabled || undefined}
       {...props}
     >
       {loading && <Skeleton className='absolute inset-0' />}

--- a/libs/ui-react/src/lib/Components/MediaImage/MediaImage.tsx
+++ b/libs/ui-react/src/lib/Components/MediaImage/MediaImage.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@ledgerhq/lumen-utils-shared';
+import { cn, useDisabledContext } from '@ledgerhq/lumen-utils-shared';
 import { cva } from 'class-variance-authority';
 import { useEffect, useState } from 'react';
 import { Skeleton } from '../Skeleton';
@@ -36,6 +36,10 @@ const mediaImageVariants = {
           square: '',
           circle: 'rounded-full',
         },
+        disabled: {
+          true: 'opacity-30',
+          false: '',
+        },
       },
     },
   ),
@@ -67,10 +71,15 @@ export const MediaImage = ({
   imgLoading = 'eager',
   fallback,
   loading = false,
+  disabled: disabledProp = false,
   ...props
 }: MediaImageProps) => {
   const [error, setError] = useState(false);
   const shouldFallback = !src || error;
+  const disabled = useDisabledContext({
+    consumerName: 'MediaImage',
+    mergeWith: { disabled: disabledProp },
+  });
 
   useEffect(() => {
     setError(false);
@@ -79,9 +88,13 @@ export const MediaImage = ({
   return (
     <div
       ref={ref}
-      className={cn(mediaImageVariants.root({ size, shape }), className)}
+      className={cn(
+        mediaImageVariants.root({ size, shape, disabled }),
+        className,
+      )}
       role='img'
       aria-label={alt}
+      data-disabled={disabled || undefined}
       {...props}
     >
       {loading && <Skeleton className='absolute inset-0' />}

--- a/libs/ui-react/src/lib/Components/MediaImage/types.ts
+++ b/libs/ui-react/src/lib/Components/MediaImage/types.ts
@@ -45,6 +45,12 @@ export type MediaImageProps = {
    */
   loading?: boolean;
   /**
+   * Shows a disabled appearance.
+   * @optional
+   * @default false
+   */
+  disabled?: boolean;
+  /**
    * Additional custom CSS classes to apply. Do not use this prop to modify the component's core appearance.
    * @optional
    */

--- a/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.mdx
+++ b/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.mdx
@@ -1,13 +1,18 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as DotIconStories from './DotIcon.stories';
+import { CustomTabs, Tab } from '../../../../.storybook/components';
 
 <Meta title='Communication/DotIcon' of={DotIconStories} />
 
 # DotIcon
 
+<CustomTabs>
+  <Tab label="Overview">
+
 ## Introduction
 
 DotIcon positions a small icon indicator at a configurable corner of a child element such as MediaImage or Spot. The dot background uses a semantic color (`success`, `muted`, or `error`) to convey meaning at a glance.
+
 > View in [Figma](https://www.figma.com/design/zSkvGGiqcnhywp2l3HTHxA/1.-Symbol-Library?node-id=6159-1866).
 
 ## Anatomy
@@ -54,3 +59,84 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 - The icon is purely decorative; the child element should carry its own accessibility label.
 - Pair semantic appearances with meaningful icons so the state can be understood without relying on color alone.
+
+</Tab>
+<Tab label="Implementation">
+
+## Setup
+
+Install and set up the library with our [Setup Guide →](?path=/docs/getting-started-setup--docs).
+
+### Basic Usage
+
+```tsx
+import { DotIcon, MediaImage } from '@ledgerhq/lumen-ui-rnative';
+import { ArrowDown } from '@ledgerhq/lumen-ui-rnative/symbols';
+
+function MyComponent() {
+  return (
+    <DotIcon appearance='success' icon={ArrowDown}>
+      <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+    </DotIcon>
+  );
+}
+```
+
+### Pin Placement
+
+Position the dot at any of the four corners of the child:
+
+```tsx
+<DotIcon appearance='success' icon={ArrowDown} pin='top-end'>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotIcon>
+```
+
+### Shapes
+
+Use `shape='square'` to match a square child element:
+
+```tsx
+<DotIcon appearance='muted' icon={ArrowDown} shape='square'>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} shape='square' />
+</DotIcon>
+```
+
+### Appearances
+
+Pick a semantic color via `appearance`:
+
+```tsx
+<DotIcon appearance='success' icon={ArrowDown}>...</DotIcon>
+<DotIcon appearance='muted' icon={ArrowUp}>...</DotIcon>
+<DotIcon appearance='error' icon={Close}>...</DotIcon>
+```
+
+### Sizing
+
+The dot size is driven by the parent's size via the mapping helpers:
+
+```tsx
+import { DotIcon, mediaImageDotIconSizeMap, MediaImage } from '@ledgerhq/lumen-ui-rnative';
+
+<DotIcon
+  appearance='success'
+  icon={ArrowDown}
+  size={mediaImageDotIconSizeMap[48]}
+>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotIcon>;
+```
+
+### Disabled State
+
+When `disabled` is `true`, the wrapper is dimmed and the disabled state is propagated to the child via context:
+
+```tsx
+<DotIcon appearance='success' icon={ArrowDown} disabled>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotIcon>
+```
+
+</Tab>
+</CustomTabs>

--- a/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.mdx
+++ b/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.mdx
@@ -55,6 +55,12 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 <Canvas of={DotIconStories.SizeShowcase} />
 
+### Disabled
+
+<Canvas of={DotIconStories.DisabledShowcase} />
+
+Only set `disabled` on `DotIcon`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
+
 ## Accessibility
 
 - The icon is purely decorative; the child element should carry its own accessibility label.
@@ -130,7 +136,7 @@ import { DotIcon, mediaImageDotIconSizeMap, MediaImage } from '@ledgerhq/lumen-u
 
 ### Disabled State
 
-When `disabled` is `true`, the wrapper is dimmed and the disabled state is propagated to the child via context:
+Only set `disabled` on `DotIcon`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
 
 ```tsx
 <DotIcon appearance='success' icon={ArrowDown} disabled>

--- a/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.mdx
+++ b/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.mdx
@@ -57,9 +57,9 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 ### Disabled
 
-<Canvas of={DotIconStories.DisabledShowcase} />
-
 Only set `disabled` on `DotIcon`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
+
+<Canvas of={DotIconStories.DisabledShowcase} />
 
 ## Accessibility
 

--- a/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.stories.tsx
@@ -113,6 +113,41 @@ export const AppearanceShowcase: Story = {
   ),
 };
 
+export const DisabledShowcase: Story = {
+  args: { appearance: 'success', icon: ArrowDown },
+  render: () => (
+    <Box lx={{ flexDirection: 'row', alignItems: 'center', gap: 's32' }}>
+      <DotIcon
+        appearance='success'
+        icon={ArrowDown}
+        size={mediaImageDotIconSizeMap[48]}
+        pin='bottom-end'
+        disabled
+      >
+        <MediaImage src={parentSrc} size={48} shape='circle' />
+      </DotIcon>
+      <DotIcon
+        appearance='muted'
+        icon={ArrowUp}
+        size={mediaImageDotIconSizeMap[48]}
+        pin='bottom-end'
+        disabled
+      >
+        <MediaImage src={parentSrc} size={48} shape='circle' />
+      </DotIcon>
+      <DotIcon
+        appearance='error'
+        icon={Close}
+        size={mediaImageDotIconSizeMap[48]}
+        pin='bottom-end'
+        disabled
+      >
+        <MediaImage src={parentSrc} size={48} shape='circle' />
+      </DotIcon>
+    </Box>
+  ),
+};
+
 export const SizeShowcase: Story = {
   args: { appearance: 'muted', icon: Link },
   render: () => (

--- a/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.tsx
@@ -2,7 +2,6 @@ import {
   DisabledProvider,
   useDisabledContext,
 } from '@ledgerhq/lumen-utils-shared';
-import { StyleSheet } from 'react-native';
 import { useStyleSheet } from '../../../styles';
 import type { IconSize } from '../Icon';
 import { Box } from '../Utility';
@@ -67,11 +66,13 @@ const useStyles = ({
   shape,
   pin,
   appearance,
+  disabled,
 }: {
   size: DotIconSize;
   shape: 'square' | 'circle';
   pin: DotIconPin;
   appearance: DotIconAppearance;
+  disabled: boolean;
 }) => {
   return useStyleSheet(
     (t) => {
@@ -81,6 +82,10 @@ const useStyles = ({
       const pinOffset = getPinOffset(pin);
 
       return {
+        root: {
+          position: 'relative',
+          ...(disabled && { opacity: 0.3 }),
+        },
         dot: {
           position: 'absolute',
           zIndex: 10,
@@ -100,7 +105,7 @@ const useStyles = ({
         },
       };
     },
-    [size, shape, pin, appearance],
+    [size, shape, pin, appearance, disabled],
   );
 };
 
@@ -129,22 +134,18 @@ export const DotIcon = ({
   ref,
   ...rest
 }: DotIconProps) => {
-  const styles = useStyles({ size, shape, pin, appearance });
   const disabled = useDisabledContext({
     consumerName: 'DotIcon',
     mergeWith: { disabled: disabledProp },
   });
+  const styles = useStyles({ size, shape, pin, appearance, disabled });
 
   return (
     <DisabledProvider value={{ disabled: false }}>
       <Box
         ref={ref}
         lx={lx}
-        style={StyleSheet.flatten([
-          { position: 'relative' },
-          disabled && { opacity: 0.3 },
-          style,
-        ])}
+        style={[styles.root, style]}
         accessibilityState={{ disabled }}
         {...rest}
       >

--- a/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.tsx
@@ -1,3 +1,7 @@
+import {
+  DisabledProvider,
+  useDisabledContext,
+} from '@ledgerhq/lumen-utils-shared';
 import { StyleSheet } from 'react-native';
 import { useStyleSheet } from '../../../styles';
 import type { IconSize } from '../Icon';
@@ -119,27 +123,39 @@ export const DotIcon = ({
   pin = 'bottom-end',
   size = 20,
   shape = 'circle',
+  disabled: disabledProp = false,
   lx = {},
   style,
   ref,
   ...rest
 }: DotIconProps) => {
   const styles = useStyles({ size, shape, pin, appearance });
+  const disabled = useDisabledContext({
+    consumerName: 'DotIcon',
+    mergeWith: { disabled: disabledProp },
+  });
 
   return (
-    <Box
-      ref={ref}
-      lx={lx}
-      style={StyleSheet.flatten([{ position: 'relative' }, style])}
-      {...rest}
-    >
-      <Box style={{ alignSelf: 'flex-start', position: 'relative' }}>
-        {children}
-        <Box testID='dot-icon-dot' style={styles.dot}>
-          <Icon size={dotIconSizeMap[size]} style={styles.icon} />
+    <DisabledProvider value={{ disabled: false }}>
+      <Box
+        ref={ref}
+        lx={lx}
+        style={StyleSheet.flatten([
+          { position: 'relative' },
+          disabled && { opacity: 0.3 },
+          style,
+        ])}
+        accessibilityState={{ disabled }}
+        {...rest}
+      >
+        <Box style={{ alignSelf: 'flex-start', position: 'relative' }}>
+          {children}
+          <Box testID='dot-icon-dot' style={styles.dot}>
+            <Icon size={dotIconSizeMap[size]} style={styles.icon} />
+          </Box>
         </Box>
       </Box>
-    </Box>
+    </DisabledProvider>
   );
 };
 

--- a/libs/ui-rnative/src/lib/Components/DotIcon/types.ts
+++ b/libs/ui-rnative/src/lib/Components/DotIcon/types.ts
@@ -38,6 +38,12 @@ export type DotIconProps = {
    */
   shape?: 'square' | 'circle';
   /**
+   * Shows a disabled appearance.
+   * @optional
+   * @default false
+   */
+  disabled?: boolean;
+  /**
    * The wrapped component (e.g. MediaImage or Spot).
    */
   children?: ReactNode;

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.mdx
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.mdx
@@ -51,9 +51,9 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 ### Disabled
 
-<Canvas of={DotSymbolStories.DisabledShowcase} />
-
 Only set `disabled` on `DotSymbol`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
+
+<Canvas of={DotSymbolStories.DisabledShowcase} />
 
 ## Accessibility
 

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.mdx
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.mdx
@@ -12,6 +12,8 @@ import { CustomTabs, Tab } from '../../../../.storybook/components';
 
 DotSymbol positions a small image indicator at a configurable corner of a child element such as MediaImage or Spot. It is commonly used to show a network badge or secondary icon overlapping a primary symbol.
 
+> View in [Figma](https://www.figma.com/design/zSkvGGiqcnhywp2l3HTHxA/1.-Symbol-Library?node-id=8602-380&m=dev).
+
 ## Anatomy
 
 <Canvas of={DotSymbolStories.Base} />

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.mdx
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.mdx
@@ -49,6 +49,12 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 <Canvas of={DotSymbolStories.SizeShowcase} />
 
+### Disabled
+
+<Canvas of={DotSymbolStories.DisabledShowcase} />
+
+Only set `disabled` on `DotSymbol`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
+
 ## Accessibility
 
 - Always provide a meaningful `alt` prop on the DotSymbol so the indicator image is announced by screen readers.
@@ -113,7 +119,7 @@ import { DotSymbol, mediaImageDotSizeMap, MediaImage } from '@ledgerhq/lumen-ui-
 
 ### Disabled State
 
-When `disabled` is `true`, the wrapper is dimmed and the disabled state is propagated to the child via context:
+Only set `disabled` on `DotSymbol`. The state is propagated to the child via context. Passing it to both stacks the opacity overlay.
 
 ```tsx
 <DotSymbol src='https://example.com/btc.png' alt='Bitcoin' disabled>

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.mdx
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.mdx
@@ -4,9 +4,10 @@ import { CustomTabs, Tab } from '../../../../.storybook/components';
 
 <Meta title='Communication/DotSymbol' of={DotSymbolStories} />
 
+# DotSymbol
+
 <CustomTabs>
   <Tab label="Overview">
-# DotSymbol
 
 ## Introduction
 
@@ -52,5 +53,73 @@ The dot size is driven by the parent MediaImage or Spot size via the mapping hel
 
 - Always provide a meaningful `alt` prop on the DotSymbol so the indicator image is announced by screen readers.
 - The child element should carry its own accessibility label independently.
+
+</Tab>
+<Tab label="Implementation">
+
+## Setup
+
+Install and set up the library with our [Setup Guide →](?path=/docs/getting-started-setup--docs).
+
+### Basic Usage
+
+```tsx
+import { DotSymbol, MediaImage } from '@ledgerhq/lumen-ui-rnative';
+
+function MyComponent() {
+  return (
+    <DotSymbol src='https://example.com/btc.png' alt='Bitcoin network'>
+      <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+    </DotSymbol>
+  );
+}
+```
+
+### Pin Placement
+
+Position the dot at any of the four corners of the child:
+
+```tsx
+<DotSymbol src='https://example.com/btc.png' alt='Bitcoin' pin='top-end'>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotSymbol>
+```
+
+### Shapes
+
+Use `shape='square'` to match a square child element:
+
+```tsx
+<DotSymbol src='https://example.com/btc.png' alt='Bitcoin' shape='square'>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} shape='square' />
+</DotSymbol>
+```
+
+### Sizing
+
+The dot size is driven by the parent's size via the mapping helpers:
+
+```tsx
+import { DotSymbol, mediaImageDotSizeMap, MediaImage } from '@ledgerhq/lumen-ui-rnative';
+
+<DotSymbol
+  src='https://example.com/btc.png'
+  alt='Bitcoin'
+  size={mediaImageDotSizeMap[48]}
+>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotSymbol>;
+```
+
+### Disabled State
+
+When `disabled` is `true`, the wrapper is dimmed and the disabled state is propagated to the child via context:
+
+```tsx
+<DotSymbol src='https://example.com/btc.png' alt='Bitcoin' disabled>
+  <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
+</DotSymbol>
+```
+
 </Tab>
 </CustomTabs>

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.stories.tsx
@@ -92,6 +92,23 @@ export const ShapeShowcase: Story = {
   ),
 };
 
+export const DisabledShowcase: Story = {
+  args: { src: dotSrc, alt: 'Disabled showcase' },
+  render: () => (
+    <Box lx={{ flexDirection: 'row', alignItems: 'center', gap: 's32' }}>
+      <DotSymbol src={dotSrc} pin='bottom-end' disabled>
+        <MediaImage src={parentSrc} size={48} shape='circle' />
+      </DotSymbol>
+      <DotSymbol src={dotSrc} pin='bottom-end' shape='square' disabled>
+        <MediaImage src={parentSrc} size={48} shape='square' />
+      </DotSymbol>
+      <DotSymbol src={dotSrc} pin='bottom-end' disabled>
+        <Spot appearance='icon' icon={CoinAlert} />
+      </DotSymbol>
+    </Box>
+  ),
+};
+
 export const SizeShowcase: Story = {
   args: { src: dotSrc, alt: 'Size showcase' },
   render: () => (

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.tsx
@@ -1,3 +1,7 @@
+import {
+  DisabledProvider,
+  useDisabledContext,
+} from '@ledgerhq/lumen-utils-shared';
 import { useEffect, useState } from 'react';
 import { Image, StyleSheet } from 'react-native';
 import { useStyleSheet } from '../../../styles';
@@ -118,6 +122,7 @@ export const DotSymbol = ({
   pin = 'bottom-end',
   size = 20,
   shape = 'circle',
+  disabled: disabledProp = false,
   lx = {},
   style,
   ref,
@@ -125,35 +130,46 @@ export const DotSymbol = ({
 }: DotSymbolProps) => {
   const styles = useStyles({ size, shape, pin });
   const [error, setError] = useState(false);
+  const disabled = useDisabledContext({
+    consumerName: 'DotSymbol',
+    mergeWith: { disabled: disabledProp },
+  });
 
   useEffect(() => {
     setError(false);
   }, [src]);
 
   return (
-    <Box
-      ref={ref}
-      lx={lx}
-      style={StyleSheet.flatten([{ position: 'relative' }, style])}
-      accessibilityRole='image'
-      accessibilityLabel={alt}
-      {...rest}
-    >
-      <Box style={{ alignSelf: 'flex-start', position: 'relative' }}>
-        {children}
-        <Box style={styles.dot}>
-          {!error && (
-            <Image
-              source={{ uri: src }}
-              style={styles.image}
-              accessible={false}
-              onError={() => setError(true)}
-              testID='dot-symbol-img'
-            />
-          )}
+    <DisabledProvider value={{ disabled: false }}>
+      <Box
+        ref={ref}
+        lx={lx}
+        style={StyleSheet.flatten([
+          { position: 'relative' },
+          disabled && { opacity: 0.3 },
+          style,
+        ])}
+        accessibilityRole='image'
+        accessibilityLabel={alt}
+        accessibilityState={{ disabled }}
+        {...rest}
+      >
+        <Box style={{ alignSelf: 'flex-start', position: 'relative' }}>
+          {children}
+          <Box style={styles.dot}>
+            {!error && (
+              <Image
+                source={{ uri: src }}
+                style={styles.image}
+                accessible={false}
+                onError={() => setError(true)}
+                testID='dot-symbol-img'
+              />
+            )}
+          </Box>
         </Box>
       </Box>
-    </Box>
+    </DisabledProvider>
   );
 };
 

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.tsx
@@ -3,7 +3,7 @@ import {
   useDisabledContext,
 } from '@ledgerhq/lumen-utils-shared';
 import { useEffect, useState } from 'react';
-import { Image, StyleSheet } from 'react-native';
+import { Image } from 'react-native';
 import { useStyleSheet } from '../../../styles';
 import type { MediaImageSize } from '../MediaImage';
 import type { SpotSize } from '../Spot';
@@ -69,10 +69,12 @@ const useStyles = ({
   size,
   shape,
   pin,
+  disabled,
 }: {
   size: DotSymbolSize;
   shape: 'square' | 'circle';
   pin: DotSymbolPin;
+  disabled: boolean;
 }) => {
   return useStyleSheet(
     (t) => {
@@ -82,6 +84,10 @@ const useStyles = ({
       const pinOffset = getPinOffset(pin, size);
 
       return {
+        root: {
+          position: 'relative',
+          ...(disabled && { opacity: 0.3 }),
+        },
         dot: {
           position: 'absolute',
           zIndex: 10,
@@ -100,7 +106,7 @@ const useStyles = ({
         },
       };
     },
-    [size, shape, pin],
+    [size, shape, pin, disabled],
   );
 };
 
@@ -128,12 +134,12 @@ export const DotSymbol = ({
   ref,
   ...rest
 }: DotSymbolProps) => {
-  const styles = useStyles({ size, shape, pin });
   const [error, setError] = useState(false);
   const disabled = useDisabledContext({
     consumerName: 'DotSymbol',
     mergeWith: { disabled: disabledProp },
   });
+  const styles = useStyles({ size, shape, pin, disabled });
 
   useEffect(() => {
     setError(false);
@@ -144,11 +150,7 @@ export const DotSymbol = ({
       <Box
         ref={ref}
         lx={lx}
-        style={StyleSheet.flatten([
-          { position: 'relative' },
-          disabled && { opacity: 0.3 },
-          style,
-        ])}
+        style={[styles.root, style]}
         accessibilityRole='image'
         accessibilityLabel={alt}
         accessibilityState={{ disabled }}

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/types.ts
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/types.ts
@@ -34,6 +34,12 @@ export type DotSymbolProps = {
    */
   shape?: 'square' | 'circle';
   /**
+   * Shows a disabled appearance.
+   * @optional
+   * @default false
+   */
+  disabled?: boolean;
+  /**
    * The wrapped component (e.g. MediaImage or Spot).
    */
   children?: ReactNode;

--- a/libs/ui-rnative/src/lib/Components/MediaImage/MediaImage.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/MediaImage/MediaImage.stories.tsx
@@ -86,3 +86,21 @@ export const LoadingShowcase: Story = {
     </Box>
   ),
 };
+
+export const DisabledShowcase: Story = {
+  render: () => (
+    <Box lx={{ flexDirection: 'row', alignItems: 'flex-end', gap: 's16' }}>
+      <MediaImage src={exampleSrc} alt='Cardano' size={32} disabled />
+      <MediaImage src={exampleSrc} alt='Cardano' size={48} disabled />
+      <MediaImage
+        src={exampleSrc}
+        alt='Cardano'
+        size={48}
+        shape='circle'
+        disabled
+      />
+      <MediaImage fallback='Bitcoin' alt='Bitcoin' size={48} disabled />
+      <MediaImage alt='Empty' size={48} disabled />
+    </Box>
+  ),
+};

--- a/libs/ui-rnative/src/lib/Components/MediaImage/MediaImage.tsx
+++ b/libs/ui-rnative/src/lib/Components/MediaImage/MediaImage.tsx
@@ -1,3 +1,4 @@
+import { useDisabledContext } from '@ledgerhq/lumen-utils-shared';
 import { useEffect, useState } from 'react';
 import { Image, StyleSheet } from 'react-native';
 import { useStyleSheet } from '../../../styles';
@@ -36,9 +37,11 @@ export const fontSizeMap: Record<MediaImageSize, number> = {
 const useStyles = ({
   size,
   shape,
+  disabled,
 }: {
   size: MediaImageSize;
   shape: MediaImageShape;
+  disabled: boolean;
 }) => {
   return useStyleSheet(
     (t) => {
@@ -61,6 +64,7 @@ const useStyles = ({
           outlineWidth: 1,
           outlineOffset: -1,
           outlineStyle: 'solid',
+          ...(disabled && { opacity: 0.3 }),
         },
         image: {
           width: '100%',
@@ -72,7 +76,7 @@ const useStyles = ({
         },
       };
     },
-    [size, shape],
+    [size, shape, disabled],
   );
 };
 
@@ -99,6 +103,7 @@ export const MediaImage = ({
   shape = 'square',
   fallback,
   loading = false,
+  disabled: disabledProp = false,
   lx = {},
   style,
   ref,
@@ -106,7 +111,11 @@ export const MediaImage = ({
 }: MediaImageProps) => {
   const [error, setError] = useState(false);
   const shouldFallback = !src || error;
-  const styles = useStyles({ size, shape });
+  const disabled = useDisabledContext({
+    consumerName: 'MediaImage',
+    mergeWith: { disabled: disabledProp },
+  });
+  const styles = useStyles({ size, shape, disabled });
 
   useEffect(() => {
     setError(false);
@@ -119,6 +128,7 @@ export const MediaImage = ({
       style={StyleSheet.flatten([styles.root, style])}
       accessibilityRole='image'
       accessibilityLabel={alt}
+      accessibilityState={{ disabled }}
       {...props}
     >
       {loading && <Skeleton style={styles.skeleton} />}

--- a/libs/ui-rnative/src/lib/Components/MediaImage/types.ts
+++ b/libs/ui-rnative/src/lib/Components/MediaImage/types.ts
@@ -36,4 +36,10 @@ export type MediaImageProps = {
    * @default false
    */
   loading?: boolean;
+  /**
+   * Shows a disabled appearance.
+   * @optional
+   * @default false
+   */
+  disabled?: boolean;
 } & Omit<StyledViewProps, 'children'>;


### PR DESCRIPTION
Closes [DLS-734](https://ledgerhq.atlassian.net/browse/DLS-734).

## Considerations

* Regarding the `<DisabledProvider value={{ disabled: false }}>` pattern, the goal is to apply the opacity to the outer wrapper and reset for the children.
If you allow it to propagate, each child applies it own opacity, resulting in this:

<img width="298" height="119" alt="image" src="https://github.com/user-attachments/assets/c18d00f2-ec92-4b0d-8067-c7904f901649" />


## Demo (iOS sandbox)

Showcasing disabled provider working correctly, provided e.g., by ListItem and picked up by MediaImage in isolation and wrapped inside DotSymbol.

Tested in iPhone 17 simulator running iOS 26.5.

https://github.com/user-attachments/assets/245e1c43-c2de-4ab2-bb64-e2add653fd79




[DLS-734]: https://ledgerhq.atlassian.net/browse/DLS-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ