### PR TITLE
BREAKING_CHANGE(ui-react/ui-rnative): rename `icon` prop to `leadingContent` in NavBar + MediaButton

### DIFF
--- a/.nx/version-plans/version-plan-1779812511478-react.md
+++ b/.nx/version-plans/version-plan-1779812511478-react.md
@@ -1,0 +1,19 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+BREAKING_CHANGE(ui-react): rename "icon" prop to "leadingContent" in NavBar/MediaButton
+
+`MediaButton` and `NavBarCoinCapsule` no longer accept an `icon` prop. The slot has been renamed to `leadingContent` to reflect that consumers can pass any node there, not just an icon. On `MediaButton`, the companion prop `iconType` has been renamed to `leadingContentShape` (same `'flat' | 'rounded'` values, same default of `'flat'`).
+
+To migrate, rename the props at each call site:
+
+```diff
+- <MediaButton icon={<MyIcon />} iconType="rounded" />
++ <MediaButton leadingContent={<MyIcon />} leadingContentShape="rounded" />
+
+- <NavBarCoinCapsule ticker="BTC" icon={<BitcoinIcon />} />
++ <NavBarCoinCapsule ticker="BTC" leadingContent={<BitcoinIcon />} />
+```
+
+Behavior, sizing expectations, and padding semantics are unchanged — this is a pure rename.

--- a/.nx/version-plans/version-plan-1779812511478-rnative.md
+++ b/.nx/version-plans/version-plan-1779812511478-rnative.md
@@ -1,0 +1,19 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+BREAKING_CHANGE(ui-rnative): rename "icon" prop to "leadingContent" in NavBar/MediaButton
+
+`MediaButton` and `NavBarCoinCapsule` no longer accept an `icon` prop. The slot has been renamed to `leadingContent` to reflect that consumers can pass any node there, not just an icon. On `MediaButton`, the companion prop `iconType` has been renamed to `leadingContentShape` (same `'flat' | 'rounded'` values, same default of `'flat'`).
+
+To migrate, rename the props at each call site:
+
+```diff
+- <MediaButton icon={<MyIcon />} iconType="rounded" />
++ <MediaButton leadingContent={<MyIcon />} leadingContentShape="rounded" />
+
+- <NavBarCoinCapsule ticker="BTC" icon={<BitcoinIcon />} />
++ <NavBarCoinCapsule ticker="BTC" leadingContent={<BitcoinIcon />} />
+```
+
+Behavior, sizing expectations, and padding semantics are unchanged — this is a pure rename.

