### PR TITLE
BREAKING_CHANGE: update DotIndicator sizes

### DIFF
--- a/.nx/version-plans/version-plan-1780069206903-react.md
+++ b/.nx/version-plans/version-plan-1780069206903-react.md
@@ -4,15 +4,17 @@
 
 BREAKING_CHANGE(ui-react): update DotIndicator sizes
 
-The `DotIndicator` size scale has shifted by one step. The previous scale (`xs | sm | md | lg`) has been replaced by (`sm | md | lg | xl`), and the default size is now `md` instead of `sm`. The underlying pixel sizes have also been reduced: the new `sm` is smaller than the old `sm`, so consumers that previously relied on the default will see a smaller dot unless they migrate.
+The `DotIndicator` size scale has been renamed and rescaled. The previous scale (`xs | sm | md | lg`) has been replaced by (`sm | md | lg | xl`), and the default size is now `md` instead of `sm`. The underlying token sizes have been reduced overall. The names did not simply shift down by one. Old `md` (`s14`) and old `lg` (`s16`) have no equivalent in the new scale.
 
 ### Migration
 
-Rename `size` values one step down the scale to preserve the previous visual size:
+The new sizes map to the old as follows, matched by token size:
 
-- `size="xs"` → `size="sm"`
-- `size="sm"` → `size="md"` (also the new default, it can be omitted)
-- `size="md"` → `size="lg"`
-- `size="lg"` → `size="xl"`
+- `size="xs"` (`s10`) → `size="lg"` (`s10`)
+- `size="sm"` (`s12`) → `size="xl"` (`s12`)
+- `size="md"` (`s14`) → no exact equivalent
+- `size="lg"` (`s16`) → no exact equivalent
 
-If you were relying on the default (no `size` prop) and want to keep the previous rendered size, pass `size="sm"` explicitly. The `Avatar` component now uses `DotIndicator` internally for its notification dot. No consumer changes are required there, but note that `showNotification` is now only rendered on Avatar `sm` and `md` sizes (suppressed on `lg`/`xl`).
+If you were relying on the default (no `size` prop) and want to keep the previous rendered size, pass `size="xl"` explicitly. Consumers previously using `md` or `lg` will end up with a smaller dot! Please review whether that is desirable for the design.
+
+The `Avatar` component's internal `dotSizeMap` has been updated to match. No consumer changes are required there, but note that `showNotification` is now only rendered on Avatar `sm` and `md` sizes (suppressed on `lg`/`xl`).

--- a/.nx/version-plans/version-plan-1780069206903-react.md
+++ b/.nx/version-plans/version-plan-1780069206903-react.md
@@ -1,0 +1,18 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+BREAKING_CHANGE(ui-react): update DotIndicator sizes
+
+The `DotIndicator` size scale has shifted by one step. The previous scale (`xs | sm | md | lg`) has been replaced by (`sm | md | lg | xl`), and the default size is now `md` instead of `sm`. The underlying pixel sizes have also been reduced: the new `sm` is smaller than the old `sm`, so consumers that previously relied on the default will see a smaller dot unless they migrate.
+
+### Migration
+
+Rename `size` values one step down the scale to preserve the previous visual size:
+
+- `size="xs"` → `size="sm"`
+- `size="sm"` → `size="md"` (also the new default, it can be omitted)
+- `size="md"` → `size="lg"`
+- `size="lg"` → `size="xl"`
+
+If you were relying on the default (no `size` prop) and want to keep the previous rendered size, pass `size="sm"` explicitly. The `Avatar` component now uses `DotIndicator` internally for its notification dot. No consumer changes are required there, but note that `showNotification` is now only rendered on Avatar `sm` and `md` sizes (suppressed on `lg`/`xl`).

--- a/.nx/version-plans/version-plan-1780069206903-react.md
+++ b/.nx/version-plans/version-plan-1780069206903-react.md
@@ -2,7 +2,7 @@
 '@ledgerhq/lumen-ui-react': patch
 ---
 
