### PR TITLE
fix(ui-rnative): page indicator component not updating on page change

### DIFF
--- a/.nx/version-plans/version-plan-1779801734000-page-indicator.md
+++ b/.nx/version-plans/version-plan-1779801734000-page-indicator.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+fix(ui-rnative): fix PageIndicator not reliably updating on slide change

--- a/libs/ui-rnative/jest.setup.ts
+++ b/libs/ui-rnative/jest.setup.ts
@@ -138,9 +138,9 @@ jest.mock('react-native-reanimated', () => {
     ScrollView: AnimatedScrollView,
     createAnimatedComponent: (component: any) => component,
     useSharedValue: (value: any) => ({ value }),
-    useAnimatedStyle: (_cb: any) => {
-      return {};
-    },
+    // Evaluate the callback so consumers see real interpolated values during
+    // render. Tests that need to assert on animated styles depend on this.
+    useAnimatedStyle: (cb: any) => cb(),
     withTiming: (value: any) => value,
     withSpring: (value: any) => value,
     withDecay: (value: any) => value,
@@ -150,6 +150,13 @@ jest.mock('react-native-reanimated', () => {
     cancelAnimation: () => {
       return;
     },
+    interpolate: (value: number, _input: number[], output: number[]) =>
+      output[0] + (output[1] - output[0]) * value,
+    interpolateColor: (
+      value: number,
+      _input: number[],
+      output: string[],
+    ): string => (value >= 0.5 ? output[1] : output[0]),
     useAnimatedProps: (_cb: any) => {
       return {};
     },

--- a/libs/ui-rnative/src/lib/Components/PageIndicator/PageIndicator.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/PageIndicator/PageIndicator.test.tsx
@@ -15,6 +15,12 @@ const renderWithProvider = (component: React.ReactElement) => {
   );
 };
 
+const wrapWithProvider = (component: React.ReactElement) => (
+  <ThemeProvider themes={ledgerLiveThemes} colorScheme='dark' locale='en'>
+    {component}
+  </ThemeProvider>
+);
+
 describe('PageIndicator Component', () => {
   describe('Rendering', () => {
     it('should render with required props', () => {
@@ -158,6 +164,78 @@ describe('PageIndicator Component', () => {
         />,
       );
       expect(screen.getByTestId('page-indicator')).toBeTruthy();
+    });
+  });
+
+  describe('Re-rendering', () => {
+    // Regression: dot/strip styles must update when currentPage changes.
+    // One bug has produced the same broken-on-update symptom:
+    //   1. Wrapping in Animated.createAnimatedComponent(Box) — Box flattens
+    //      style arrays via StyleSheet.flatten, which snapshots reanimated
+    //      animated styles and stops updates.
+    // Initial render looked correct in both cases — only re-render exposed
+    // the issue, which is what the tests below exercise.
+    it('updates the rendered tree when currentPage changes', () => {
+      const { rerender } = renderWithProvider(
+        <PageIndicator
+          testID='page-indicator'
+          currentPage={1}
+          totalPages={5}
+        />,
+      );
+      const treeBefore = JSON.stringify(screen.toJSON());
+
+      rerender(
+        wrapWithProvider(
+          <PageIndicator
+            testID='page-indicator'
+            currentPage={3}
+            totalPages={5}
+          />,
+        ),
+      );
+      const treeAfter = JSON.stringify(screen.toJSON());
+
+      expect(treeAfter).not.toEqual(treeBefore);
+    });
+
+    it('updates the active dot style when currentPage changes', () => {
+      type Node = {
+        type: string;
+        props: { style?: unknown };
+        children: Node[] | null;
+      };
+      const getDotStyles = (): unknown[] => {
+        const root = screen.toJSON() as Node | null;
+        if (!root?.children) throw new Error('Expected container children');
+        const viewport = root.children[0];
+        if (!viewport?.children) throw new Error('Expected viewport children');
+        const strip = viewport.children[0];
+        if (!strip?.children) throw new Error('Expected strip children');
+        return strip.children.map((dot) => dot.props.style);
+      };
+
+      const { rerender } = renderWithProvider(
+        <PageIndicator
+          testID='page-indicator'
+          currentPage={1}
+          totalPages={5}
+        />,
+      );
+      const stylesBefore = JSON.stringify(getDotStyles());
+
+      rerender(
+        wrapWithProvider(
+          <PageIndicator
+            testID='page-indicator'
+            currentPage={3}
+            totalPages={5}
+          />,
+        ),
+      );
+      const stylesAfter = JSON.stringify(getDotStyles());
+
+      expect(stylesAfter).not.toEqual(stylesBefore);
     });
   });
 

--- a/libs/ui-rnative/src/lib/Components/PageIndicator/PageIndicator.tsx
+++ b/libs/ui-rnative/src/lib/Components/PageIndicator/PageIndicator.tsx
@@ -12,7 +12,6 @@ import { useTimingConfig } from '../../Animations/useTimingConfig';
 import { Box } from '../Utility';
 import type { PageIndicatorProps } from './types';
 
-const AnimatedBox = Animated.createAnimatedComponent(Box);
 const MAX_VISIBLE_DOTS = 4;
 
 const useDotAnimation = ({
@@ -33,13 +32,19 @@ const useDotAnimation = ({
 
   useEffect(() => {
     colorProgress.value = withTiming(isActive ? 1 : 0, timingConfig);
-    return () => cancelAnimation(colorProgress);
   }, [isActive, colorProgress, timingConfig]);
 
   useEffect(() => {
+    return () => cancelAnimation(colorProgress);
+  }, [colorProgress]);
+
+  useEffect(() => {
     shrinkProgress.value = withTiming(isShrunk ? 1 : 0, timingConfig);
-    return () => cancelAnimation(shrinkProgress);
   }, [isShrunk, shrinkProgress, timingConfig]);
+
+  useEffect(() => {
+    return () => cancelAnimation(shrinkProgress);
+  }, [shrinkProgress]);
 
   const animatedStyle = useAnimatedStyle(() => {
     const backgroundColor = interpolateColor(
@@ -102,8 +107,11 @@ const useStripAnimation = ({
 
   useEffect(() => {
     translateX.value = withTiming(-offset * dotWidth, timingConfig);
+  }, [offset, dotWidth, translateX, timingConfig]);
+
+  useEffect(() => {
     return () => cancelAnimation(translateX);
-  }, [currentPage, totalPages, offset, dotWidth, translateX, timingConfig]);
+  }, [translateX]);
 
   const stripAnimatedStyle = useAnimatedStyle(
     () => ({
@@ -157,7 +165,7 @@ const PageIndicatorDot = ({
   const styles = useDotStyles();
   const { animatedStyle } = useDotAnimation({ isActive, isShrunk });
 
-  return <AnimatedBox style={[styles.dot, animatedStyle]} />;
+  return <Animated.View style={[styles.dot, animatedStyle]} />;
 };
 
 /**
@@ -202,7 +210,7 @@ export const PageIndicator = ({
       {...props}
     >
       <Box style={[styles.viewport, { width: viewportWidth }]}>
-        <AnimatedBox style={[styles.strip, stripAnimatedStyle]}>
+        <Animated.View style={[styles.strip, stripAnimatedStyle]}>
           {dotIndexes.map((index) => (
             <PageIndicatorDot
               key={index}
@@ -210,7 +218,7 @@ export const PageIndicator = ({
               isShrunk={isShrunk(index)}
             />
           ))}
-        </AnimatedBox>
+        </Animated.View>
       </Box>
     </Box>
   );


### PR DESCRIPTION
**Context:**

The page indicator was not moving or updating correctly on slide change for product tour and walletV4Tour. 

**Reason for change:**
During investigation it was evident that the bug was coming from the lumen component itself rather than a LWM bug.

**Bug Details:**
useTimingConfig({ duration: 200, easing: 'easeInOut' }) returns a reference that ends up being unstable enough to be in the useEffect deps, combined with return () => cancelAnimation(...) in cleanup. Each time the effect re-runs, the cleanup cancels any in-progress withTiming before it has a chance to make visible progress. The dot's colorProgress never actually animates.