### PR TITLE
[M]DLS-736-feat(AmountDisplay): Add size variant support

### DIFF
--- a/.nx/version-plans/version-plan-1779884598436.md
+++ b/.nx/version-plans/version-plan-1779884598436.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+feat(AmountDisplay): add `size` prop (`sm`, `md` default)

--- a/apps/app-sandbox-rnative/src/app/blocks/AmountDisplays.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/AmountDisplays.tsx
@@ -71,6 +71,11 @@ export function AmountDisplays() {
           <Text style={styles.sectionDescription}>With hide button</Text>
         </View>
         <View style={styles.sectionContainer}>
+          <AmountDisplay value={1234.56} formatter={eurFormatter} size='md' />
+          <AmountDisplay value={1234.56} formatter={eurFormatter} size='sm' />
+          <Text style={styles.sectionDescription}>Sizes</Text>
+        </View>
+        <View style={styles.sectionContainer}>
           <AmountDisplay
             value={1234.56}
             formatter={eurFormatter}

--- a/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.mdx
+++ b/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.mdx
@@ -39,6 +39,12 @@ The AmountDisplay component renders formatted monetary amounts with flexible cur
 <Canvas of={AmountDisplayStories.Base} />
 <Controls of={AmountDisplayStories.Base} />
 
+### Size
+
+The `size` prop controls the typographic scale of the amount display. Use `md` (default) for primary amounts and `sm` for secondary or contextual amounts.
+
+<Canvas of={AmountDisplayStories.Sizes} />
+
 ### Privacy
 
 The `hidden` prop allows you to toggle amount visibility for privacy-sensitive applications. When set to `true`, the component displays bullet points (••••) instead of the actual amount, while keeping the currency symbol visible. The example below demonstrates toggling amount visibility with a button.

--- a/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.stories.tsx
@@ -79,6 +79,12 @@ const meta: Meta<typeof AmountDisplay> = {
         type: 'boolean',
       },
     },
+    size: {
+      control: {
+        type: 'select',
+      },
+      options: ['sm', 'md'],
+    },
   },
   parameters: {
     layout: 'centered',
@@ -107,6 +113,18 @@ export const Base: Story = {
       },
     },
   },
