### PR TITLE
fix(Card.stories): remove unnecessary opacity wrapper around CryptoIcon

### DIFF
--- a/libs/ui-react/src/lib/Components/Card/Card.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Card/Card.stories.tsx
@@ -158,9 +158,7 @@ export const StatesShowcase: Story = {
       <Card {...args} className='w-320' disabled>
         <CardHeader>
           <CardLeading>
-            <div className='opacity-30'>
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
-            </div>
+            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
             <CardContent>
               <CardContentTitle>Disabled</CardContentTitle>
               <CardContentDescription>Non-interactive</CardContentDescription>

--- a/libs/ui-rnative/src/lib/Components/Card/Card.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/Card/Card.stories.tsx
@@ -196,9 +196,7 @@ export const StatesShowcase: Story = {
       <Card {...args} lx={{ width: 's320' }} disabled>
         <CardHeader>
           <CardLeading>
-            <Box lx={{ opacity: 0.3 }}>
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
-            </Box>
+            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
             <CardContent>
               <CardContentTitle>Disabled</CardContentTitle>
               <CardContentDescription>Non-interactive</CardContentDescription>


### PR DESCRIPTION
<img width="1333" height="148" alt="Screenshot 2026-05-28 at 10 37 00" src="https://github.com/user-attachments/assets/bd9e95ee-4a11-43fc-acbd-bb8a892130e3" />
