### PR TITLE
feat(MediaImage, DotIcon, DotSymbol): add support for 72px size 

### DIFF
--- a/.nx/version-plans/version-plan-1748313283001-ui-react.md
+++ b/.nx/version-plans/version-plan-1748313283001-ui-react.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+feat(MediaImage): add new size of 72px

--- a/.nx/version-plans/version-plan-1748313283002-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1748313283002-ui-rnative.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+feat(MediaImage): add new size of 72px

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.stories.tsx
@@ -191,6 +191,14 @@ export const SizeShowcase: Story = {
       >
         <MediaImage src={parentSrc} size={64} shape='circle' />
       </DotIcon>
+      <DotIcon
+        appearance='muted'
+        icon={Spinner}
+        size={mediaImageDotIconSizeMap[72]}
+        pin='bottom-end'
+      >
+        <MediaImage src={parentSrc} size={72} shape='circle' />
+      </DotIcon>
     </div>
   ),
 };

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
@@ -56,6 +56,7 @@ export const mediaImageDotIconSizeMap = {
   48: 20,
   56: 24,
   64: 24,
+  72: 24,
 } as const satisfies Record<number, DotIconSize>;
 
 export const spotDotIconSizeMap = {

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.tsx
@@ -25,6 +25,7 @@ const dotVariants = cva(
         16: 'size-16 border',
         20: 'size-20 border',
         24: 'size-24 border',
+        32: 'size-32 border',
       },
       shape: {
         square: '',
@@ -46,6 +47,7 @@ const dotVariants = cva(
       { size: 16, shape: 'square', className: 'rounded-[5px]' },
       { size: 20, shape: 'square', className: 'rounded-[6px]' },
       { size: 24, shape: 'square', className: 'rounded-[8px]' },
+      { size: 32, shape: 'square', className: 'rounded-[10px]' },
       { shape: 'circle', className: 'rounded-full' },
     ],
   },
@@ -56,20 +58,21 @@ export const mediaImageDotIconSizeMap = {
   48: 20,
   56: 24,
   64: 24,
-  72: 24,
+  72: 32,
 } as const satisfies Record<number, DotIconSize>;
 
 export const spotDotIconSizeMap = {
   40: 16,
   48: 20,
   56: 24,
-  72: 24,
+  72: 32,
 } as const satisfies Record<number, DotIconSize>;
 
 export const dotIconSizeMap: Record<DotIconSize, IconSize> = {
   16: 12,
   20: 16,
   24: 16,
+  32: 20,
 };
 
 const pinAxisMap: Record<DotIconPin, [vertical: string, horizontal: string]> = {

--- a/libs/ui-react/src/lib/Components/DotIcon/types.ts
+++ b/libs/ui-react/src/lib/Components/DotIcon/types.ts
@@ -1,7 +1,7 @@
 import type { ComponentPropsWithRef, ComponentType, ReactNode } from 'react';
 import type { IconSize } from '../Icon';
 
-export type DotIconSize = 16 | 20 | 24;
+export type DotIconSize = 16 | 20 | 24 | 32;
 
 export type DotIconPin =
   | 'top-start'

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.stories.tsx
@@ -173,6 +173,13 @@ export const SizeShowcase: Story = {
         >
           <MediaImage src={parentSrc} size={64} shape='circle' />
         </DotSymbol>
+        <DotSymbol
+          src={dotSrc}
+          size={mediaImageDotSizeMap[72]}
+          pin='bottom-end'
+        >
+          <MediaImage src={parentSrc} size={72} shape='circle' />
+        </DotSymbol>
       </div>
       <div className='inline-flex items-end gap-24 body-2'>
         <DotSymbol
@@ -230,6 +237,14 @@ export const SizeShowcase: Story = {
           pin='bottom-end'
         >
           <MediaImage src={parentSrc} size={64} shape='square' />
+        </DotSymbol>
+        <DotSymbol
+          shape='square'
+          src={dotSrc}
+          size={mediaImageDotSizeMap[72]}
+          pin='bottom-end'
+        >
+          <MediaImage src={parentSrc} size={72} shape='square' />
         </DotSymbol>
       </div>
     </div>

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
@@ -29,6 +29,7 @@ const dotVariants = cva(
         16: 'size-16 border',
         20: 'size-20 border',
         24: 'size-24 border',
+        32: 'size-32 border',
       },
       shape: {
         square: '',
@@ -51,6 +52,7 @@ const dotVariants = cva(
       { size: 16, shape: 'square', className: 'rounded-[5px]' },
       { size: 20, shape: 'square', className: 'rounded-[6px]' },
       { size: 24, shape: 'square', className: 'rounded-[8px]' },
+      { size: 32, shape: 'square', className: 'rounded-[10px]' },
       { shape: 'circle', className: 'rounded-full' },
     ],
   },
@@ -63,6 +65,7 @@ const offsetBySize: Record<DotSymbolSize, number> = {
   16: -3,
   20: -3,
   24: -3,
+  32: -3,
 };
 
 export const mediaImageDotSizeMap: Record<MediaImageSize, DotSymbolSize> = {
@@ -75,7 +78,7 @@ export const mediaImageDotSizeMap: Record<MediaImageSize, DotSymbolSize> = {
   48: 20,
   56: 24,
   64: 24,
-  72: 24,
+  72: 32,
 } as const;
 
 export const spotDotSizeMap: Record<SpotSize, DotSymbolSize> = {
@@ -83,7 +86,7 @@ export const spotDotSizeMap: Record<SpotSize, DotSymbolSize> = {
   40: 16,
   48: 20,
   56: 24,
-  72: 24,
+  72: 32,
 } as const;
 
 const pinAxisMap: Record<DotSymbolPin, [vertical: string, horizontal: string]> =

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.tsx
@@ -75,6 +75,7 @@ export const mediaImageDotSizeMap: Record<MediaImageSize, DotSymbolSize> = {
   48: 20,
   56: 24,
   64: 24,
+  72: 24,
 } as const;
 
 export const spotDotSizeMap: Record<SpotSize, DotSymbolSize> = {

--- a/libs/ui-react/src/lib/Components/DotSymbol/types.ts
+++ b/libs/ui-react/src/lib/Components/DotSymbol/types.ts
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithRef, ReactNode } from 'react';
 
-export type DotSymbolSize = 8 | 10 | 12 | 16 | 20 | 24;
+export type DotSymbolSize = 8 | 10 | 12 | 16 | 20 | 24 | 32;
 
 export type DotSymbolPin =
   | 'top-start'

--- a/libs/ui-react/src/lib/Components/MediaImage/MediaImage.mdx
+++ b/libs/ui-react/src/lib/Components/MediaImage/MediaImage.mdx
@@ -39,7 +39,7 @@ MediaImage displays an image with consistent sizing and shape. When the image fa
 
 ### Sizes
 
-Nine sizes are available (12, 16, 20, 24, 32, 40, 48, 56, 64). Border radius scales with size.
+Ten sizes are available (12, 16, 20, 24, 32, 40, 48, 56, 64, 72). Border radius scales with size.
 
 <Canvas of={MediaImageStories.SizeShowcase} />
 

--- a/libs/ui-react/src/lib/Components/MediaImage/MediaImage.stories.tsx
+++ b/libs/ui-react/src/lib/Components/MediaImage/MediaImage.stories.tsx
@@ -44,6 +44,7 @@ export const SizeShowcase: Story = {
       <MediaImage src={exampleSrc} alt={`Size 48`} size={48} />
       <MediaImage src={exampleSrc} alt={`Size 56`} size={56} />
       <MediaImage src={exampleSrc} alt={`Size 64`} size={64} />
+      <MediaImage src={exampleSrc} alt={`Size 72`} size={72} />
     </div>
   ),
 };
@@ -70,6 +71,7 @@ export const FallbackShowcase: Story = {
       <MediaImage fallback='Bitcoin' alt='Bitcoin' size={48} />
       <MediaImage fallback='Bitcoin' alt='Bitcoin' size={56} />
       <MediaImage fallback='Bitcoin' alt='Bitcoin' size={64} />
+      <MediaImage fallback='Bitcoin' alt='Bitcoin' size={72} />
     </div>
   ),
 };
@@ -86,6 +88,7 @@ export const LoadingShowcase: Story = {
       <MediaImage loading alt='Loading' size={48} />
       <MediaImage loading alt='Loading' size={56} />
       <MediaImage loading alt='Loading' size={64} />
+      <MediaImage loading alt='Loading' size={72} />
     </div>
   ),
 };

--- a/libs/ui-react/src/lib/Components/MediaImage/MediaImage.tsx
+++ b/libs/ui-react/src/lib/Components/MediaImage/MediaImage.tsx
@@ -14,6 +14,7 @@ export const fontSizeMap: Record<MediaImageSize, number> = {
   48: 24,
   56: 24,
   64: 24,
+  72: 32,
 };
 
 const mediaImageVariants = {
@@ -31,6 +32,7 @@ const mediaImageVariants = {
           48: 'size-48 rounded-md',
           56: 'size-56 rounded-lg',
           64: 'size-64 rounded-lg',
+          72: 'size-72 rounded-lg',
         },
         shape: {
           square: '',

--- a/libs/ui-react/src/lib/Components/MediaImage/types.ts
+++ b/libs/ui-react/src/lib/Components/MediaImage/types.ts
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithRef } from 'react';
 
-export type MediaImageSize = 12 | 16 | 20 | 24 | 32 | 40 | 48 | 56 | 64;
+export type MediaImageSize = 12 | 16 | 20 | 24 | 32 | 40 | 48 | 56 | 64 | 72;
 
 export type MediaImageShape = 'square' | 'circle';
 

--- a/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.stories.tsx
@@ -184,6 +184,14 @@ export const SizeShowcase: Story = {
       >
         <MediaImage src={parentSrc} size={64} shape='circle' />
       </DotIcon>
+      <DotIcon
+        appearance='muted'
+        icon={Spinner}
+        size={mediaImageDotIconSizeMap[72]}
+        pin='bottom-end'
+      >
+        <MediaImage src={parentSrc} size={72} shape='circle' />
+      </DotIcon>
     </Box>
   ),
 };

--- a/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.tsx
@@ -29,6 +29,7 @@ export const mediaImageDotIconSizeMap = {
   48: 20,
   56: 24,
   64: 24,
+  72: 24,
 } as const satisfies Record<number, DotIconSize>;
 
 export const spotDotIconSizeMap = {

--- a/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotIcon/DotIcon.tsx
@@ -16,12 +16,14 @@ const dotIconSizeMap: Record<DotIconSize, IconSize> = {
   16: 12,
   20: 16,
   24: 16,
+  32: 20,
 };
 
 const dotSquareRadiusMap: Record<DotIconSize, number> = {
   16: 5,
   20: 6,
   24: 8,
+  32: 10,
 };
 
 export const mediaImageDotIconSizeMap = {
@@ -29,14 +31,14 @@ export const mediaImageDotIconSizeMap = {
   48: 20,
   56: 24,
   64: 24,
-  72: 24,
+  72: 32,
 } as const satisfies Record<number, DotIconSize>;
 
 export const spotDotIconSizeMap = {
   40: 16,
   48: 20,
   56: 24,
-  72: 24,
+  72: 32,
 } as const satisfies Record<number, DotIconSize>;
 
 const pinAxisMap: Record<DotIconPin, [vertical: string, horizontal: string]> = {

--- a/libs/ui-rnative/src/lib/Components/DotIcon/types.ts
+++ b/libs/ui-rnative/src/lib/Components/DotIcon/types.ts
@@ -3,7 +3,7 @@ import type { StyleProp, TextStyle } from 'react-native';
 import type { StyledViewProps } from '../../../styles';
 import type { IconSize } from '../Icon';
 
-export type DotIconSize = 16 | 20 | 24;
+export type DotIconSize = 16 | 20 | 24 | 32;
 
 export type DotIconPin =
   | 'top-start'

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.stories.tsx
@@ -163,6 +163,13 @@ export const SizeShowcase: Story = {
         >
           <MediaImage src={parentSrc} size={64} shape='circle' />
         </DotSymbol>
+        <DotSymbol
+          src={dotSrc}
+          size={mediaImageDotSizeMap[72]}
+          pin='bottom-end'
+        >
+          <MediaImage src={parentSrc} size={72} shape='circle' />
+        </DotSymbol>
       </Box>
       <Box lx={{ flexDirection: 'row', alignItems: 'flex-end', gap: 's24' }}>
         <DotSymbol
@@ -220,6 +227,14 @@ export const SizeShowcase: Story = {
           pin='bottom-end'
         >
           <MediaImage src={parentSrc} size={64} shape='square' />
+        </DotSymbol>
+        <DotSymbol
+          shape='square'
+          src={dotSrc}
+          size={mediaImageDotSizeMap[72]}
+          pin='bottom-end'
+        >
+          <MediaImage src={parentSrc} size={72} shape='square' />
         </DotSymbol>
       </Box>
     </Box>

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.tsx
@@ -17,6 +17,7 @@ const dotSquareRadiusMap: Record<DotSymbolSize, number> = {
   16: 5,
   20: 6,
   24: 8,
+  32: 10,
 };
 
 const offsetBySize: Record<DotSymbolSize, number> = {
@@ -26,6 +27,7 @@ const offsetBySize: Record<DotSymbolSize, number> = {
   16: -3,
   20: -3,
   24: -3,
+  32: -3,
 };
 
 export const mediaImageDotSizeMap: Record<MediaImageSize, DotSymbolSize> = {
@@ -38,7 +40,7 @@ export const mediaImageDotSizeMap: Record<MediaImageSize, DotSymbolSize> = {
   48: 20,
   56: 24,
   64: 24,
-  72: 24,
+  72: 32,
 };
 
 export const spotDotSizeMap: Record<SpotSize, DotSymbolSize> = {
@@ -46,7 +48,7 @@ export const spotDotSizeMap: Record<SpotSize, DotSymbolSize> = {
   40: 16,
   48: 20,
   56: 24,
-  72: 24,
+  72: 32,
 };
 
 const pinAxisMap: Record<DotSymbolPin, [vertical: string, horizontal: string]> =

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/DotSymbol.tsx
@@ -38,6 +38,7 @@ export const mediaImageDotSizeMap: Record<MediaImageSize, DotSymbolSize> = {
   48: 20,
   56: 24,
   64: 24,
+  72: 24,
 };
 
 export const spotDotSizeMap: Record<SpotSize, DotSymbolSize> = {

--- a/libs/ui-rnative/src/lib/Components/DotSymbol/types.ts
+++ b/libs/ui-rnative/src/lib/Components/DotSymbol/types.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import type { StyledViewProps } from '../../../styles';
 
-export type DotSymbolSize = 8 | 10 | 12 | 16 | 20 | 24;
+export type DotSymbolSize = 8 | 10 | 12 | 16 | 20 | 24 | 32;
 
 export type DotSymbolPin =
   | 'top-start'

--- a/libs/ui-rnative/src/lib/Components/MediaImage/MediaImage.mdx
+++ b/libs/ui-rnative/src/lib/Components/MediaImage/MediaImage.mdx
@@ -37,7 +37,7 @@ MediaImage displays an image with consistent sizing and shape. When the image fa
 
 ### Sizes
 
-Nine sizes are available (12, 16, 20, 24, 32, 40, 48, 56, 64). Border radius scales with size.
+Ten sizes are available (12, 16, 20, 24, 32, 40, 48, 56, 64, 72). Border radius scales with size.
 
 <Canvas of={MediaImageStories.SizeShowcase} />
 

--- a/libs/ui-rnative/src/lib/Components/MediaImage/MediaImage.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/MediaImage/MediaImage.stories.tsx
@@ -42,6 +42,7 @@ export const SizeShowcase: Story = {
       <MediaImage src={exampleSrc} alt='Size 48' size={48} />
       <MediaImage src={exampleSrc} alt='Size 56' size={56} />
       <MediaImage src={exampleSrc} alt='Size 64' size={64} />
+      <MediaImage src={exampleSrc} alt='Size 72' size={72} />
     </Box>
   ),
 };
@@ -67,6 +68,7 @@ export const FallbackShowcase: Story = {
       <MediaImage fallback='Bitcoin' alt='Bitcoin' size={48} />
       <MediaImage fallback='Bitcoin' alt='Bitcoin' size={56} />
       <MediaImage fallback='Bitcoin' alt='Bitcoin' size={64} />
+      <MediaImage fallback='Bitcoin' alt='Bitcoin' size={72} />
     </Box>
   ),
 };
@@ -83,6 +85,7 @@ export const LoadingShowcase: Story = {
       <MediaImage loading alt='Loading' size={48} />
       <MediaImage loading alt='Loading' size={56} />
       <MediaImage loading alt='Loading' size={64} />
+      <MediaImage loading alt='Loading' size={72} />
     </Box>
   ),
 };

--- a/libs/ui-rnative/src/lib/Components/MediaImage/MediaImage.tsx
+++ b/libs/ui-rnative/src/lib/Components/MediaImage/MediaImage.tsx
@@ -20,6 +20,7 @@ const borderRadiusMap: Record<MediaImageSize, BorderRadiusKey> = {
   48: 'md',
   56: 'lg',
   64: 'lg',
+  72: 'lg',
 };
 
 export const fontSizeMap: Record<MediaImageSize, number> = {
@@ -32,6 +33,7 @@ export const fontSizeMap: Record<MediaImageSize, number> = {
   48: 24,
   56: 24,
   64: 24,
+  72: 32,
 };
 
 const useStyles = ({

--- a/libs/ui-rnative/src/lib/Components/MediaImage/types.ts
+++ b/libs/ui-rnative/src/lib/Components/MediaImage/types.ts
@@ -1,6 +1,6 @@
 import type { StyledViewProps } from '../../../styles';
 
-export type MediaImageSize = 12 | 16 | 20 | 24 | 32 | 40 | 48 | 56 | 64;
+export type MediaImageSize = 12 | 16 | 20 | 24 | 32 | 40 | 48 | 56 | 64 | 72;
 
 export type MediaImageShape = 'square' | 'circle';
 


### PR DESCRIPTION

- Updated MediaImage to support a new size of 72px, including adjustments in stories and documentation.
- Enhanced DotIcon and DotSymbol components to include the 72px size in their respective size maps and stories.
- Updated type definitions to reflect the new size option for MediaImage.