+};
+
+export const Sizes: Story = {
+  args: {
+    value: 1234.56,
+  },
+  render: (props) => (
+    <View style={{ alignItems: 'center', gap: 24 }}>
+      <AmountDisplay {...props} size='md' />
+      <AmountDisplay {...props} size='sm' />
+    </View>
+  ),
 };
 
 export const WithHideButton: Story = {

--- a/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.tsx
+++ b/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.tsx
@@ -8,8 +8,8 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { useCommonTranslation } from '../../../i18n';
-import { useStyleSheet } from '../../../styles';
 import type { LumenTypographyTokenName } from '../../../styles';
+import { useStyleSheet } from '../../../styles';
 import { Pulse } from '../../Animations/Pulse';
 import { useTimingConfig } from '../../Animations/useTimingConfig';
 import { RuntimeConstants } from '../../utils';
@@ -23,7 +23,7 @@ import type {
 } from './types';
 import { DIGITS } from './types';
 
-const TYPOGRAPHY_WIDTHS: Record<string, DigitWidths> = {
+const TYPOGRAPHY_WIDTHS = {
   heading1SemiBold: {
     0: 25,
     1: 15.5,
@@ -60,11 +60,13 @@ const TYPOGRAPHY_WIDTHS: Record<string, DigitWidths> = {
     8: 12.5,
     9: 12.5,
   },
-};
+} as const satisfies Partial<Record<LumenTypographyTokenName, DigitWidths>>;
+
+type MeasuredTypography = keyof typeof TYPOGRAPHY_WIDTHS;
 
 type SizeTypographyConfig = {
-  integer: LumenTypographyTokenName;
-  decimal: LumenTypographyTokenName;
+  integer: MeasuredTypography;
+  decimal: MeasuredTypography;
 };
 
 const SIZE_TYPOGRAPHY: Record<AmountDisplaySize, SizeTypographyConfig> = {
@@ -258,7 +260,7 @@ DigitStripList.displayName = 'DigitStripList';
  * <AmountDisplay value={1234.56} formatter={usdFormatter} hidden={true} />
  * ```
  */
-export const AmountDisplay = ({
+export function AmountDisplay({
   value,
   formatter,
   hidden = false,
@@ -266,7 +268,7 @@ export const AmountDisplay = ({
   animate = true,
   size = 'md',
   ...props
-}: AmountDisplayProps) => {
+}: AmountDisplayProps) {
   const styles = useStyles(size);
   const { t } = useCommonTranslation();
   const parts = formatter(value);
@@ -341,4 +343,4 @@ export const AmountDisplay = ({
       </Pulse>
     </Box>
   );
-};
+}

--- a/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.tsx
+++ b/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.tsx
@@ -9,44 +9,71 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useCommonTranslation } from '../../../i18n';
 import { useStyleSheet } from '../../../styles';
+import type { LumenTypographyTokenName } from '../../../styles';
 import { Pulse } from '../../Animations/Pulse';
 import { useTimingConfig } from '../../Animations/useTimingConfig';
 import { RuntimeConstants } from '../../utils';
 import { Box } from '../Utility';
 import type {
   AmountDisplayProps,
+  AmountDisplaySize,
   DigitStripListProps,
   DigitStripProps,
+  DigitWidths,
 } from './types';
 import { DIGITS } from './types';
 
-const INTEGER_DIGIT_WIDTHS = {
-  0: 25,
-  1: 15.5,
-  2: 23.5,
-  3: 24.5,
-  4: 25.5,
-  5: 23.5,
-  6: 25,
-  7: 22,
-  8: 24.5,
-  9: 24.5,
+const TYPOGRAPHY_WIDTHS: Record<string, DigitWidths> = {
+  heading1SemiBold: {
+    0: 25,
+    1: 15.5,
+    2: 23.5,
+    3: 24.5,
+    4: 25.5,
+    5: 23.5,
+    6: 25,
+    7: 22,
+    8: 24.5,
+    9: 24.5,
+  },
+  heading2SemiBold: {
+    0: 17.5,
+    1: 11,
+    2: 16.5,
+    3: 17,
+    4: 18,
+    5: 16,
+    6: 17.5,
+    7: 15,
+    8: 17,
+    9: 17,
+  },
+  heading4SemiBold: {
+    0: 13,
+    1: 8.5,
+    2: 12.5,
+    3: 12.5,
+    4: 13,
+    5: 12,
+    6: 12.5,
+    7: 11.5,
+    8: 12.5,
+    9: 12.5,
+  },
 };
 
-const DECIMAL_DIGIT_WIDTHS = {
-  0: 17.5,
-  1: 11,
-  2: 16.5,
-  3: 17,
-  4: 18,
-  5: 16,
-  6: 17.5,
-  7: 15,
-  8: 17,
-  9: 17,
+type SizeTypographyConfig = {
+  integer: LumenTypographyTokenName;
+  decimal: LumenTypographyTokenName;
 };
 
-const useStyles = () => {
+const SIZE_TYPOGRAPHY: Record<AmountDisplaySize, SizeTypographyConfig> = {
+  md: { integer: 'heading1SemiBold', decimal: 'heading2SemiBold' },
+  sm: { integer: 'heading2SemiBold', decimal: 'heading4SemiBold' },
+};
+
+const useStyles = (size: AmountDisplaySize) => {
+  const typography = SIZE_TYPOGRAPHY[size];
   return useStyleSheet(
     (t) => ({
       container: {
@@ -61,19 +88,19 @@ const useStyles = () => {
         paddingBottom: t.spacings.s2,
       },
       integerText: {
-        ...t.typographies.heading1SemiBold,
+        ...t.typographies[typography.integer],
         color: t.colors.text.base,
       },
       decimalText: {
-        ...t.typographies.heading2SemiBold,
+        ...t.typographies[typography.decimal],
         color: t.colors.text.muted,
       },
       currencyStartText: {
-        ...t.typographies.heading1SemiBold,
+        ...t.typographies[typography.integer],
         color: t.colors.text.base,
       },
       currencyEndText: {
-        ...t.typographies.heading2SemiBold,
+        ...t.typographies[typography.decimal],
         color: t.colors.text.muted,
       },
       spacingStart: {
@@ -83,7 +110,7 @@ const useStyles = () => {
         marginLeft: t.spacings.s4,
       },
     }),
-    [],
+    [typography],
   );
 };
 
@@ -136,10 +163,8 @@ const useAnimatedDigitStrip = ({
 };
 
 const DigitStrip = memo(
-  ({ value, textStyle, animate, type }: DigitStripProps) => {
-    const targetWidth = (
-      type === 'integer' ? INTEGER_DIGIT_WIDTHS : DECIMAL_DIGIT_WIDTHS
-    )[value];
+  ({ value, textStyle, animate, widths }: DigitStripProps) => {
+    const targetWidth = widths[value];
     const lineHeight = textStyle.lineHeight;
     const width = useSharedValue<number>(targetWidth);
     const { animatedStyle } = useAnimatedDigitStrip({
@@ -176,7 +201,7 @@ const DigitStrip = memo(
 DigitStrip.displayName = 'DigitStrip';
 
 const DigitStripList = memo(
-  ({ items, textStyle, animate, type }: DigitStripListProps) => {
+  ({ items, textStyle, animate, widths }: DigitStripListProps) => {
     return items.map((item, index) => {
       const key = items.length - index;
       if (item.type === 'separator') {
@@ -192,7 +217,7 @@ const DigitStripList = memo(
           value={Number(item.value) as DigitStripProps['value']}
           animate={animate}
           textStyle={textStyle}
-          type={type}
+          widths={widths}
         />
       );
     });
@@ -239,9 +264,10 @@ export const AmountDisplay = ({
   hidden = false,
   loading = false,
   animate = true,
+  size = 'md',
   ...props
 }: AmountDisplayProps) => {
-  const styles = useStyles();
+  const styles = useStyles(size);
   const { t } = useCommonTranslation();
   const parts = formatter(value);
   const splitDigits = useSplitText(parts);
@@ -250,6 +276,9 @@ export const AmountDisplay = ({
     hidden,
     t('components.amountDisplay.amountHiddenAriaLabel'),
   );
+  const typography = SIZE_TYPOGRAPHY[size];
+  const integerWidths = TYPOGRAPHY_WIDTHS[typography.integer];
+  const decimalWidths = TYPOGRAPHY_WIDTHS[typography.decimal];
 
   return (
     <Box
@@ -281,7 +310,7 @@ export const AmountDisplay = ({
                 items={splitDigits.integerPart}
                 textStyle={styles.integerText}
                 animate={animate}
-                type='integer'
+                widths={integerWidths}
               />
             )}
           </View>
@@ -296,7 +325,7 @@ export const AmountDisplay = ({
                 items={splitDigits.decimalPart}
                 textStyle={styles.decimalText}
                 animate={animate}
-                type='decimal'
+                widths={decimalWidths}
               />
             )}
             {parts.currencyPosition === 'end' && (

--- a/libs/ui-rnative/src/lib/Components/AmountDisplay/index.ts
+++ b/libs/ui-rnative/src/lib/Components/AmountDisplay/index.ts
@@ -1,2 +1,6 @@
 export { AmountDisplay } from './AmountDisplay';
-export type { AmountDisplayProps, FormattedValue } from './types';
+export type {
+  AmountDisplayProps,
+  AmountDisplaySize,
+  FormattedValue,
+} from './types';

--- a/libs/ui-rnative/src/lib/Components/AmountDisplay/types.ts
+++ b/libs/ui-rnative/src/lib/Components/AmountDisplay/types.ts
@@ -4,7 +4,7 @@ import type { StyledViewProps } from '../../../styles';
 
 export type { FormattedValue };
 
-export const DIGITS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+export const DIGITS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
 
 type Digit = (typeof DIGITS)[number];
 

--- a/libs/ui-rnative/src/lib/Components/AmountDisplay/types.ts
+++ b/libs/ui-rnative/src/lib/Components/AmountDisplay/types.ts
@@ -4,15 +4,19 @@ import type { StyledViewProps } from '../../../styles';
 
 export type { FormattedValue };
 
-export const DIGITS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
+export const DIGITS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-type IntegerDigit = (typeof DIGITS)[number];
+type Digit = (typeof DIGITS)[number];
+
+export type AmountDisplaySize = 'sm' | 'md';
+
+export type DigitWidths = Record<Digit, number>;
 
 export type DigitStripProps = {
-  value: IntegerDigit;
+  value: Digit;
   animate: boolean;
   textStyle: TextStyle & { lineHeight: number };
-  type: 'integer' | 'decimal';
+  widths: DigitWidths;
 };
 
 export type DigitStripListProps = {
@@ -48,4 +52,9 @@ export type AmountDisplayProps = ViewProps & {
    * @default true
    */
   animate?: boolean;
+  /**
+   * The size variant of the amount display.
+   * @default 'md'
+   */
+  size?: AmountDisplaySize;
 } & Omit<StyledViewProps, 'children'>;


### PR DESCRIPTION
## Overview

- Add new size prop with t-shirt sizings 'sm', and default 'md'.
- Refactor size mapping.
- Export component as function instead of deprecated arrow function.