-BREAKING_CHANGE(ui-react): update DotIndicator sizes
+BREAKING_CHANGE(DotIndicator): update DotIndicator sizes
 
 The `DotIndicator` size scale has been renamed and rescaled. The previous scale (`xs | sm | md | lg`) has been replaced by (`sm | md | lg | xl`), and the default size is now `md` instead of `sm`. The underlying token sizes have been reduced overall. The names did not simply shift down by one. Old `md` (`s14`) and old `lg` (`s16`) have no equivalent in the new scale.
 

--- a/.nx/version-plans/version-plan-1780069206903-rnative.md
+++ b/.nx/version-plans/version-plan-1780069206903-rnative.md
@@ -4,15 +4,17 @@
 
 BREAKING_CHANGE(ui-rnative): update DotIndicator sizes
 
-The `DotIndicator` size scale has shifted by one step. The previous scale (`xs | sm | md | lg`) has been replaced by (`sm | md | lg | xl`), and the default size is now `md` instead of `sm`. The underlying pixel sizes have also been reduced: the new `sm` is smaller than the old `sm`, so consumers that previously relied on the default will see a smaller dot unless they migrate.
+The `DotIndicator` size scale has been renamed and rescaled. The previous scale (`xs | sm | md | lg`) has been replaced by (`sm | md | lg | xl`), and the default size is now `md` instead of `sm`. The underlying token sizes have been reduced overall. The names did not simply shift down by one. Old `md` (`s14`) and old `lg` (`s16`) have no equivalent in the new scale.
 
 ### Migration
 
-Rename `size` values one step down the scale to preserve the previous visual size:
+The new sizes map to the old as follows, matched by token size:
 
-- `size="xs"` → `size="sm"`
-- `size="sm"` → `size="md"` (also the new default, it can be omitted)
-- `size="md"` → `size="lg"`
-- `size="lg"` → `size="xl"`
+- `size="xs"` (`s10`) → `size="lg"` (`s10`)
+- `size="sm"` (`s12`) → `size="xl"` (`s12`)
+- `size="md"` (`s14`) → no exact equivalent
+- `size="lg"` (`s16`) → no exact equivalent
 
-If you were relying on the default (no `size` prop) and want to keep the previous rendered size, pass `size="sm"` explicitly. The `Avatar` component now uses `DotIndicator` internally for its notification dot. No consumer changes are required there, but note that `showNotification` is now only rendered on Avatar `sm` and `md` sizes (suppressed on `lg`/`xl`).
+If you were relying on the default (no `size` prop) and want to keep the previous rendered size, pass `size="xl"` explicitly. Consumers previously using `md` or `lg` will end up with a smaller dot! Please review whether that is desirable for the design.
+
+The `Avatar` component's internal `dotSizeMap` has been updated to match. No consumer changes are required there, but note that `showNotification` is now only rendered on Avatar `sm` and `md` sizes (suppressed on `lg`/`xl`).

--- a/.nx/version-plans/version-plan-1780069206903-rnative.md
+++ b/.nx/version-plans/version-plan-1780069206903-rnative.md
@@ -1,0 +1,18 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+BREAKING_CHANGE(ui-rnative): update DotIndicator sizes
+
+The `DotIndicator` size scale has shifted by one step. The previous scale (`xs | sm | md | lg`) has been replaced by (`sm | md | lg | xl`), and the default size is now `md` instead of `sm`. The underlying pixel sizes have also been reduced: the new `sm` is smaller than the old `sm`, so consumers that previously relied on the default will see a smaller dot unless they migrate.
+
+### Migration
+
+Rename `size` values one step down the scale to preserve the previous visual size:
+
+- `size="xs"` → `size="sm"`
+- `size="sm"` → `size="md"` (also the new default, it can be omitted)
+- `size="md"` → `size="lg"`
+- `size="lg"` → `size="xl"`
+
+If you were relying on the default (no `size` prop) and want to keep the previous rendered size, pass `size="sm"` explicitly. The `Avatar` component now uses `DotIndicator` internally for its notification dot. No consumer changes are required there, but note that `showNotification` is now only rendered on Avatar `sm` and `md` sizes (suppressed on `lg`/`xl`).

