### PR TITLE
feat(nx): add version plan check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,21 @@ env:
   NX_NO_CLOUD: true
 
 jobs:
+  version-plan-check:
+    name: Version Plan Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - name: Check that affected publishable libs have a version plan
+        run: npx nx release plan:check --base=origin/main --verbose
+
   static-analysis:
     name: Static Analysis
     runs-on: ubuntu-latest

--- a/nx.json
+++ b/nx.json
@@ -157,7 +157,16 @@
       "libs/*"
     ],
     "projectsRelationship": "independent",
-    "versionPlans": true,
+    "versionPlans": {
+      "ignorePatternsForPlanCheck": [
+        "**/*.stories.@(ts|tsx|js|jsx|mdx)",
+        "**/*.test.@(ts|tsx)",
+        "**/*.spec.@(ts|tsx)",
+        "**/*.md",
+        "**/*.mdx",
+        "**/*.figma.@(ts|tsx)"
+      ]
+    },
     "version": {
       "preVersionCommand": "npx nx run-many -t build --projects='libs/*'",
       "updateDependents": "auto"

--- a/nx.json
+++ b/nx.json
@@ -159,9 +159,16 @@
     "projectsRelationship": "independent",
     "versionPlans": {
       "ignorePatternsForPlanCheck": [
-        "**/*.stories.@(ts|tsx|js|jsx|mdx)",
-        "**/*.test.@(ts|tsx)",
-        "**/*.spec.@(ts|tsx)",
+        "**/.eslintrc.json",
+        "**/eslint.config.mjs",
+        "**/*.spec.{js,jsx,ts,tsx}",
+        "**/*.test.{js,jsx,ts,tsx}",
+        "**/*.snap",
+        "**/tsconfig*.json",
+        "**/test-setup.{js,ts}",
+        "**/*.stories.{js,jsx,ts,tsx,mdx}",
+        "**/.storybook/**",
+        "**/jest.config.{js,ts}",
         "**/*.md",
         "**/*.mdx",
         "**/*.figma.@(ts|tsx)"


### PR DESCRIPTION
`nx.json` — replaced `"versionPlans": true` with an object that adds `ignorePatternsForPlanCheck`, excluding:
- *.stories.* — storybook files
- *.test.* / *.spec.* — unit tests
- *.md / *.mdx — docs
- *.figma.* — code connect files
--> These are all "non-shipping" changes that shouldn't mandate a release plan.

`.github/workflows/pr.yml` — added a new `version-plan-check` job that runs before static analysis. On any PR touching a publishable lib without a matching version plan, it will fail with the list of offending projects and tell contributors to run nx release plan.