--- a/apps/app-sandbox-rnative/src/app/blocks/MediaButtons.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/MediaButtons.tsx
@@ -5,17 +5,25 @@ export const MediaButtons = () => {
   return (
     <Box lx={{ gap: 's16' }}>
       <Box lx={{ gap: 's16', flexDirection: 'row' }}>
-        <MediaButton size='sm' icon={<Star size={20} />} iconType='flat'>
+        <MediaButton
+          size='sm'
+          leadingContent={<Star size={20} />}
+          leadingContentShape='flat'
+        >
           Small
         </MediaButton>
-        <MediaButton size='md' icon={<Star size={20} />} iconType='flat'>
+        <MediaButton
+          size='md'
+          leadingContent={<Star size={20} />}
+          leadingContentShape='flat'
+        >
           Medium
         </MediaButton>
       </Box>
       <Box lx={{ gap: 's16', flexDirection: 'row' }}>
         <MediaButton
           size='sm'
-          icon={
+          leadingContent={
             <MediaImage
               src='https://crypto-icons.ledger.com/BTC.png'
               alt='BTC'
@@ -23,14 +31,14 @@ export const MediaButtons = () => {
               shape='circle'
             />
           }
-          iconType='rounded'
+          leadingContentShape='rounded'
           hideChevron
         >
           Small
         </MediaButton>
         <MediaButton
           size='md'
-          icon={
+          leadingContent={
             <MediaImage
               src='https://crypto-icons.ledger.com/BTC.png'
               alt='BTC'
@@ -38,7 +46,7 @@ export const MediaButtons = () => {
               shape='circle'
             />
           }
-          iconType='rounded'
+          leadingContentShape='rounded'
           hideChevron
         >
           Medium

--- a/apps/app-sandbox-rnative/src/app/blocks/NavBars.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/NavBars.tsx
@@ -88,7 +88,9 @@ export const NavBars = () => {
           <NavBarContent>
             <NavBarCoinCapsule
               ticker='BTC'
-              icon={<Icon ledgerId='bitcoin' ticker='BTC' size={24} />}
+              leadingContent={
+                <Icon ledgerId='bitcoin' ticker='BTC' size={24} />
+              }
             />
           </NavBarContent>
         </NavBar>

--- a/apps/app-sandbox-rnative/src/app/blocks/OptionLists.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/OptionLists.tsx
@@ -46,7 +46,7 @@ const CurrencySelectExample = () => {
   return (
     <Box>
       <MediaButton
-        icon={
+        leadingContent={
           selectedMeta ? (
             <CryptoIconNative
               ledgerId={selectedMeta.icon}
@@ -194,7 +194,7 @@ const NetworkSelectExample = () => {
   return (
     <Box>
       <MediaButton
-        icon={
+        leadingContent={
           selected?.meta ? (
             <CryptoIconNative
               ledgerId={selected.meta.icon}
@@ -314,7 +314,7 @@ const SearchableSelectExample = () => {
   return (
     <Box>
       <MediaButton
-        icon={
+        leadingContent={
           selectedMeta ? (
             <CryptoIconNative
               ledgerId={selectedMeta.icon}

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.figma.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.figma.tsx
@@ -16,14 +16,14 @@ figma.connect(
         sm: 'sm',
         md: 'md',
       }),
-      icon: figma.instance('leading-content'),
+      leadingContent: figma.instance('leading-content'),
       children: figma.string('label'),
     },
     example: (props) => (
       <MediaButton
         appearance={props.appearance}
         size={props.size}
-        leadingContent={props.icon}
+        leadingContent={props.leadingContent}
       >
         {props.children}
       </MediaButton>

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.figma.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.figma.tsx
@@ -23,7 +23,7 @@ figma.connect(
       <MediaButton
         appearance={props.appearance}
         size={props.size}
-        icon={props.icon}
+        leadingContent={props.icon}
       >
         {props.children}
       </MediaButton>

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.mdx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.mdx
@@ -28,9 +28,9 @@ Three appearances are available: `gray` (default), `transparent`, and `no-backgr
 
 <Canvas of={MediaButtonStories.SizeShowcase} />
 
-## Icon Types
+## Leading Content Shapes
 
-The `iconType` prop controls the padding scheme based on the leading icon's shape:
+The `leadingContentShape` prop controls the padding scheme based on the leading content's shape:
 
 - **`flat`**: Standard padding for interface icons (line icons without background).
 - **`rounded`**: Tighter left padding for circular icons with their own background (e.g., crypto icons).

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.mdx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.mdx
@@ -22,7 +22,7 @@ A specialized media button designed exclusively for select and dropdown patterns
 
 Three appearances are available: `gray` (default), `transparent`, and `no-background`.
 
-<Canvas of={MediaButtonStories.AllAppearancesWithIcons} />
+<Canvas of={MediaButtonStories.AllAppearancesWithLeadingShowcase} />
 
 ## Sizes
 
@@ -35,4 +35,4 @@ The `leadingContentShape` prop controls the padding scheme based on the leading 
 - **`flat`**: Standard padding for interface icons (line icons without background).
 - **`rounded`**: Tighter left padding for circular icons with their own background (e.g., crypto icons).
 
-<Canvas of={MediaButtonStories.IconTypeShowcase} />
+<Canvas of={MediaButtonStories.LeadingContentShapeShowcase} />

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.stories.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.stories.tsx
@@ -8,8 +8,8 @@ import type { MediaButtonProps } from './types';
 type Size = NonNullable<MediaButtonProps['size']>;
 
 const cryptoIconSizes = {
-  sm: '24px',
-  md: '32px',
+  sm: 24,
+  md: 32,
 } as const;
 
 const resolveIcon = (
@@ -121,7 +121,7 @@ export const IconTypeShowcase: Story = {
         </MediaButton>
         <MediaButton
           leadingContent={
-            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size='32px' />
+            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} />
           }
           leadingContentShape='rounded'
           appearance='gray'
@@ -141,7 +141,7 @@ export const IconTypeShowcase: Story = {
         </MediaButton>
         <MediaButton
           leadingContent={
-            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size='24px' />
+            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />
           }
           leadingContentShape='rounded'
           appearance='gray'
@@ -175,7 +175,7 @@ export const AllAppearancesWithIcons: Story = {
             <MediaButton
               appearance={appearance}
               leadingContent={
-                <CryptoIcon ledgerId='bitcoin' ticker='BTC' size='32px' />
+                <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} />
               }
               leadingContentShape='rounded'
             >

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.stories.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.stories.tsx
@@ -8,8 +8,8 @@ import type { MediaButtonProps } from './types';
 type Size = NonNullable<MediaButtonProps['size']>;
 
 const cryptoIconSizes = {
-  sm: 24,
-  md: 32,
+  sm: '24px',
+  md: '32px',
 } as const;
 
 const resolveIcon = (
@@ -50,11 +50,11 @@ const meta: Meta<typeof MediaButton> = {
     },
   },
   argTypes: {
-    icon: {
+    leadingContent: {
       control: 'select',
       options: ['None', 'Settings (flat)', 'Bitcoin (rounded)'],
     },
-    iconType: {
+    leadingContentShape: {
       control: 'select',
       options: ['flat', 'rounded'],
     },
@@ -72,14 +72,14 @@ export const Base: Story = {
     children: 'All accounts',
     appearance: 'gray',
   },
-  render: ({ icon, size, iconType, ...args }) => {
-    const resolved = resolveIcon(icon as string, size);
+  render: ({ leadingContent, size, leadingContentShape, ...args }) => {
+    const resolved = resolveIcon(leadingContent as string, size);
     return (
       <MediaButton
         {...args}
         size={size}
-        icon={resolved.node}
-        iconType={resolved.type ?? iconType}
+        leadingContent={resolved.node}
+        leadingContentShape={resolved.type ?? leadingContentShape}
       >
         {args.children}
       </MediaButton>
@@ -90,10 +90,18 @@ export const Base: Story = {
 export const SizeShowcase: Story = {
   render: () => (
     <div className='flex items-center gap-16'>
-      <MediaButton size='sm' icon={<Star size={20} />} iconType='flat'>
+      <MediaButton
+        size='sm'
+        leadingContent={<Star size={20} />}
+        leadingContentShape='flat'
+      >
         Small
       </MediaButton>
-      <MediaButton size='md' icon={<Star size={20} />} iconType='flat'>
+      <MediaButton
+        size='md'
+        leadingContent={<Star size={20} />}
+        leadingContentShape='flat'
+      >
         Medium
       </MediaButton>
     </div>
@@ -105,15 +113,17 @@ export const IconTypeShowcase: Story = {
     <div className='flex flex-col gap-16'>
       <div className='flex items-center gap-16'>
         <MediaButton
-          icon={<Settings size={20} />}
-          iconType='flat'
+          leadingContent={<Settings size={20} />}
+          leadingContentShape='flat'
           appearance='gray'
         >
           Flat icon (md)
         </MediaButton>
         <MediaButton
-          icon={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} />}
-          iconType='rounded'
+          leadingContent={
+            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size='32px' />
+          }
+          leadingContentShape='rounded'
           appearance='gray'
         >
           Rounded icon (md)
@@ -122,16 +132,18 @@ export const IconTypeShowcase: Story = {
       </div>
       <div className='flex items-center gap-16'>
         <MediaButton
-          icon={<Settings size={20} />}
-          iconType='flat'
+          leadingContent={<Settings size={20} />}
+          leadingContentShape='flat'
           appearance='gray'
           size='sm'
         >
           Flat icon (sm)
         </MediaButton>
         <MediaButton
-          icon={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />}
-          iconType='rounded'
+          leadingContent={
+            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size='24px' />
+          }
+          leadingContentShape='rounded'
           appearance='gray'
           size='sm'
         >
@@ -155,15 +167,17 @@ export const AllAppearancesWithIcons: Story = {
             <MediaButton appearance={appearance}>{appearance}</MediaButton>
             <MediaButton
               appearance={appearance}
-              icon={<Settings size={20} />}
-              iconType='flat'
+              leadingContent={<Settings size={20} />}
+              leadingContentShape='flat'
             >
               {appearance}
             </MediaButton>
             <MediaButton
               appearance={appearance}
-              icon={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} />}
-              iconType='rounded'
+              leadingContent={
+                <CryptoIcon ledgerId='bitcoin' ticker='BTC' size='32px' />
+              }
+              leadingContentShape='rounded'
             >
               {appearance}
             </MediaButton>

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.stories.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.stories.tsx
@@ -1,39 +1,7 @@
 import { CryptoIcon } from '@ledgerhq/crypto-icons';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { ReactNode } from 'react';
 import { Settings, Star } from '../../Symbols';
 import { MediaButton } from './MediaButton';
-import type { MediaButtonProps } from './types';
-
-type Size = NonNullable<MediaButtonProps['size']>;
-
-const cryptoIconSizes = {
-  sm: 24,
-  md: 32,
-} as const;
-
-const resolveIcon = (
-  iconKey: string | undefined,
-  size: Size = 'md',
-): { node?: ReactNode; type?: 'flat' | 'rounded' } => {
-  switch (iconKey) {
-    case 'Settings (flat)':
-      return { node: <Settings size={20} />, type: 'flat' };
-    case 'Bitcoin (rounded)':
-      return {
-        node: (
-          <CryptoIcon
-            ledgerId='bitcoin'
-            ticker='BTC'
-            size={cryptoIconSizes[size]}
-          />
-        ),
-        type: 'rounded',
-      };
-    default:
-      return {};
-  }
-};
 
 const meta: Meta<typeof MediaButton> = {
   component: MediaButton,
@@ -50,10 +18,6 @@ const meta: Meta<typeof MediaButton> = {
     },
   },
   argTypes: {
-    leadingContent: {
-      control: 'select',
-      options: ['None', 'Settings (flat)', 'Bitcoin (rounded)'],
-    },
     leadingContentShape: {
       control: 'select',
       options: ['flat', 'rounded'],
@@ -71,20 +35,13 @@ export const Base: Story = {
   args: {
     children: 'All accounts',
     appearance: 'gray',
+    leadingContentShape: 'flat',
   },
-  render: ({ leadingContent, size, leadingContentShape, ...args }) => {
-    const resolved = resolveIcon(leadingContent as string, size);
-    return (
-      <MediaButton
-        {...args}
-        size={size}
-        leadingContent={resolved.node}
-        leadingContentShape={resolved.type ?? leadingContentShape}
-      >
-        {args.children}
-      </MediaButton>
-    );
-  },
+  render: (args) => (
+    <MediaButton {...args} leadingContent={<Settings size={20} />}>
+      {args.children}
+    </MediaButton>
+  ),
 };
 
 export const SizeShowcase: Story = {
@@ -108,7 +65,7 @@ export const SizeShowcase: Story = {
   ),
 };
 
-export const IconTypeShowcase: Story = {
+export const LeadingContentShapeShowcase: Story = {
   render: () => (
     <div className='flex flex-col gap-16'>
       <div className='flex items-center gap-16'>
@@ -157,7 +114,7 @@ export const IconTypeShowcase: Story = {
   ),
 };
 
-export const AllAppearancesWithIcons: Story = {
+export const AllAppearancesWithLeadingShowcase: Story = {
   render: () => {
     const appearances = ['gray', 'transparent', 'no-background'] as const;
     return (

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.test.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.test.tsx
@@ -22,8 +22,8 @@ describe('MediaButton', () => {
   it('should render with a flat interface icon', () => {
     const { container } = render(
       <MediaButton
-        icon={<Settings size={20} data-testid='icon' />}
-        iconType='flat'
+        leadingContent={<Settings size={20} data-testid='icon' />}
+        leadingContentShape='flat'
       >
         Network
       </MediaButton>,
@@ -35,8 +35,8 @@ describe('MediaButton', () => {
   it('should render with a rounded icon', () => {
     render(
       <MediaButton
-        icon={<span data-testid='crypto-icon'>BTC</span>}
-        iconType='rounded'
+        leadingContent={<span data-testid='crypto-icon'>BTC</span>}
+        leadingContentShape='rounded'
       >
         Bitcoin
       </MediaButton>,

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
@@ -11,23 +11,23 @@ const triggerVariants = cva('gap-8 body-2-semi-bold', {
       sm: '',
       md: '',
     },
-    iconType: {
+    leadingContentShape: {
       flat: '',
       rounded: '',
       none: '',
     },
   },
   compoundVariants: [
-    { size: 'md', iconType: 'flat', class: 'px-16 py-12' },
-    { size: 'md', iconType: 'rounded', class: 'py-8 pr-16 pl-8' },
-    { size: 'md', iconType: 'none', class: 'px-16 py-14' },
-    { size: 'sm', iconType: 'flat', class: 'px-12 py-10' },
-    { size: 'sm', iconType: 'rounded', class: 'py-8 pr-10 pl-8' },
-    { size: 'sm', iconType: 'none', class: 'px-12 py-10' },
+    { size: 'md', leadingContentShape: 'flat', class: 'px-16 py-12' },
+    { size: 'md', leadingContentShape: 'rounded', class: 'py-8 pr-16 pl-8' },
+    { size: 'md', leadingContentShape: 'none', class: 'px-16 py-14' },
+    { size: 'sm', leadingContentShape: 'flat', class: 'px-12 py-10' },
+    { size: 'sm', leadingContentShape: 'rounded', class: 'py-8 pr-10 pl-8' },
+    { size: 'sm', leadingContentShape: 'none', class: 'px-12 py-10' },
   ],
   defaultVariants: {
     size: 'md',
-    iconType: 'none',
+    leadingContentShape: 'none',
   },
 });
 
@@ -65,8 +65,8 @@ export const MediaButton = ({
   size = 'md',
   disabled: disabledProp = false,
   asChild = false,
-  icon,
-  iconType = 'flat',
+  leadingContent,
+  leadingContentShape = 'flat',
   hideChevron = false,
   children,
   ...props
@@ -75,7 +75,10 @@ export const MediaButton = ({
     consumerName: 'MediaButton',
     mergeWith: { disabled: disabledProp },
   });
-  const effectiveIconType = icon ? iconType : 'none';
+  const effectiveLeadingContentShape = leadingContent
+    ? leadingContentShape
+    : 'none';
+
   const Comp = asChild ? Slot : 'button';
 
   return (
@@ -87,15 +90,20 @@ export const MediaButton = ({
           disabled,
           loading: false,
         }),
-        triggerVariants({ size, iconType: effectiveIconType }),
+        triggerVariants({
+          size,
+          leadingContentShape: effectiveLeadingContentShape,
+        }),
         className,
       )}
       data-disabled={disabled || undefined}
       disabled={disabled}
       {...props}
     >
-      {icon && (
-        <span className='inline-flex shrink-0 items-center'>{icon}</span>
+      {leadingContent && (
+        <span className='inline-flex shrink-0 items-center'>
+          {leadingContent}
+        </span>
       )}
       <span className='flex items-center gap-2'>
         {asChild ? (

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
@@ -51,7 +51,7 @@ const triggerVariants = cva('gap-8 body-2-semi-bold', {
  * </MediaButton>
  *
  * // With rounded crypto icon
- * <MediaButton leadingContent={<CryptoIcon ledgerId="bitcoin" size="32px" />} leadingContentShape="rounded">
+ * <MediaButton leadingContent={<CryptoIcon ledgerId="bitcoin" size={32} />} leadingContentShape="rounded">
  *   Bitcoin
  * </MediaButton>
  *

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
@@ -46,12 +46,12 @@ const triggerVariants = cva('gap-8 body-2-semi-bold', {
  * import { Settings } from '@ledgerhq/lumen-ui-react/symbols';
  *
  * // With flat interface icon
- * <MediaButton icon={<Settings size={20} />} iconType="flat">
+ * <MediaButton leadingContent={<Settings size={20} />} leadingContentShape="flat">
  *   Network
  * </MediaButton>
  *
  * // With rounded crypto icon
- * <MediaButton icon={<CryptoIcon ledgerId="bitcoin" size={32} />} iconType="rounded">
+ * <MediaButton leadingContent={<CryptoIcon ledgerId="bitcoin" size="32px" />} leadingContentShape="rounded">
  *   Bitcoin
  * </MediaButton>
  *

--- a/libs/ui-react/src/lib/Components/MediaButton/types.ts
+++ b/libs/ui-react/src/lib/Components/MediaButton/types.ts
@@ -13,19 +13,19 @@ export type MediaButtonProps = {
    */
   size?: 'sm' | 'md';
   /**
-   * An optional pre-rendered icon to display as leading content.
+   * An optional leading content, usually a pre-rendered icon.
    * Consumer is responsible for sizing the icon (typically 20px).
    */
-  icon?: ReactNode;
+  leadingContent?: ReactNode;
   /**
-   * Determines the padding scheme when an icon is present.
+   * Determines the padding scheme when `leadingContent` is present.
    * - `'flat'`: Standard padding for line/interface icons.
    * - `'rounded'`: Tighter left padding for circular icons with their own background (e.g., crypto icons).
    *
-   * Only relevant when `icon` is provided.
+   * Only relevant when `leadingContent` is provided.
    * @default 'flat'
    */
-  iconType?: 'flat' | 'rounded';
+  leadingContentShape?: 'flat' | 'rounded';
   /**
    * When true, hides the trailing chevron indicator.
    * @default false

--- a/libs/ui-react/src/lib/Components/NavBar/CoinCapsule.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/CoinCapsule.tsx
@@ -10,7 +10,7 @@ import type { CoinCapsuleProps } from './types';
 export const CoinCapsule = ({
   ref,
   ticker,
-  icon,
+  leadingContent,
   className,
 }: CoinCapsuleProps) => {
   return (
@@ -23,7 +23,7 @@ export const CoinCapsule = ({
       data-slot='coin-capsule'
     >
       <span className='flex size-24 shrink-0 items-center justify-center'>
-        {icon}
+        {leadingContent}
       </span>
       <span className='body-1 text-base select-none'>{ticker}</span>
     </div>

--- a/libs/ui-react/src/lib/Components/NavBar/CoinCapsule.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/CoinCapsule.tsx
@@ -3,7 +3,7 @@ import type { CoinCapsuleProps } from './types';
 
 /**
  * @internal
- * Internal component for displaying a cryptocurrency coin capsule with icon and ticker.
+ * Internal component for displaying a cryptocurrency coin capsule with leading content and ticker.
  * This component is not exported publicly. Use NavBarCoinCapsule instead for NavBar usage.
  * Kept as a separate component for potential future extraction as a standalone component.
  */

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.figma.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.figma.tsx
@@ -29,7 +29,7 @@ figma.connect(
           <NavBarCoinCapsule
             ticker='Bitcoin'
             leadingContent={
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size='24px' />
+              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />
             }
           />
         ),

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.figma.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.figma.tsx
@@ -28,7 +28,9 @@ figma.connect(
         'with-asset': (
           <NavBarCoinCapsule
             ticker='Bitcoin'
-            icon={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />}
+            leadingContent={
+              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size='24px' />
+            }
           />
         ),
       }),

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.mdx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.mdx
@@ -187,7 +187,7 @@ function AssetDetailPage() {
       <NavBarBackButton onClick={() => navigate(-1)} />
       <NavBarCoinCapsule
         ticker='BTC'
-        leadingContent={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size='24px' />}
+        leadingContent={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />}
       />
       <NavBarTrailing>
         <IconButton

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.mdx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.mdx
@@ -187,7 +187,7 @@ function AssetDetailPage() {
       <NavBarBackButton onClick={() => navigate(-1)} />
       <NavBarCoinCapsule
         ticker='BTC'
-        icon={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size='24px' />}
+        leadingContent={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size='24px' />}
       />
       <NavBarTrailing>
         <IconButton

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.stories.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.stories.tsx
@@ -243,7 +243,7 @@ export const WithCoinCapsule: Story = {
       <NavBarCoinCapsule
         ticker='BTC'
         leadingContent={
-          <CryptoIcon ledgerId='bitcoin' ticker='BTC' size='24px' />
+          <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />
         }
       />
       <NavBarTrailing>
@@ -265,7 +265,7 @@ import { NavBar, NavBarBackButton, NavBarCoinCapsule, NavBarTrailing, IconButton
 
 <NavBar>
   <NavBarBackButton onClick={() => navigate(-1)} />
-  <NavBarCoinCapsule ticker="BTC" leadingContent={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size="24px" />} />
+  <NavBarCoinCapsule ticker="BTC" leadingContent={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size={24} />} />
   <NavBarTrailing>
     <IconButton
       appearance="gray"

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.stories.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.stories.tsx
@@ -265,7 +265,7 @@ import { NavBar, NavBarBackButton, NavBarCoinCapsule, NavBarTrailing, IconButton
 
 <NavBar>
   <NavBarBackButton onClick={() => navigate(-1)} />
-  <NavBarCoinCapsule ticker="BTC" icon={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size={24} />} />
+  <NavBarCoinCapsule ticker="BTC" leadingContent={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size="24px" />} />
   <NavBarTrailing>
     <IconButton
       appearance="gray"

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.stories.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.stories.tsx
@@ -242,7 +242,9 @@ export const WithCoinCapsule: Story = {
       <NavBarBackButton onClick={() => console.log('Back clicked')} />
       <NavBarCoinCapsule
         ticker='BTC'
-        icon={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />}
+        leadingContent={
+          <CryptoIcon ledgerId='bitcoin' ticker='BTC' size='24px' />
+        }
       />
       <NavBarTrailing>
         <IconButton

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.test.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.test.tsx
@@ -142,7 +142,7 @@ describe('NavBar', () => {
 describe('NavBarCoinCapsule', () => {
   it('renders ticker and icon correctly', () => {
     const MockIcon = () => <svg data-testid='coin-icon' />;
-    render(<NavBarCoinCapsule ticker='BTC' icon={<MockIcon />} />);
+    render(<NavBarCoinCapsule ticker='BTC' leadingContent={<MockIcon />} />);
 
     expect(screen.getByText('BTC')).toBeInTheDocument();
     expect(screen.getByTestId('coin-icon')).toBeInTheDocument();
@@ -153,7 +153,7 @@ describe('NavBarCoinCapsule', () => {
     render(
       <NavBarCoinCapsule
         ticker='ETH'
-        icon={<MockIcon />}
+        leadingContent={<MockIcon />}
         className='bg-accent'
       />,
     );
@@ -166,14 +166,14 @@ describe('NavBarCoinCapsule', () => {
   it('renders different tickers', () => {
     const MockIcon = () => <svg />;
     const { rerender } = render(
-      <NavBarCoinCapsule ticker='BTC' icon={<MockIcon />} />,
+      <NavBarCoinCapsule ticker='BTC' leadingContent={<MockIcon />} />,
     );
     expect(screen.getByText('BTC')).toBeInTheDocument();
 
-    rerender(<NavBarCoinCapsule ticker='ETH' icon={<MockIcon />} />);
+    rerender(<NavBarCoinCapsule ticker='ETH' leadingContent={<MockIcon />} />);
     expect(screen.getByText('ETH')).toBeInTheDocument();
 
-    rerender(<NavBarCoinCapsule ticker='USDT' icon={<MockIcon />} />);
+    rerender(<NavBarCoinCapsule ticker='USDT' leadingContent={<MockIcon />} />);
     expect(screen.getByText('USDT')).toBeInTheDocument();
   });
 });
@@ -184,7 +184,7 @@ describe('NavBar with NavBarCoinCapsule', () => {
     render(
       <NavBar>
         <NavBarBackButton onClick={vi.fn()} />
-        <NavBarCoinCapsule ticker='BTC' icon={<MockIcon />} />
+        <NavBarCoinCapsule ticker='BTC' leadingContent={<MockIcon />} />
         <NavBarTrailing>
           <button>More</button>
         </NavBarTrailing>

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.test.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.test.tsx
@@ -140,7 +140,7 @@ describe('NavBar', () => {
 });
 
 describe('NavBarCoinCapsule', () => {
-  it('renders ticker and icon correctly', () => {
+  it('renders ticker and leading content correctly', () => {
     const MockIcon = () => <svg data-testid='coin-icon' />;
     render(<NavBarCoinCapsule ticker='BTC' leadingContent={<MockIcon />} />);
 

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.tsx
@@ -21,7 +21,7 @@ import type {
  * import { NavBar, NavBarBackButton, NavBarCoinCapsule, NavBarTrailing } from '@ledgerhq/lumen-ui-react';
  * import { CryptoIcon } from '@ledgerhq/crypto-icons';
  *
- * <NavBarCoinCapsule ticker="BTC" icon={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size={24} />} />
+ * <NavBarCoinCapsule ticker="BTC" leadingContent={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size="24px" />} />
  */
 export const NavBarCoinCapsule = ({
   ref,
@@ -204,7 +204,7 @@ export const NavBarTrailing = ({
  *
  * <NavBar>
  *   <NavBarBackButton onClick={handleBack} />
- *   <NavBarCoinCapsule ticker="BTC" icon={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size={24} />} />
+ *   <NavBarCoinCapsule ticker="BTC" leadingContent={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size="24px" />} />
  *   <NavBarTrailing>
  *     <IconButton icon={MoreHorizontal} aria-label="More options" />
  *   </NavBarTrailing>

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.tsx
@@ -21,7 +21,7 @@ import type {
  * import { NavBar, NavBarBackButton, NavBarCoinCapsule, NavBarTrailing } from '@ledgerhq/lumen-ui-react';
  * import { CryptoIcon } from '@ledgerhq/crypto-icons';
  *
- * <NavBarCoinCapsule ticker="BTC" leadingContent={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size="24px" />} />
+ * <NavBarCoinCapsule ticker="BTC" leadingContent={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size={24} />} />
  */
 export const NavBarCoinCapsule = ({
   ref,
@@ -204,7 +204,7 @@ export const NavBarTrailing = ({
  *
  * <NavBar>
  *   <NavBarBackButton onClick={handleBack} />
- *   <NavBarCoinCapsule ticker="BTC" leadingContent={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size="24px" />} />
+ *   <NavBarCoinCapsule ticker="BTC" leadingContent={<CryptoIcon ledgerId="bitcoin" ticker="BTC" size={24} />} />
  *   <NavBarTrailing>
  *     <IconButton icon={MoreHorizontal} aria-label="More options" />
  *   </NavBarTrailing>

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.tsx
@@ -15,7 +15,7 @@ import type {
 
 /**
  * A coin capsule component for displaying cryptocurrency information within the NavBar.
- * Shows an icon and ticker symbol in a pill-shaped container.
+ * Shows leading content (e.g., an icon) and ticker symbol in a pill-shaped container.
  *
  * @example
  * import { NavBar, NavBarBackButton, NavBarCoinCapsule, NavBarTrailing } from '@ledgerhq/lumen-ui-react';

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.tsx
@@ -26,11 +26,16 @@ import type {
 export const NavBarCoinCapsule = ({
   ref,
   ticker,
-  icon,
+  leadingContent,
   className,
 }: NavBarCoinCapsuleProps) => (
   <div className='flex flex-1 items-center' data-slot='navbar-coin-capsule'>
-    <CoinCapsule ref={ref} ticker={ticker} icon={icon} className={className} />
+    <CoinCapsule
+      ref={ref}
+      ticker={ticker}
+      leadingContent={leadingContent}
+      className={className}
+    />
   </div>
 );
 

--- a/libs/ui-react/src/lib/Components/NavBar/types.ts
+++ b/libs/ui-react/src/lib/Components/NavBar/types.ts
@@ -87,9 +87,9 @@ export type CoinCapsuleProps = {
    */
   ticker: string;
   /**
-   * The icon element to display (typically a crypto coin icon).
+   * The leading content, typically a crypto coin icon.
    */
-  icon: ReactNode;
+  leadingContent: ReactNode;
   /**
    * Additional custom CSS classes to apply.
    */

--- a/libs/ui-react/src/lib/Components/Select/Select.mdx
+++ b/libs/ui-react/src/lib/Components/Select/Select.mdx
@@ -535,7 +535,7 @@ The `SelectTrigger` component accepts an optional `render` prop that replaces th
 
 #### Using `MediaButton`
 
-Use `MediaButton` directly as a button-style trigger. It accepts props like `appearance`, `size`, `icon`, and `iconType`.
+Use `MediaButton` directly as a button-style trigger. It accepts props like `appearance`, `size`, `leadingContent`, and `leadingContentShape`.
 
 ```tsx
 import {
@@ -560,7 +560,7 @@ function MyComponent() {
     <Select items={accountOptions} value={value} onValueChange={setValue}>
       <SelectTrigger
         render={({ selectedValue, selectedContent }) => (
-          <MediaButton icon={<Settings size={20} />} iconType='flat'>
+          <MediaButton leadingContent={<Settings size={20} />} leadingContentShape='flat'>
             {selectedValue ? selectedContent : 'All accounts'}
           </MediaButton>
         )}

--- a/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
@@ -536,7 +536,10 @@ export const TriggerShowcase: Story = {
         >
           <SelectTrigger
             render={({ selectedValue, selectedContent }) => (
-              <MediaButton icon={<Settings size={20} />} iconType='flat'>
+              <MediaButton
+                leadingContent={<Settings size={20} />}
+                leadingContentShape='flat'
+              >
                 {selectedValue ? selectedContent : 'Settings'}
               </MediaButton>
             )}
@@ -560,16 +563,16 @@ export const TriggerShowcase: Story = {
           <SelectTrigger
             render={({ selectedValue, selectedContent }) => (
               <MediaButton
-                icon={
+                leadingContent={
                   selectedCrypto ? (
                     <CryptoIcon
                       ledgerId={(selectedCrypto.meta?.ledgerId as string) ?? ''}
                       ticker={(selectedCrypto.meta?.ticker as string) ?? ''}
-                      size={32}
+                      size='32px'
                     />
                   ) : undefined
                 }
-                iconType='rounded'
+                leadingContentShape='rounded'
               >
                 {selectedValue ? selectedContent : 'Network'}
               </MediaButton>
@@ -586,7 +589,7 @@ export const TriggerShowcase: Story = {
                   <CryptoIcon
                     ledgerId={(crypto.meta?.ledgerId as string) ?? ''}
                     ticker={(crypto.meta?.ticker as string) ?? ''}
-                    size={24}
+                    size='24px'
                   />
                   <SelectItemText>{crypto.label}</SelectItemText>
                 </SelectItem>
@@ -741,7 +744,7 @@ export const LeadingContentShowcase: Story = {
                     <CryptoIcon
                       ledgerId={(item.meta?.ledgerId as string) ?? ''}
                       ticker={(item.meta?.ticker as string) ?? ''}
-                      size={24}
+                      size='24px'
                     />
                     <SelectItemText>{item.label}</SelectItemText>
                   </SelectItem>
@@ -766,7 +769,7 @@ export const LeadingContentShowcase: Story = {
                     <CryptoIcon
                       ledgerId={(item.meta?.ledgerId as string) ?? ''}
                       ticker={(item.meta?.ticker as string) ?? ''}
-                      size={32}
+                      size='32px'
                     />
                     <SelectItemContent>
                       <SelectItemText>{item.label}</SelectItemText>

--- a/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
@@ -568,7 +568,7 @@ export const TriggerShowcase: Story = {
                     <CryptoIcon
                       ledgerId={(selectedCrypto.meta?.ledgerId as string) ?? ''}
                       ticker={(selectedCrypto.meta?.ticker as string) ?? ''}
-                      size='32px'
+                      size={32}
                     />
                   ) : undefined
                 }
@@ -589,7 +589,7 @@ export const TriggerShowcase: Story = {
                   <CryptoIcon
                     ledgerId={(crypto.meta?.ledgerId as string) ?? ''}
                     ticker={(crypto.meta?.ticker as string) ?? ''}
-                    size='24px'
+                    size={24}
                   />
                   <SelectItemText>{crypto.label}</SelectItemText>
                 </SelectItem>
@@ -744,7 +744,7 @@ export const LeadingContentShowcase: Story = {
                     <CryptoIcon
                       ledgerId={(item.meta?.ledgerId as string) ?? ''}
                       ticker={(item.meta?.ticker as string) ?? ''}
-                      size='24px'
+                      size={24}
                     />
                     <SelectItemText>{item.label}</SelectItemText>
                   </SelectItem>
@@ -769,7 +769,7 @@ export const LeadingContentShowcase: Story = {
                     <CryptoIcon
                       ledgerId={(item.meta?.ledgerId as string) ?? ''}
                       ticker={(item.meta?.ticker as string) ?? ''}
-                      size='32px'
+                      size={32}
                     />
                     <SelectItemContent>
                       <SelectItemText>{item.label}</SelectItemText>

--- a/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.mdx
+++ b/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.mdx
@@ -32,9 +32,9 @@ Three appearances are available: `gray` (default), `transparent`, and `no-backgr
 
 <Canvas of={MediaButtonStories.SizeShowcase} />
 
-## Icon Types
+## Leading Content Shapes
 
-The `iconType` prop controls the padding scheme based on the leading icon's shape:
+The `leadingContentShape` prop controls the padding scheme based on the leading content's shape:
 
 - **`flat`**: Standard padding for interface icons (line icons without background).
 - **`rounded`**: Tighter left padding for circular icons with their own background (e.g., crypto icons).

--- a/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.mdx
+++ b/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.mdx
@@ -39,6 +39,6 @@ The `leadingContentShape` prop controls the padding scheme based on the leading 
 - **`flat`**: Standard padding for interface icons (line icons without background).
 - **`rounded`**: Tighter left padding for circular icons with their own background (e.g., crypto icons).
 
-<Canvas of={MediaButtonStories.IconTypeShowcase} />
+<Canvas of={MediaButtonStories.LeadingContentShapeShowcase} />
 </Tab>
 </CustomTabs>

--- a/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.stories.tsx
@@ -44,10 +44,18 @@ export const Base: Story = {
 export const SizeShowcase: Story = {
   render: () => (
     <Box lx={{ flexDirection: 'row', alignItems: 'center', gap: 's16' }}>
-      <MediaButton size='sm' icon={<Star size={20} />} iconType='flat'>
+      <MediaButton
+        size='sm'
+        leadingContent={<Star size={20} />}
+        leadingContentShape='flat'
+      >
         Small
       </MediaButton>
-      <MediaButton size='md' icon={<Star size={20} />} iconType='flat'>
+      <MediaButton
+        size='md'
+        leadingContent={<Star size={20} />}
+        leadingContentShape='flat'
+      >
         Medium
       </MediaButton>
     </Box>
@@ -59,15 +67,17 @@ export const IconTypeShowcase: Story = {
     <Box lx={{ flexDirection: 'column', gap: 's16' }}>
       <Box lx={{ flexDirection: 'row', alignItems: 'center', gap: 's16' }}>
         <MediaButton
-          icon={<Settings size={20} />}
-          iconType='flat'
+          leadingContent={<Settings size={20} />}
+          leadingContentShape='flat'
           appearance='gray'
         >
           Flat icon (md)
         </MediaButton>
         <MediaButton
-          icon={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} />}
-          iconType='rounded'
+          leadingContent={
+            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} />
+          }
+          leadingContentShape='rounded'
           appearance='gray'
         >
           Rounded icon (md)
@@ -76,16 +86,18 @@ export const IconTypeShowcase: Story = {
       </Box>
       <Box lx={{ flexDirection: 'row', alignItems: 'center', gap: 's16' }}>
         <MediaButton
-          icon={<Settings size={20} />}
-          iconType='flat'
+          leadingContent={<Settings size={20} />}
+          leadingContentShape='flat'
           appearance='gray'
           size='sm'
         >
           Flat icon (sm)
         </MediaButton>
         <MediaButton
-          icon={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />}
-          iconType='rounded'
+          leadingContent={
+            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />
+          }
+          leadingContentShape='rounded'
           appearance='gray'
           size='sm'
         >
@@ -112,15 +124,17 @@ export const AppearanceShowcase: Story = {
             <MediaButton appearance={appearance}>{appearance}</MediaButton>
             <MediaButton
               appearance={appearance}
-              icon={<Settings size={20} />}
-              iconType='flat'
+              leadingContent={<Settings size={20} />}
+              leadingContentShape='flat'
             >
               {appearance}
             </MediaButton>
             <MediaButton
               appearance={appearance}
-              icon={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} />}
-              iconType='rounded'
+              leadingContent={
+                <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} />
+              }
+              leadingContentShape='rounded'
             >
               {appearance}
             </MediaButton>

--- a/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.stories.tsx
@@ -62,7 +62,7 @@ export const SizeShowcase: Story = {
   ),
 };
 
-export const IconTypeShowcase: Story = {
+export const LeadingContentShapeShowcase: Story = {
   render: () => (
     <Box lx={{ flexDirection: 'column', gap: 's16' }}>
       <Box lx={{ flexDirection: 'row', alignItems: 'center', gap: 's16' }}>

--- a/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.test.tsx
@@ -64,8 +64,8 @@ describe('MediaButton', () => {
       renderWithProvider(
         <MediaButton
           testID='trigger'
-          icon={<Settings size={20} testID='icon' />}
-          iconType='flat'
+          leadingContent={<Settings size={20} testID='icon' />}
+          leadingContentShape='flat'
         >
           Network
         </MediaButton>,
@@ -78,8 +78,8 @@ describe('MediaButton', () => {
       renderWithProvider(
         <MediaButton
           testID='trigger'
-          icon={<View testID='crypto-icon' />}
-          iconType='rounded'
+          leadingContent={<View testID='crypto-icon' />}
+          leadingContentShape='rounded'
         >
           Bitcoin
         </MediaButton>,

--- a/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.tsx
+++ b/libs/ui-rnative/src/lib/Components/MediaButton/MediaButton.tsx
@@ -7,20 +7,20 @@ import type { MediaButtonProps } from './types';
 
 type Appearance = NonNullable<MediaButtonProps['appearance']>;
 type Size = NonNullable<MediaButtonProps['size']>;
-type IconType = 'flat' | 'rounded' | 'none';
+type LeadingContentShape = 'flat' | 'rounded' | 'none';
 
 const useStyles = ({
   appearance,
   size,
   disabled,
   pressed,
-  iconType,
+  leadingContentShape,
 }: {
   appearance: Appearance;
   size: Size;
   disabled: boolean;
   pressed: boolean;
-  iconType: IconType;
+  leadingContentShape: LeadingContentShape;
 }) => {
   return useStyleSheet(
     (t) => {
@@ -45,7 +45,10 @@ const useStyles = ({
         paddingRight: number;
       };
 
-      const paddingMap: Record<Size, Record<IconType, PaddingStyle>> = {
+      const paddingMap: Record<
+        Size,
+        Record<LeadingContentShape, PaddingStyle>
+      > = {
         md: {
           flat: {
             paddingTop: t.spacings.s12,
@@ -97,7 +100,7 @@ const useStyles = ({
             backgroundColor: bgColors[appearance],
             gap: t.spacings.s8,
           },
-          paddingMap[size][iconType],
+          paddingMap[size][leadingContentShape],
           pressed && { backgroundColor: pressedBgColors[appearance] },
           disabled && { backgroundColor: t.colors.bg.disabled },
           appearance === 'no-background' &&
@@ -115,7 +118,7 @@ const useStyles = ({
           alignItems: 'center',
           gap: t.spacings.s2,
         },
-        icon: {
+        leadingContent: {
           flexShrink: 0,
         },
         chevron: {
@@ -124,13 +127,13 @@ const useStyles = ({
         },
       };
     },
-    [appearance, size, disabled, pressed, iconType],
+    [appearance, size, disabled, pressed, leadingContentShape],
   );
 };
 
 /**
  * Media button for select/dropdown components. Displays a label with an optional
- * leading icon and a trailing chevron indicator.
+ * leading content and a trailing chevron indicator.
  *
  * This component is intended to be used exclusively as the trigger inside a Select or
  * dropdown pattern. It should not be used as a standalone action button — use `Button`
@@ -142,7 +145,7 @@ const useStyles = ({
  * import { MediaButton } from '@ledgerhq/lumen-ui-rnative';
  * import { Settings } from '@ledgerhq/lumen-ui-rnative/symbols';
  *
- * <MediaButton icon={<Settings size={20} />} iconType="flat">
+ * <MediaButton leadingContent={<Settings size={20} />} leadingContentShape="flat">
  *   Network
  * </MediaButton>
  *
@@ -154,14 +157,16 @@ export const MediaButton = ({
   appearance = 'gray',
   size = 'md',
   disabled = false,
-  icon,
-  iconType = 'flat',
+  leadingContent,
+  leadingContentShape = 'flat',
   hideChevron = false,
   children: label,
   ref,
   ...props
 }: MediaButtonProps) => {
-  const effectiveIconType: IconType = icon ? iconType : 'none';
+  const effectiveLeadingContentShape: LeadingContentShape = leadingContent
+    ? leadingContentShape
+    : 'none';
 
   return (
     <Pressable
@@ -179,8 +184,8 @@ export const MediaButton = ({
           size={size}
           disabled={disabled}
           pressed={pressed}
-          iconType={effectiveIconType}
-          icon={icon}
+          leadingContent={leadingContent}
+          leadingContentShape={effectiveLeadingContentShape}
           hideChevron={hideChevron}
         >
           {label}
@@ -195,8 +200,8 @@ type MediaButtonContentProps = PropsWithChildren<{
   size: Size;
   disabled: boolean;
   pressed: boolean;
-  iconType: IconType;
-  icon?: MediaButtonProps['icon'];
+  leadingContent?: MediaButtonProps['leadingContent'];
+  leadingContentShape: LeadingContentShape;
   hideChevron: boolean;
 }>;
 
@@ -205,16 +210,24 @@ const MediaButtonContent = ({
   size,
   disabled,
   pressed,
-  iconType,
-  icon,
+  leadingContent,
+  leadingContentShape,
   hideChevron,
   children,
 }: MediaButtonContentProps) => {
-  const styles = useStyles({ appearance, size, disabled, pressed, iconType });
+  const styles = useStyles({
+    appearance,
+    size,
+    disabled,
+    pressed,
+    leadingContentShape,
+  });
 
   return (
     <View style={styles.container} testID='button-trigger-content'>
-      {icon && <View style={styles.icon}>{icon}</View>}
+      {leadingContent && (
+        <View style={styles.leadingContent}>{leadingContent}</View>
+      )}
       <View style={styles.labelWrapper}>
         <Text style={styles.label} numberOfLines={1} ellipsizeMode='tail'>
           {children}

--- a/libs/ui-rnative/src/lib/Components/MediaButton/types.ts
+++ b/libs/ui-rnative/src/lib/Components/MediaButton/types.ts
@@ -13,19 +13,19 @@ export type MediaButtonProps = {
    */
   size?: 'sm' | 'md';
   /**
-   * An optional pre-rendered icon element to display as leading content.
-   * Consumer is responsible for sizing the icon.
+   * An optional leading content, usually a pre-rendered icon.
+   * Consumer is responsible for sizing the icon (typically 20px).
    */
-  icon?: ReactNode;
+  leadingContent?: ReactNode;
   /**
-   * Determines the padding scheme when an icon is present.
+   * Determines the padding scheme when `leadingContent` is present.
    * - `'flat'`: Standard padding for line/interface icons.
    * - `'rounded'`: Tighter left padding for circular icons with their own background (e.g., crypto icons).
    *
-   * Only relevant when `icon` is provided.
+   * Only relevant when `leadingContent` is provided.
    * @default 'flat'
    */
-  iconType?: 'flat' | 'rounded';
+  leadingContentShape?: 'flat' | 'rounded';
   /**
    * When true, hides the trailing chevron indicator.
    * @default false

--- a/libs/ui-rnative/src/lib/Components/NavBar/CoinCapsule.tsx
+++ b/libs/ui-rnative/src/lib/Components/NavBar/CoinCapsule.tsx
@@ -2,12 +2,12 @@ import { useStyleSheet } from '../../../styles';
 import { Box, Text } from '../Utility';
 import type { CoinCapsuleProps } from './types';
 
-export function CoinCapsule({ ticker, icon }: CoinCapsuleProps) {
+export function CoinCapsule({ ticker, leadingContent }: CoinCapsuleProps) {
   const styles = useStyles();
 
   return (
     <Box style={styles.container}>
-      {icon}
+      {leadingContent}
       <Text style={styles.text}>{ticker}</Text>
     </Box>
   );

--- a/libs/ui-rnative/src/lib/Components/NavBar/NavBar.mdx
+++ b/libs/ui-rnative/src/lib/Components/NavBar/NavBar.mdx
@@ -135,7 +135,7 @@ import { NavBarCoinCapsule } from '@ledgerhq/lumen-ui-rnative';
   <NavBarContent>
     <NavBarCoinCapsule
       ticker='BTC'
-      icon={<Icon ledgerId='bitcoin' ticker='BTC' size={24} />}
+      leadingContent={<Icon ledgerId='bitcoin' ticker='BTC' size={24} />}
     />
     <NavBarTitle>Bitcoin</NavBarTitle>
   </NavBarContent>

--- a/libs/ui-rnative/src/lib/Components/NavBar/NavBar.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/NavBar/NavBar.stories.tsx
@@ -111,7 +111,9 @@ export const WithCoinCapsule: Story = {
       <NavBarContent>
         <NavBarCoinCapsule
           ticker='BTC'
-          icon={<CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />}
+          leadingContent={
+            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />
+          }
         />
       </NavBarContent>
       <NavBarTrailing>

--- a/libs/ui-rnative/src/lib/Components/NavBar/NavBar.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/NavBar/NavBar.test.tsx
@@ -252,7 +252,7 @@ describe('NavBar', () => {
   });
 
   describe('NavBarCoinCapsule', () => {
-    it('should render ticker and icon', () => {
+    it('should render ticker and leading content', () => {
       renderWithProvider(
         <NavBar density='compact'>
           <NavBarContent>

--- a/libs/ui-rnative/src/lib/Components/NavBar/NavBar.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/NavBar/NavBar.test.tsx
@@ -69,7 +69,7 @@ describe('NavBar', () => {
       renderWithProvider(
         <NavBar testID='navbar' density='compact'>
           <NavBarContent>
-            <NavBarCoinCapsule ticker='BTC' icon={<MockIcon />} />
+            <NavBarCoinCapsule ticker='BTC' leadingContent={<MockIcon />} />
           </NavBarContent>
         </NavBar>,
       );
@@ -256,7 +256,7 @@ describe('NavBar', () => {
       renderWithProvider(
         <NavBar density='compact'>
           <NavBarContent>
-            <NavBarCoinCapsule ticker='ETH' icon={<MockIcon />} />
+            <NavBarCoinCapsule ticker='ETH' leadingContent={<MockIcon />} />
           </NavBarContent>
         </NavBar>,
       );

--- a/libs/ui-rnative/src/lib/Components/NavBar/NavBar.tsx
+++ b/libs/ui-rnative/src/lib/Components/NavBar/NavBar.tsx
@@ -122,12 +122,12 @@ export function NavBarDescription({
 
 export function NavBarCoinCapsule({
   ticker,
-  icon,
+  leadingContent,
   ...props
 }: NavBarCoinCapsuleProps) {
   return (
     <Box {...props}>
-      <CoinCapsule ticker={ticker} icon={icon} />
+      <CoinCapsule ticker={ticker} leadingContent={leadingContent} />
     </Box>
   );
 }

--- a/libs/ui-rnative/src/lib/Components/NavBar/types.ts
+++ b/libs/ui-rnative/src/lib/Components/NavBar/types.ts
@@ -57,9 +57,9 @@ export type CoinCapsuleProps = {
    */
   ticker: string;
   /**
-   * The icon element to display (typically a crypto coin icon).
+   * The leading content, typically a crypto coin icon.
    */
-  icon: ReactElement;
+  leadingContent: ReactElement;
 } & Omit<StyledViewProps, 'children'>;
 
 /**

--- a/libs/ui-rnative/src/lib/Components/NavBar/types.ts
+++ b/libs/ui-rnative/src/lib/Components/NavBar/types.ts
@@ -1,5 +1,5 @@
 import type { Density } from '@ledgerhq/lumen-utils-shared';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import type { StyledViewProps } from '../../../styles';
 import type { IconButtonProps } from '../IconButton';
 
@@ -59,7 +59,7 @@ export type CoinCapsuleProps = {
   /**
    * The leading content, typically a crypto coin icon.
    */
-  leadingContent: ReactElement;
+  leadingContent: ReactNode;
 } & Omit<StyledViewProps, 'children'>;
 
 /**

--- a/libs/ui-rnative/src/lib/Components/OptionList/OptionList.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/OptionList/OptionList.stories.tsx
@@ -865,8 +865,8 @@ export const TriggerShowcase: Story = {
         <MediaButton
           appearance='gray'
           onPress={() => iconRef.current?.present()}
-          icon={<Settings size={20} />}
-          iconType='flat'
+          leadingContent={<Settings size={20} />}
+          leadingContentShape='flat'
         >
           {selectedIcon?.label ?? 'Settings'}
         </MediaButton>
@@ -874,7 +874,7 @@ export const TriggerShowcase: Story = {
         <MediaButton
           appearance='gray'
           onPress={() => cryptoRef.current?.present()}
-          icon={
+          leadingContent={
             selectedCrypto?.meta ? (
               <CryptoIcon
                 ledgerId={selectedCrypto.meta.ledgerId as string}
@@ -883,7 +883,7 @@ export const TriggerShowcase: Story = {
               />
             ) : undefined
           }
-          iconType='rounded'
+          leadingContentShape='rounded'
         >
           {selectedCrypto?.label ?? 'Network'}
         </MediaButton>


### PR DESCRIPTION
Closes [DLS-730](https://ledgerhq.atlassian.net/browse/DLS-730).

## Considerations

* On ui-rnative, changed CoinCapsule's icon/leading content type from `ReactElement` -> `ReactNode` because the constraint isn't load-bearing: there's no clone or children traversal to justify it being a `ReactElement`, it just renders `{ leadingContent }` directly. Also consistency with ui-react.

[DLS-730]: https://ledgerhq.atlassian.net/browse/DLS-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