--- a/.nx/version-plans/version-plan-1780069206903-rnative.md
+++ b/.nx/version-plans/version-plan-1780069206903-rnative.md
@@ -2,7 +2,7 @@
 '@ledgerhq/lumen-ui-rnative': patch
 ---
 
-BREAKING_CHANGE(ui-rnative): update DotIndicator sizes
+BREAKING_CHANGE(DotIndicator): update DotIndicator sizes
 
 The `DotIndicator` size scale has been renamed and rescaled. The previous scale (`xs | sm | md | lg`) has been replaced by (`sm | md | lg | xl`), and the default size is now `md` instead of `sm`. The underlying token sizes have been reduced overall. The names did not simply shift down by one. Old `md` (`s14`) and old `lg` (`s16`) have no equivalent in the new scale.
 

--- a/apps/app-sandbox-rnative/src/app/blocks/DotIndicators.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/DotIndicators.tsx
@@ -4,10 +4,10 @@ export function DotIndicators() {
   return (
     <Box lx={{ gap: 's24' }}>
       <Box lx={{ gap: 's12', flexDirection: 'row', alignItems: 'center' }}>
-        <DotIndicator size='xs' />
         <DotIndicator size='sm' />
         <DotIndicator size='md' />
         <DotIndicator size='lg' />
+        <DotIndicator size='xl' />
       </Box>
       <Box lx={{ gap: 's12', flexDirection: 'row', alignItems: 'center' }}>
         <DotIndicator />

--- a/apps/app-sandbox-rnative/src/app/blocks/DotIndicators.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/DotIndicators.tsx
@@ -16,7 +16,7 @@ export function DotIndicators() {
       </Box>
       <Box lx={{ gap: 's12', flexDirection: 'row', alignItems: 'center' }}>
         <Avatar size='md' showNotification />
-        <DotIndicator appearance='red'>
+        <DotIndicator size='xl' appearance='red'>
           <Button size='sm' disabled>
             Submit
           </Button>

--- a/libs/ui-react/src/lib/Components/Avatar/Avatar.mdx
+++ b/libs/ui-react/src/lib/Components/Avatar/Avatar.mdx
@@ -58,6 +58,8 @@ An optional notification indicator can be displayed to show status or alerts:
 
 - **showNotification**: Boolean prop to toggle the notification dot (default: false)
 
+> The notification dot is only rendered on the `sm` and `md` sizes. It is suppressed on `lg` and `xl` even when `showNotification` is `true`.
+
 <Canvas of={AvatarStories.NotificationShowcase} />
 
 ### As Interactive Trigger

--- a/libs/ui-react/src/lib/Components/Avatar/Avatar.test.tsx
+++ b/libs/ui-react/src/lib/Components/Avatar/Avatar.test.tsx
@@ -82,6 +82,37 @@ describe('Avatar Component', () => {
     expect(notificationDot).toBeInTheDocument();
   });
 
+  it.each(['sm', 'md'] as const)(
+    'should render the notification indicator on size=%s',
+    (size) => {
+      const { container } = render(
+        <Avatar src={validSrc} size={size} showNotification />,
+      );
+
+      const notificationDot = container.querySelector('.bg-error-strong');
+      expect(notificationDot).toBeInTheDocument();
+    },
+  );
+
+  it.each(['lg', 'xl'] as const)(
+    'should not render the notification indicator on size=%s',
+    (size) => {
+      const { container } = render(
+        <Avatar src={validSrc} size={size} showNotification />,
+      );
+
+      const notificationDot = container.querySelector('.bg-error-strong');
+      expect(notificationDot).not.toBeInTheDocument();
+    },
+  );
+
+  it('should not include notification in aria-label on lg/xl even when showNotification is true', () => {
+    render(<Avatar src={validSrc} size='lg' showNotification />);
+
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('aria-label', 'components.avatar.defaultAlt');
+  });
+
   it('should include notification in aria-label when showNotification is true', () => {
     render(<Avatar src={validSrc} showNotification />);
 

--- a/libs/ui-react/src/lib/Components/Avatar/Avatar.tsx
+++ b/libs/ui-react/src/lib/Components/Avatar/Avatar.tsx
@@ -2,6 +2,7 @@ import { cva } from 'class-variance-authority';
 import { useState, useEffect } from 'react';
 import { useCommonTranslation } from '../../../i18n';
 import { User } from '../../Symbols';
+import { DotIndicator } from '../DotIndicator';
 import type { AvatarProps } from './types';
 
 const avatarVariants = {
@@ -21,17 +22,9 @@ const avatarVariants = {
       },
     },
   ),
-  notification: cva('absolute top-0 right-0 rounded-full bg-error-strong', {
-    variants: {
-      size: {
-        sm: 'size-10',
-        md: 'size-12',
-        lg: 'size-14',
-        xl: 'size-16',
-      },
-    },
-  }),
 };
+
+type Size = NonNullable<AvatarProps['size']>;
 
 const fallbackSizes = {
   sm: 16,
@@ -39,6 +32,13 @@ const fallbackSizes = {
   lg: 32,
   xl: 40,
 } as const;
+
+const dotSizeMap: Partial<
+  Record<Size, NonNullable<React.ComponentProps<typeof DotIndicator>['size']>>
+> = {
+  sm: 'lg',
+  md: 'xl',
+};
 
 /**
  * A circular avatar component that displays a user image or fallback icon.
@@ -63,7 +63,7 @@ export const Avatar = ({
   alt,
   size = 'md',
   imgLoading,
-  showNotification = false,
+  showNotification: showNotificationProp = false,
   ...props
 }: AvatarProps) => {
   const { t } = useCommonTranslation();
@@ -71,6 +71,10 @@ export const Avatar = ({
   const shouldFallback = !src || error;
 
   const resolvedAlt = alt || t('components.avatar.defaultAlt');
+
+  // dot indicator is not visible on larger sizes, regardless of the `showNotification` prop
+  const showNotification =
+    showNotificationProp && (size === 'sm' || size === 'md');
 
   const ariaLabel = showNotification
     ? `${resolvedAlt}, ${t('components.avatar.notificationAriaLabel')}`
@@ -80,7 +84,7 @@ export const Avatar = ({
     setError(false);
   }, [src]);
 
-  return (
+  const avatarContent = (
     <div
       ref={ref}
       className={avatarVariants.root({ size, className })}
@@ -88,12 +92,6 @@ export const Avatar = ({
       aria-label={ariaLabel}
       {...props}
     >
-      {showNotification && (
-        <div
-          className={avatarVariants.notification({ size })}
-          aria-hidden='true'
-        />
-      )}
       {shouldFallback ? (
         <User
           size={fallbackSizes[size]}
@@ -112,4 +110,14 @@ export const Avatar = ({
       )}
     </div>
   );
+
+  if (showNotification) {
+    return (
+      <DotIndicator size={dotSizeMap[size]} appearance='red'>
+        {avatarContent}
+      </DotIndicator>
+    );
+  }
+
+  return avatarContent;
 };

--- a/libs/ui-react/src/lib/Components/DotIndicator/DotIndicator.mdx
+++ b/libs/ui-react/src/lib/Components/DotIndicator/DotIndicator.mdx
@@ -24,10 +24,10 @@ import { CustomTabs, Tab } from '../../../../.storybook/components';
 
     DotIndicator comes in four sizes:
 
-    - **xs** - compact dot for tight layouts.
-    - **sm** (default) - standard dot for most use cases.
-    - **md** - medium dot for prominent indicators.
-    - **lg** - large dot for maximum visibility.
+    - **sm** - compact dot for tight layouts.
+    - **md** (default) - standard dot for most use cases.
+    - **lg** - large dot for prominent indicators.
+    - **xl** - extra-large dot for maximum visibility.
 
     <Canvas of={DotIndicatorStories.SizeShowcase} />
 

--- a/libs/ui-react/src/lib/Components/DotIndicator/DotIndicator.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DotIndicator/DotIndicator.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
   argTypes: {
     size: {
       control: 'radio',
-      options: ['xs', 'sm', 'md', 'lg'],
+      options: ['sm', 'md', 'lg', 'xl'],
     },
     appearance: {
       control: 'radio',
@@ -42,10 +42,10 @@ export const Base: Story = {
 export const SizeShowcase: Story = {
   render: () => (
     <div className='flex items-center gap-12'>
-      <DotIndicator size='xs' />
       <DotIndicator size='sm' />
       <DotIndicator size='md' />
       <DotIndicator size='lg' />
+      <DotIndicator size='xl' />
     </div>
   ),
 };

--- a/libs/ui-react/src/lib/Components/DotIndicator/DotIndicator.test.tsx
+++ b/libs/ui-react/src/lib/Components/DotIndicator/DotIndicator.test.tsx
@@ -35,8 +35,8 @@ describe('DotIndicator', () => {
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });
 
-  it('should render in xs size', () => {
-    const { container } = render(<DotIndicator size='xs' />);
+  it('should render in sm size', () => {
+    const { container } = render(<DotIndicator size='sm' />);
     expect(container.firstChild).toBeInTheDocument();
   });
 
@@ -47,6 +47,11 @@ describe('DotIndicator', () => {
 
   it('should render in lg size', () => {
     const { container } = render(<DotIndicator size='lg' />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('should render in xl size', () => {
+    const { container } = render(<DotIndicator size='xl' />);
     expect(container.firstChild).toBeInTheDocument();
   });
 

--- a/libs/ui-react/src/lib/Components/DotIndicator/DotIndicator.tsx
+++ b/libs/ui-react/src/lib/Components/DotIndicator/DotIndicator.tsx
@@ -5,10 +5,10 @@ import type { DotIndicatorProps } from './types';
 const dotIndicatorVariants = cva('pointer-events-none rounded-full', {
   variants: {
     size: {
-      xs: 'size-10',
-      sm: 'size-12',
-      md: 'size-14',
-      lg: 'size-16',
+      sm: 'size-6',
+      md: 'size-8',
+      lg: 'size-10',
+      xl: 'size-12',
     },
     appearance: {
       base: 'bg-interactive',
@@ -20,14 +20,14 @@ const dotIndicatorVariants = cva('pointer-events-none rounded-full', {
     },
   },
   defaultVariants: {
-    size: 'sm',
+    size: 'md',
     appearance: 'base',
     disabled: false,
   },
 });
 
 export function DotIndicator({
-  size = 'sm',
+  size = 'md',
   appearance = 'base',
   disabled: disabledProp = false,
   children,

--- a/libs/ui-react/src/lib/Components/DotIndicator/types.ts
+++ b/libs/ui-react/src/lib/Components/DotIndicator/types.ts
@@ -3,9 +3,9 @@ import type { ComponentPropsWithRef, ReactNode } from 'react';
 export type DotIndicatorProps = {
   /**
    * The size of the dot indicator.
-   * @default 'sm'
+   * @default md
    */
-  size?: 'xs' | 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg' | 'xl';
   /**
    * The appearance of the dot indicator.
    * @default 'base'

--- a/libs/ui-rnative/src/lib/Components/Avatar/Avatar.mdx
+++ b/libs/ui-rnative/src/lib/Components/Avatar/Avatar.mdx
@@ -55,6 +55,8 @@ An optional notification indicator can be displayed to show status or alerts:
 
 - **showNotification**: Boolean prop to toggle the notification dot (default: false)
 
+> The notification dot is only rendered on the `sm` and `md` sizes. It is suppressed on `lg` and `xl` even when `showNotification` is `true`.
+
 <Canvas of={AvatarStories.NotificationShowcase} />
 
 ### As Interactive Trigger

--- a/libs/ui-rnative/src/lib/Components/Avatar/Avatar.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/Avatar/Avatar.test.tsx
@@ -195,25 +195,23 @@ describe('Avatar Component', () => {
 
     dot = toJSON().children[0];
     expect(dot.props.style.height).toBe(sizes.s12);
-
-    rerender(
-      <TestWrapper>
-        <Avatar testID='avatar-id' size='lg' showNotification />
-      </TestWrapper>,
-    );
-
-    dot = toJSON().children[0];
-    expect(dot.props.style.height).toBe(sizes.s14);
-
-    rerender(
-      <TestWrapper>
-        <Avatar testID='avatar-id' size='xl' showNotification />
-      </TestWrapper>,
-    );
-
-    dot = toJSON().children[0];
-    expect(dot.props.style.height).toBe(sizes.s16);
   });
+
+  it.each(['lg', 'xl'] as const)(
+    'should not render the notification indicator on size=%s even when showNotification is true',
+    (size) => {
+      const { toJSON } = render(
+        <TestWrapper>
+          <Avatar testID='avatar-id' size={size} showNotification />
+        </TestWrapper>,
+      );
+
+      const tree = toJSON();
+      expect(tree.props.testID).toBe('avatar-id');
+      expect(tree.props.accessibilityRole).toBe('image');
+      expect(tree.props.accessibilityLabel).toBe('avatar');
+    },
+  );
 
   it('should apply custom styles', () => {
     const customStyle = { borderWidth: 2 };

--- a/libs/ui-rnative/src/lib/Components/Avatar/Avatar.tsx
+++ b/libs/ui-rnative/src/lib/Components/Avatar/Avatar.tsx
@@ -16,14 +16,11 @@ const fallbackSizes = {
   xl: 40,
 } as const;
 
-const dotSizeMap: Record<
-  Size,
-  NonNullable<React.ComponentProps<typeof DotIndicator>['size']>
+const dotSizeMap: Partial<
+  Record<Size, NonNullable<React.ComponentProps<typeof DotIndicator>['size']>>
 > = {
-  sm: 'xs',
-  md: 'sm',
-  lg: 'md',
-  xl: 'lg',
+  sm: 'lg',
+  md: 'xl',
 };
 
 const useStyles = ({ size }: { size: Size }) => {
@@ -81,7 +78,7 @@ export const Avatar = ({
   src,
   alt = 'avatar',
   size = 'md',
-  showNotification = false,
+  showNotification: showNotificationProp = false,
   testID,
   ref,
   ...props
@@ -92,6 +89,10 @@ export const Avatar = ({
   const styles = useStyles({ size });
 
   const resolvedAlt = alt || t('components.avatar.defaultAlt');
+
+  // dot indicator is not visible on larger sizes, regardless of the `showNotification` prop
+  const showNotification =
+    showNotificationProp && (size === 'sm' || size === 'md');
 
   const accessibilityLabel = showNotification
     ? `${resolvedAlt}, ${t('components.avatar.notificationAriaLabel')}`

--- a/libs/ui-rnative/src/lib/Components/DotIndicator/DotIndicator.mdx
+++ b/libs/ui-rnative/src/lib/Components/DotIndicator/DotIndicator.mdx
@@ -24,10 +24,10 @@ import { CustomTabs, Tab } from '../../../../.storybook/components';
 
     DotIndicator comes in four sizes:
 
-    - **xs** - compact dot for tight layouts.
-    - **sm** (default) - standard dot for most use cases.
-    - **md** - medium dot for prominent indicators.
-    - **lg** - large dot for maximum visibility.
+    - **sm** - compact dot for tight layouts.
+    - **md** (default) - standard dot for most use cases.
+    - **lg** - large dot for prominent indicators.
+    - **xl** - extra-large dot for maximum visibility.
 
     <Canvas of={DotIndicatorStories.SizeShowcase} />
 

--- a/libs/ui-rnative/src/lib/Components/DotIndicator/DotIndicator.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotIndicator/DotIndicator.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
   argTypes: {
     size: {
       control: 'radio',
-      options: ['xs', 'sm', 'md', 'lg'],
+      options: ['sm', 'md', 'lg', 'xl'],
     },
     appearance: {
       control: 'radio',
@@ -42,10 +42,10 @@ export const Base: Story = {
 export const SizeShowcase: Story = {
   render: () => (
     <Box lx={{ flexDirection: 'row', alignItems: 'center', gap: 's12' }}>
-      <DotIndicator size='xs' />
       <DotIndicator size='sm' />
       <DotIndicator size='md' />
       <DotIndicator size='lg' />
+      <DotIndicator size='xl' />
     </Box>
   ),
 };

--- a/libs/ui-rnative/src/lib/Components/DotIndicator/DotIndicator.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotIndicator/DotIndicator.test.tsx
@@ -77,10 +77,10 @@ describe('DotIndicator', () => {
     expect(ref.current).toBeTruthy();
   });
 
-  it('should render in xs size', () => {
+  it('should render in sm size', () => {
     const { toJSON } = render(
       <TestWrapper>
-        <DotIndicator size='xs' />
+        <DotIndicator size='sm' />
       </TestWrapper>,
     );
 
@@ -101,6 +101,16 @@ describe('DotIndicator', () => {
     const { toJSON } = render(
       <TestWrapper>
         <DotIndicator size='lg' />
+      </TestWrapper>,
+    );
+
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('should render in xl size', () => {
+    const { toJSON } = render(
+      <TestWrapper>
+        <DotIndicator size='xl' />
       </TestWrapper>,
     );
 

--- a/libs/ui-rnative/src/lib/Components/DotIndicator/DotIndicator.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotIndicator/DotIndicator.tsx
@@ -5,7 +5,7 @@ import { Box } from '../Utility';
 import type { DotIndicatorProps } from './types';
 
 export function DotIndicator({
-  size = 'sm',
+  size = 'md',
   appearance = 'base',
   disabled: disabledProp = false,
   lx = {},
@@ -63,10 +63,10 @@ const useStyles = ({
   return useStyleSheet(
     (t) => {
       const sizeMap = {
-        xs: t.sizes.s10,
-        sm: t.sizes.s12,
-        md: t.sizes.s14,
-        lg: t.sizes.s16,
+        sm: t.sizes.s6,
+        md: t.sizes.s8,
+        lg: t.sizes.s10,
+        xl: t.sizes.s12,
       };
 
       const bgColorMap = {

--- a/libs/ui-rnative/src/lib/Components/DotIndicator/types.ts
+++ b/libs/ui-rnative/src/lib/Components/DotIndicator/types.ts
@@ -4,9 +4,9 @@ import type { StyledViewProps } from '../../../styles';
 export type DotIndicatorProps = {
   /**
    * The size of the dot indicator.
-   * @default sm
+   * @default md
    */
-  size?: 'xs' | 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg' | 'xl';
   /**
    * The appearance of the dot indicator.
    * @default base


### PR DESCRIPTION
Closes [DLS-757](https://ledgerhq.atlassian.net/browse/DLS-757).

## Considerations

* As confirmed with Laurine, the new default is `md` (from `sm`) with a pixel size of `12px` (from `8px`).
* On ui-react, refactored `Avatar` to use `DotIndicator`, syncing the logic between both libs.
* The dot indicator should only show for avatars with sizes `sm` (`lg` dot) and `md` (`xl` dot). For larger avatar sizes `lg` and `xl`, even if the `showNotification` prop is present, the badge will not show. See demo below:

<img width="375" height="235" alt="image" src="https://github.com/user-attachments/assets/af6aadcc-cd52-4d87-9a00-b7f2829a14cc" />

## Demo

Tested on iOS 26.5 (iPhone 17 simulator).

<img width="369" height="214" alt="image" src="https://github.com/user-attachments/assets/c5518d48-f2bf-48d5-94b6-410a8ad6c883" />

[DLS-757]: https://ledgerhq.atlassian.net/browse/DLS-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