### PR TITLE
refactor(ui-rnative-visualization): align axis API with react-visualization + fix tick values

### DIFF
--- a/.nx/version-plans/version-plan-1780320400001-rnative-visualization.md
+++ b/.nx/version-plans/version-plan-1780320400001-rnative-visualization.md
@@ -1,0 +1,23 @@
+---
+'@ledgerhq/lumen-ui-rnative-visualization': patch
+---
+
+fix(charts): respect `xAxis.data` as the source of truth for tick values
+
+When `xAxis.data` is provided without explicit `ticks`, `buildTicksData` now
+derives ticks from the data itself (numeric values for numeric data, indices
+for string data) instead of falling back to `scale.ticks()`. This removes
+d3-invented intermediate ticks (e.g. `1, 3` for `[0, 2, 4]`, or `0.5, 1.5`
+between `'Jan', 'Feb', 'Mar'`).
+
+The existing `ticks: []` short-circuit (passing an empty array to render no
+labels) is preserved.
+
+refactor(charts): align axis API with react-visualization
+
+Consolidate axis configuration onto a single `BaseAxisProps` type (merging the
+former `AxisConfigProps` fields: `scaleType`, `data`, `domain`), add a `nice`
+opt-out on numeric scales (default `true`; set `false` to keep the domain
+exactly as provided), and cap `toScaledPoints` iteration at `xData.length` so a
+series with more points than the axis has labels no longer overflows the right
+edge of the chart.

--- a/apps/app-sandbox-rnative/src/app/blocks/LineCharts.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/LineCharts.tsx
@@ -36,6 +36,7 @@ export const LineCharts = () => (
     <ScrubberMultiSeriesWithBeacons />
     <ScrubberWithAxes />
     <ReferenceLineBasic />
+    <ScrubberWithTooltip />
     <RandomAutoUpdate />
     <MagnetizedPoint />
   </Box>
@@ -45,7 +46,7 @@ const sampleSeries = [
   {
     id: 'prices',
     stroke: '#7B61FF',
-    data: [10, 45, 98, 45, 22, 52, 21, 20, 37],
+    data: [10, 45, 98, 45, 22, 52, 21, 20, 3],
   },
 ];
 
@@ -370,6 +371,35 @@ const ScrubberWithAxes = () => (
       }}
     >
       <Scrubber />
+    </LineChart>
+  </Section>
+);
+
+const ScrubberWithTooltip = () => (
+  <Section title='Scrubber – with tooltip'>
+    <LineChart
+      series={sampleSeries}
+      height={220}
+      showArea
+      showYAxis
+      enableScrubbing
+      yAxis={{
+        domain: (bounds) => ({
+          min: bounds.min - 10,
+          max: bounds.max,
+        }),
+        showGrid: true,
+        tickLabelFormatter: (v) => `$${v}`,
+      }}
+    >
+      <Scrubber
+        tooltip={(i) => ({
+          items: [
+            { label: 'Date', value: months[i] },
+            { label: 'Price', value: `$${sampleSeries[0].data[i]}` },
+          ],
+        })}
+      />
     </LineChart>
   </Section>
 );

--- a/apps/app-sandbox-rnative/src/app/blocks/LineCharts.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/LineCharts.tsx
@@ -10,7 +10,15 @@ import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 
 export const LineCharts = () => (
-  <Box lx={{ flexDirection: 'column', gap: 's24', width: 'full' }}>
+  <Box
+    lx={{
+      flexDirection: 'column',
+      gap: 's24',
+      width: 'full',
+      paddingLeft: 's16',
+      paddingRight: 's16',
+    }}
+  >
     <BasicLine />
     <WithAreaFill />
     <WithXAxis />
@@ -90,13 +98,13 @@ const Section = ({
 
 const BasicLine = () => (
   <Section title='Basic line'>
-    <LineChart series={sampleSeries} width={400} height={200} />
+    <LineChart series={sampleSeries} height={150} />
   </Section>
 );
 
 const WithAreaFill = () => (
   <Section title='With area fill'>
-    <LineChart series={sampleSeries} width={400} height={200} showArea />
+    <LineChart series={sampleSeries} height={150} showArea />
   </Section>
 );
 
@@ -104,8 +112,7 @@ const WithXAxis = () => (
   <Section title='With X axis'>
     <LineChart
       series={sampleSeries}
-      width={400}
-      height={200}
+      height={150}
       showXAxis
       xAxis={{
         gridLineStyle: 'solid',
@@ -120,8 +127,7 @@ const WithBothAxes = () => (
   <Section title='With both axes'>
     <LineChart
       series={sampleSeries}
-      width={400}
-      height={200}
+      height={150}
       showXAxis
       showYAxis
       xAxis={{
@@ -141,8 +147,7 @@ const WithStringLabels = () => (
   <Section title='With string labels'>
     <LineChart
       series={sampleSeries}
-      width={400}
-      height={200}
+      height={150}
       showXAxis
       xAxis={{
         data: months,
@@ -156,8 +161,7 @@ const MultipleSeries = () => (
   <Section title='Multiple series'>
     <LineChart
       series={multiSeries}
-      width={400}
-      height={200}
+      height={150}
       showXAxis
       showYAxis
       xAxis={{
@@ -176,8 +180,7 @@ const MultipleSeriesWithArea = () => (
   <Section title='Multiple series with area'>
     <LineChart
       series={multiSeries}
-      width={400}
-      height={200}
+      height={150}
       showArea
       showXAxis
       showYAxis
@@ -196,8 +199,7 @@ const CustomDomain = () => (
   <Section title='Custom domain (0–1)'>
     <LineChart
       series={sampleSeries}
-      width={400}
-      height={200}
+      height={150}
       showXAxis
       showYAxis
       xAxis={{
@@ -222,7 +224,7 @@ const PointMinMax = () => {
 
   return (
     <Section title='Point – min/max highlights'>
-      <LineChart series={sampleSeries} width={400} height={200} showArea>
+      <LineChart series={sampleSeries} height={150} showArea>
         <Point dataX={maxIdx} dataY={max} color='#47883A' label={`$${max}`} />
         <Point
           dataX={minIdx}
@@ -238,7 +240,7 @@ const PointMinMax = () => {
 
 const PointAllDataPoints = () => (
   <Section title='Point – all data points'>
-    <LineChart series={sampleSeries} width={400} height={200} showArea>
+    <LineChart series={sampleSeries} height={150} showArea>
       {sampleSeries[0].data.map((value, i) => (
         <Point key={i} dataX={i} dataY={value} size={8} />
       ))}
@@ -248,7 +250,7 @@ const PointAllDataPoints = () => (
 
 const PointLabelFunction = () => (
   <Section title='Point – label function'>
-    <LineChart series={sampleSeries} width={400} height={200}>
+    <LineChart series={sampleSeries} height={150}>
       <Point
         dataX={2}
         dataY={98}
@@ -268,7 +270,7 @@ const PointLabelFunction = () => (
 
 const PointHiddenPoint = () => (
   <Section title='Point – hidden point (label only)'>
-    <LineChart series={sampleSeries} width={400} height={200} showArea>
+    <LineChart series={sampleSeries} height={150} showArea>
       <Point dataX={2} dataY={98} hidePoint label='Peak' />
       <Point
         dataX={0}
@@ -285,7 +287,6 @@ const PointWithAxes = () => (
   <Section title='Point – with axes'>
     <LineChart
       series={sampleSeries}
-      width={400}
       height={220}
       showArea
       showXAxis
@@ -313,8 +314,7 @@ const ScrubberBasic = () => (
   <Section title='Scrubber – basic'>
     <LineChart
       series={sampleSeries}
-      width={400}
-      height={200}
+      height={150}
       showArea
       enableScrubbing
       showYAxis
@@ -334,8 +334,7 @@ const ScrubberMultiSeriesWithBeacons = () => (
   <Section title='Scrubber – multi-series with beacons'>
     <LineChart
       series={multiSeries}
-      width={400}
-      height={200}
+      height={150}
       enableScrubbing
       showYAxis
       yAxis={{
@@ -357,7 +356,6 @@ const ScrubberWithAxes = () => (
   <Section title='Scrubber – with axes'>
     <LineChart
       series={sampleSeries}
-      width={400}
       height={220}
       showArea
       showYAxis
@@ -379,7 +377,7 @@ const ScrubberWithAxes = () => (
 const ReferenceLineBasic = () => {
   return (
     <Section title='Reference line'>
-      <LineChart series={sampleSeries} width={320} height={200}>
+      <LineChart series={sampleSeries} width={320} height={150}>
         <ReferenceLine
           dataY={98}
           labelDy={-4}
@@ -424,8 +422,7 @@ const RandomAutoUpdate = () => {
     <Section title='Random series (auto-updates every 3s)'>
       <LineChart
         series={series}
-        width={400}
-        height={200}
+        height={150}
         showArea
         showYAxis
         yAxis={{

--- a/libs/ui-rnative-visualization/src/lib/Components/Axis/Axis.constants.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Axis/Axis.constants.ts
@@ -1,0 +1,23 @@
+import { DEFAULT_AXIS_WIDTH } from './YAxis';
+
+import type { XAxisProps } from './XAxis';
+import type { YAxisProps } from './YAxis';
+
+export const defaultXAxisProps: XAxisProps = {
+  position: 'bottom',
+  showGrid: false,
+  showLine: false,
+  showTickMark: false,
+  scaleType: 'linear',
+  nice: false,
+};
+
+export const defaultYAxisProps: YAxisProps = {
+  position: 'start',
+  showGrid: false,
+  showLine: false,
+  showTickMark: false,
+  scaleType: 'linear',
+  nice: true,
+  width: DEFAULT_AXIS_WIDTH,
+};

--- a/libs/ui-rnative-visualization/src/lib/Components/Axis/Axis.constants.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Axis/Axis.constants.ts
@@ -1,6 +1,6 @@
+import type { XAxisProps } from './XAxis';
 import { DEFAULT_AXIS_WIDTH } from './YAxis';
 
-import type { XAxisProps } from './XAxis';
 import type { YAxisProps } from './YAxis';
 
 export const defaultXAxisProps: XAxisProps = {

--- a/libs/ui-rnative-visualization/src/lib/Components/Axis/Axis.types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Axis/Axis.types.ts
@@ -1,3 +1,8 @@
+export type AxisBounds = {
+  min: number;
+  max: number;
+};
+
 export type BaseAxisProps = {
   /**
    * Whether to render grid lines at each tick.
@@ -29,4 +34,39 @@ export type BaseAxisProps = {
    * Receives the raw tick value (number or string label) and must return a string.
    */
   tickLabelFormatter?: (value: number | string) => string;
+  /**
+   * Scale algorithm used by this axis.
+   * @default 'linear'
+   */
+  scaleType?: 'linear' | 'log' | 'band';
+  /**
+   * Explicit data values for band scales or category labels.
+   * For band scales, provides the discrete domain. For numeric scales, string values
+   * are used as tick labels at corresponding indices.
+   */
+  data?: string[] | number[];
+  /**
+   * Fixed domain bounds or a function that adjusts the computed bounds.
+   * A partial object overrides only the specified bound(s).
+   * A function receives the auto-computed bounds and returns adjusted ones.
+   *
+   * Applied before {@link BaseAxisProps.nice}. To keep your bounds exactly as
+   * provided, set `nice: false` alongside a full `{ min, max }` override.
+   */
+  domain?: Partial<AxisBounds> | ((bounds: AxisBounds) => AxisBounds);
+  /**
+   * Round the domain outward to clean boundaries via d3's `.nice()`
+   * (e.g. `[4, 98]` becomes `[0, 100]`).
+   *
+   * Defaults to `true` for Y Axis and `false` for X Axis.
+   *
+   * Set to `false` to keep the domain exactly as provided
+   * so data fills the plot area boundary-to-boundary — typically only useful
+   * when you also pass a full `domain: { min, max }` and don't have overlays
+   * (reference lines, scrubber positions, annotations) that may sit outside
+   * the data range.
+   *
+   * Applied after any {@link BaseAxisProps.domain} override.
+   */
+  nice?: boolean;
 };

--- a/libs/ui-rnative-visualization/src/lib/Components/Axis/index.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Axis/index.ts
@@ -1,0 +1,2 @@
+export * from './Axis.types';
+export * from './Axis.constants';

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
@@ -9,7 +9,8 @@ import { RevealClipDefs } from './RevealClip';
 import type { CartesianChartProps } from './types';
 import {
   DEFAULT_HEIGHT,
-  OVERFLOW_NEGATIVE_MARGIN,
+  OVERFLOW_BUFFER,
+  OVERFLOW_OFFSET,
   resolveAxisPadding,
   resolveInset,
 } from './utils';
@@ -43,6 +44,15 @@ export function CartesianChart({
 
   const resolvedWidth = width ?? measuredWidth ?? 0;
 
+  // The SVG canvas is enlarged by the overflow buffer on every side so edge
+  // content (labels, points, ticks) is not clipped, then shifted back by the
+  // negative margin so the drawing area still spans the container footprint.
+  const svgWidth =
+    resolvedWidth > 0
+      ? resolvedWidth + OVERFLOW_BUFFER.left + OVERFLOW_BUFFER.right
+      : 0;
+  const svgHeight = height + OVERFLOW_BUFFER.top + OVERFLOW_BUFFER.bottom;
+
   const resolvedInset = useMemo(() => resolveInset(inset), [inset]);
   const resolvedAxisPadding = useMemo(
     () => resolveAxisPadding(axisPadding),
@@ -53,8 +63,8 @@ export function CartesianChart({
     series,
     xAxis,
     yAxis,
-    width: resolvedWidth,
-    height,
+    width: svgWidth,
+    height: svgHeight,
     inset: resolvedInset,
     axisPadding: resolvedAxisPadding,
   });
@@ -68,23 +78,24 @@ export function CartesianChart({
       style={{
         width: needsMeasurement ? undefined : resolvedWidth,
         height,
-        ...OVERFLOW_NEGATIVE_MARGIN,
+        overflow: 'visible',
       }}
     >
       {resolvedWidth > 0 && (
         <CartesianChartProvider value={contextValue}>
           <MagneticPointsProvider>
             <ScrubberProvider
-              width={resolvedWidth}
-              height={height}
+              width={svgWidth}
+              height={svgHeight}
               enableScrubbing={enableScrubbing}
               onScrubberPositionChange={onScrubberPositionChange}
+              style={OVERFLOW_OFFSET}
               magnetRadius={magnetRadius}
             >
               <Svg
                 testID='chart-svg'
-                width={resolvedWidth}
-                height={height}
+                width={svgWidth}
+                height={svgHeight}
                 style={{ overflow: 'visible' }}
               >
                 <RevealClipDefs

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/CartesianChart.tsx
@@ -45,8 +45,8 @@ export function CartesianChart({
   const resolvedWidth = width ?? measuredWidth ?? 0;
 
   // The SVG canvas is enlarged by the overflow buffer on every side so edge
-  // content (labels, points, ticks) is not clipped, then shifted back by the
-  // negative margin so the drawing area still spans the container footprint.
+  // content (labels, points, ticks) is not clipped, then shifted back by
+  // `OVERFLOW_OFFSET` so the drawing area still spans the container footprint.
   const svgWidth =
     resolvedWidth > 0
       ? resolvedWidth + OVERFLOW_BUFFER.left + OVERFLOW_BUFFER.right

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/context/useBuildChartContext.test.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/context/useBuildChartContext.test.ts
@@ -221,4 +221,60 @@ describe('useBuildChartContext', () => {
     expect(result.current.drawingArea.width).toBe(400 - 40);
     expect(result.current.drawingArea.height).toBe(200 - 28);
   });
+
+  describe('nice domain prop', () => {
+    // Series of length 3770 → auto X domain is [0, 3769]; `.nice()` rounds it
+    // outward to [0, 4000] (the trailing "dead zone" keeps overlays that sit
+    // outside the data range — e.g. reference lines — from being clipped).
+    const longSeries = makeSeries(Array.from({ length: 3770 }, (_, i) => i));
+
+    it('rounds the X domain by default (.nice())', () => {
+      const { result } = renderHook(() =>
+        useBuildChartContext(hookParams({ series: [longSeries] })),
+      );
+      expect(result.current.getXScale()!.domain()).toEqual([0, 4000]);
+    });
+
+    it('rounds the Y domain by default (.nice())', () => {
+      const { result } = renderHook(() =>
+        useBuildChartContext(
+          hookParams({
+            yAxis: {
+              domain: (bounds: { min: number; max: number }) => ({
+                min: bounds.min - 5,
+                max: bounds.max + 5,
+              }),
+            },
+          }),
+        ),
+      );
+      expect(result.current.getYScale()!.domain()).toEqual([0, 40]);
+    });
+
+    it('opts the X axis out of .nice() when nice is false', () => {
+      const { result } = renderHook(() =>
+        useBuildChartContext(
+          hookParams({ series: [longSeries], xAxis: { nice: false } }),
+        ),
+      );
+      expect(result.current.getXScale()!.domain()).toEqual([0, 3769]);
+    });
+
+    it('opts the Y axis out of .nice() when nice is false', () => {
+      const { result } = renderHook(() =>
+        useBuildChartContext(
+          hookParams({
+            yAxis: {
+              nice: false,
+              domain: (bounds: { min: number; max: number }) => ({
+                min: bounds.min - 5,
+                max: bounds.max + 5,
+              }),
+            },
+          }),
+        ),
+      );
+      expect(result.current.getYScale()!.domain()).toEqual([5, 35]);
+    });
+  });
 });

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/context/useBuildChartContext.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/context/useBuildChartContext.ts
@@ -11,19 +11,18 @@ import {
   isBandScaleType,
 } from '../../../utils/scales/scales';
 import type {
-  AxisBounds,
-  AxisConfigProps,
   CartesianChartContextValue,
   ChartInset,
   ChartScaleFunction,
   DrawingArea,
   Series,
 } from '../../../utils/types';
+import type { AxisBounds, BaseAxisProps } from '../../Axis';
 
 type UseBuildChartContextParams = {
   series: Series[];
-  xAxis?: Partial<AxisConfigProps>;
-  yAxis?: Partial<AxisConfigProps>;
+  xAxis?: Partial<BaseAxisProps>;
+  yAxis?: Partial<BaseAxisProps>;
   width: number;
   height: number;
   inset: ChartInset;
@@ -45,11 +44,12 @@ export const computeAxisRange = (
 export const buildScale = (
   domain: AxisBounds,
   range: AxisRange,
-  scaleType: AxisConfigProps['scaleType'] = 'linear',
+  scaleType: BaseAxisProps['scaleType'] = 'linear',
+  nice?: boolean,
 ): ChartScaleFunction =>
   isBandScaleType(scaleType)
     ? getCategoricalScale({ domain, range })
-    : getNumericScale({ scaleType, domain, range });
+    : getNumericScale({ scaleType, domain, range, nice });
 
 export const computeDrawingArea = (
   width: number,
@@ -94,8 +94,8 @@ export const useBuildChartContext = ({
     if (drawingArea.width > 0 && drawingArea.height > 0) {
       const xDomain = computeXDomain(series, xAxis);
       const yDomain = computeYDomain(series, yAxis);
-      xScale = buildScale(xDomain, xRange, xAxis?.scaleType);
-      yScale = buildScale(yDomain, yRange, yAxis?.scaleType);
+      xScale = buildScale(xDomain, xRange, xAxis?.scaleType, xAxis?.nice);
+      yScale = buildScale(yDomain, yRange, yAxis?.scaleType, yAxis?.nice);
     }
 
     const dataLength = computeDataLength(series, xAxis);

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 
-import type { AxisConfigProps, ChartInset, Series } from '../../utils/types';
+import type { ChartInset, Series } from '../../utils/types';
+import type { BaseAxisProps } from '../Axis';
 
 export type CartesianChartProps = {
   /**
@@ -10,11 +11,11 @@ export type CartesianChartProps = {
   /**
    * Scale and domain configuration for the x-axis.
    */
-  xAxis?: Partial<AxisConfigProps>;
+  xAxis?: Partial<BaseAxisProps>;
   /**
    * Scale and domain configuration for the y-axis.
    */
-  yAxis?: Partial<AxisConfigProps>;
+  yAxis?: Partial<BaseAxisProps>;
   /**
    * Width of the chart in pixels.
    * When omitted, the component auto-measures via `onLayout`.

--- a/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/utils.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/CartesianChart/utils.ts
@@ -4,9 +4,11 @@ import type { CartesianChartProps } from './types';
 export const DEFAULT_HEIGHT = 160;
 
 /**
- * Internal buffer that prevents SVG content (labels, points, ticks) from being
- * clipped at the edge of the container. Compensated by negative margins on the
- * wrapper so the chart's visual footprint stays unchanged.
+ * Internal buffer added around the drawing area so SVG content (labels, points,
+ * ticks) drawn at the edges is not clipped. The SVG canvas is enlarged by this
+ * buffer on every side and shifted back by {@link OVERFLOW_OFFSET} so
+ * the chart's layout footprint (and the drawing area) stays exactly the
+ * consumer-provided width/height.
  */
 export const OVERFLOW_BUFFER: ChartInset = {
   top: 50,
@@ -14,11 +16,19 @@ export const OVERFLOW_BUFFER: ChartInset = {
   bottom: 50,
   left: 50,
 };
-export const OVERFLOW_NEGATIVE_MARGIN = {
-  marginTop: -OVERFLOW_BUFFER.top,
-  marginRight: -OVERFLOW_BUFFER.right,
-  marginBottom: -OVERFLOW_BUFFER.bottom,
-  marginLeft: -OVERFLOW_BUFFER.left,
+/**
+ * Top/left offset applied to the (enlarged) SVG group so its drawing area aligns
+ * with the container's top-left. The extra width/height added to the SVG
+ * overflows symmetrically on every side via `overflow: visible`.
+ *
+ * Uses `position: relative` to keep parity with the web implementation, where a
+ * negative `margin-top` would collapse through the container instead of
+ * offsetting the SVG inside it.
+ */
+export const OVERFLOW_OFFSET = {
+  position: 'relative' as const,
+  top: -OVERFLOW_BUFFER.top,
+  left: -OVERFLOW_BUFFER.left,
 };
 export const ZERO_PADDING: ChartInset = {
   top: 0,

--- a/libs/ui-rnative-visualization/src/lib/Components/Line/utils.test.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Line/utils.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { getCategoricalScale, getNumericScale } from '../../utils/scales/scales';
+
+import { toScaledPoints } from './utils';
+
+const xScale = getNumericScale({
+  scaleType: 'linear',
+  domain: { min: 0, max: 7 },
+  range: { min: 0, max: 800 },
+  nice: false,
+});
+
+const yScale = getNumericScale({
+  scaleType: 'linear',
+  domain: { min: 0, max: 100 },
+  range: { min: 200, max: 0 },
+});
+
+describe('toScaledPoints', () => {
+  it('uses index as x input when no xData is provided', () => {
+    const data = [10, 50, 90];
+    const points = toScaledPoints(data, xScale, yScale);
+
+    expect(points).not.toBeNull();
+    expect(points).toHaveLength(3);
+    expect(points![0][0]).toBe(0);
+    expect(points![1][0]).toBeCloseTo(800 / 7);
+    expect(points![2][0]).toBeCloseTo((800 / 7) * 2);
+  });
+
+  it('caps iteration to xData.length when series is longer', () => {
+    const data = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+    const xData = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug'];
+
+    const points = toScaledPoints(data, xScale, yScale, xData);
+
+    expect(points).not.toBeNull();
+    expect(points).toHaveLength(xData.length);
+    expect(points![0][0]).toBe(0);
+    expect(points![points!.length - 1][0]).toBe(800);
+  });
+
+  it('skips null values without affecting the cap', () => {
+    const data: (number | null)[] = [10, null, 30, 40, 50, 60, 70, 80, 90];
+    const xData = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+
+    const points = toScaledPoints(data, xScale, yScale, xData);
+
+    expect(points).not.toBeNull();
+    expect(points).toHaveLength(7);
+    expect(points![points!.length - 1][0]).toBe((800 / 7) * 7);
+  });
+
+  it('uses numeric xData values as the x input', () => {
+    const data = [10, 20, 30];
+    const customX = [0, 3.5, 7];
+
+    const points = toScaledPoints(data, xScale, yScale, customX);
+
+    expect(points![0][0]).toBe(0);
+    expect(points![1][0]).toBeCloseTo(400);
+    expect(points![2][0]).toBe(800);
+  });
+
+  it('centers points within categorical band scales', () => {
+    const bandScale = getCategoricalScale({
+      domain: { min: 0, max: 2 },
+      range: { min: 0, max: 300 },
+      padding: 0,
+    });
+    const data = [10, 50, 90];
+
+    const points = toScaledPoints(data, bandScale, yScale);
+
+    expect(points).toHaveLength(3);
+    const bandwidth = bandScale.bandwidth();
+    expect(points![0][0]).toBe((bandScale(0) ?? 0) + bandwidth / 2);
+  });
+
+  it('returns null when fewer than 2 valid points remain', () => {
+    const data: (number | null)[] = [10, null, null];
+    const xData = ['A', 'B', 'C'];
+
+    expect(toScaledPoints(data, xScale, yScale, xData)).toBeNull();
+  });
+});

--- a/libs/ui-rnative-visualization/src/lib/Components/Line/utils.test.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Line/utils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { getCategoricalScale, getNumericScale } from '../../utils/scales/scales';
+import {
+  getCategoricalScale,
+  getNumericScale,
+} from '../../utils/scales/scales';
 
 import { toScaledPoints } from './utils';
 

--- a/libs/ui-rnative-visualization/src/lib/Components/Line/utils.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Line/utils.ts
@@ -14,6 +14,10 @@ type Point = [x: number, y: number];
  *
  * When `xData` contains numeric values, those values are fed into the scale
  * instead of the array index so the points honour a numeric X domain.
+ *
+ * When `xData` is provided, iteration is capped at `xData.length` so a series
+ * with more points than the axis has labels does not overflow past the right
+ * edge of the chart. The axis is treated as authoritative for the X domain.
  */
 export const toScaledPoints = (
   data: (number | null)[],
@@ -22,8 +26,9 @@ export const toScaledPoints = (
   xData?: readonly (string | number)[],
 ): Point[] | null => {
   const pts: Point[] = [];
+  const limit = xData ? Math.min(data.length, xData.length) : data.length;
 
-  for (let i = 0; i < data.length; i++) {
+  for (let i = 0; i < limit; i++) {
     const value = data[i];
     if (value === null) continue;
 

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.stories.tsx
@@ -76,6 +76,42 @@ export const WithXAxis: Story = {
   },
 };
 
+export const XAxisExplicitNumericData: Story = {
+  parameters: {
+    layout: 'centered',
+    backgrounds: { default: 'light' },
+  },
+  args: {
+    series: sampleSeries,
+    width: 400,
+    height: 250,
+    showXAxis: true,
+    xAxis: {
+      showLine: true,
+      showGrid: true,
+      data: [0, 2, 4],
+    },
+  },
+};
+
+export const XAxisStringData: Story = {
+  parameters: {
+    layout: 'centered',
+    backgrounds: { default: 'light' },
+  },
+  args: {
+    series: sampleSeries,
+    width: 400,
+    height: 250,
+    showXAxis: true,
+    xAxis: {
+      showLine: true,
+      showGrid: true,
+      data: ['Jan', 'Feb', 'Mar'],
+    },
+  },
+};
+
 export const WithStringLabels: Story = {
   parameters: {
     layout: 'centered',

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.test.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from '@jest/globals';
 import { ledgerLiveThemes } from '@ledgerhq/lumen-design-core';
 import { ThemeProvider } from '@ledgerhq/lumen-ui-rnative';
 import { render } from '@testing-library/react-native';
+import { Circle } from 'react-native-svg';
 
 import { LineChart } from './LineChart';
 
@@ -95,6 +96,161 @@ describe('LineChart', () => {
           height={200}
           animate={false}
         />
+      </LineChartWrapper>,
+    );
+    getByTestId('chart-svg');
+  });
+
+  it('renders a Path for each series when multiple series are provided', () => {
+    const multipleSeries = [
+      { id: 'a', stroke: '#000', data: [10, 20, 30, 40, 50] },
+      { id: 'b', stroke: '#f00', data: [5, 15, 25, 35, 45] },
+    ];
+    const { getAllByTestId } = render(
+      <LineChartWrapper>
+        <LineChart series={multipleSeries} width={400} height={200} />
+      </LineChartWrapper>,
+    );
+    expect(getAllByTestId('line-path')).toHaveLength(2);
+  });
+
+  it('renders an area fill for each series when showArea is true', () => {
+    const multipleSeries = [
+      { id: 'a', stroke: '#000', data: [10, 20, 30, 40, 50] },
+      { id: 'b', stroke: '#f00', data: [5, 15, 25, 35, 45] },
+    ];
+    const { getAllByTestId } = render(
+      <LineChartWrapper>
+        <LineChart series={multipleSeries} width={400} height={200} showArea />
+      </LineChartWrapper>,
+    );
+    expect(getAllByTestId('line-area')).toHaveLength(2);
+  });
+
+  it('renders custom children inside the chart', () => {
+    const { getByTestId } = render(
+      <LineChartWrapper>
+        <LineChart series={sampleSeries} width={400} height={200}>
+          <Circle testID='custom-child' cx={10} cy={10} r={5} />
+        </LineChart>
+      </LineChartWrapper>,
+    );
+    getByTestId('custom-child');
+  });
+
+  it('renders x-axis tick labels when showXAxis is true', () => {
+    const { getByText } = render(
+      <LineChartWrapper>
+        <LineChart
+          series={sampleSeries}
+          width={400}
+          height={200}
+          showXAxis
+          xAxis={{ ticks: [0, 2, 4] }}
+        />
+      </LineChartWrapper>,
+    );
+    getByText('0');
+    getByText('2');
+    getByText('4');
+  });
+
+  it('renders x-axis tick labels when positioned at the top', () => {
+    const { getByText } = render(
+      <LineChartWrapper>
+        <LineChart
+          series={sampleSeries}
+          width={400}
+          height={200}
+          showXAxis
+          xAxis={{ position: 'top', ticks: [0, 4] }}
+        />
+      </LineChartWrapper>,
+    );
+    getByText('0');
+    getByText('4');
+  });
+
+  it('renders y-axis tick labels when showYAxis is true', () => {
+    const { getByText } = render(
+      <LineChartWrapper>
+        <LineChart
+          series={sampleSeries}
+          width={400}
+          height={200}
+          showYAxis
+          yAxis={{ ticks: [10, 50] }}
+        />
+      </LineChartWrapper>,
+    );
+    getByText('10');
+    getByText('50');
+  });
+
+  it('renders y-axis tick labels when positioned at the end', () => {
+    const { getByText } = render(
+      <LineChartWrapper>
+        <LineChart
+          series={sampleSeries}
+          width={400}
+          height={200}
+          showYAxis
+          yAxis={{ position: 'end', ticks: [10, 50] }}
+        />
+      </LineChartWrapper>,
+    );
+    getByText('10');
+    getByText('50');
+  });
+
+  it('does not render axis tick labels by default', () => {
+    const { queryByText } = render(
+      <LineChartWrapper>
+        <LineChart
+          series={sampleSeries}
+          width={400}
+          height={200}
+          xAxis={{ ticks: [0, 2, 4] }}
+        />
+      </LineChartWrapper>,
+    );
+    expect(queryByText('0')).toBeNull();
+    expect(queryByText('2')).toBeNull();
+    expect(queryByText('4')).toBeNull();
+  });
+
+  it('renders with scrubbing enabled', () => {
+    const { getByTestId } = render(
+      <LineChartWrapper>
+        <LineChart
+          series={sampleSeries}
+          width={400}
+          height={200}
+          enableScrubbing
+        />
+      </LineChartWrapper>,
+    );
+    getByTestId('chart-svg');
+  });
+
+  it('renders with a custom inset', () => {
+    const { getByTestId } = render(
+      <LineChartWrapper>
+        <LineChart
+          series={sampleSeries}
+          width={400}
+          height={200}
+          inset={{ top: 10, bottom: 10, left: 20, right: 20 }}
+        />
+      </LineChartWrapper>,
+    );
+    expect(getByTestId('line-path')).toBeTruthy();
+  });
+
+  it('uses the default height when none is provided', () => {
+    const { getByTestId } = render(
+      <LineChartWrapper>
+        <LineChart series={sampleSeries} width={400} />
       </LineChartWrapper>,
     );
     getByTestId('chart-svg');

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 
-import type { AxisConfigProps, ChartInset } from '../../utils/types';
+import type { ChartInset } from '../../utils/types';
+import { defaultXAxisProps, defaultYAxisProps } from '../Axis';
 import { DEFAULT_AXIS_HEIGHT, XAxis } from '../Axis/XAxis';
-import { DEFAULT_AXIS_WIDTH, YAxis } from '../Axis/YAxis';
+import { YAxis } from '../Axis/YAxis';
 import { CartesianChart } from '../CartesianChart';
 import { Line } from '../Line';
 
@@ -25,51 +26,38 @@ export const LineChart = ({
   animate,
   magnetRadius,
 }: LineChartProps) => {
-  const {
-    scaleType: xScaleType,
-    data: xData,
-    domain: xDomain,
-    ...xAxisVisualProps
-  } = xAxis ?? {};
-
-  const {
-    scaleType: yScaleType,
-    data: yData,
-    domain: yDomain,
-    ...yAxisVisualProps
-  } = yAxis ?? {};
-
-  const xAxisConfig: Partial<AxisConfigProps> = {
-    scaleType: xScaleType,
-    data: xData,
-    domain: xDomain,
+  const xAxisConfig = {
+    ...defaultXAxisProps,
+    ...xAxis,
   };
-
-  const yAxisConfig: Partial<AxisConfigProps> = {
-    scaleType: yScaleType,
-    data: yData,
-    domain: yDomain,
+  const yAxisConfig = {
+    ...defaultYAxisProps,
+    ...yAxis,
   };
 
   const axisPadding: Partial<ChartInset> | undefined = useMemo(() => {
-    if (!showXAxis && !showYAxis) return undefined;
-    const xAxisPosition =
-      xAxisVisualProps.position === 'top' ? 'top' : 'bottom';
-    const yAxisPosition =
-      yAxisVisualProps.position === 'end' ? 'right' : 'left';
-    const yAxisWidth = yAxisVisualProps.width ?? DEFAULT_AXIS_WIDTH;
+    if (!showXAxis && !showYAxis) {
+      return undefined;
+    }
+
     return {
-      top: showXAxis && xAxisPosition === 'top' ? DEFAULT_AXIS_HEIGHT : 0,
-      bottom: showXAxis && xAxisPosition === 'bottom' ? DEFAULT_AXIS_HEIGHT : 0,
-      left: showYAxis && yAxisPosition === 'left' ? yAxisWidth : 0,
-      right: showYAxis && yAxisPosition === 'right' ? yAxisWidth : 0,
+      top:
+        showXAxis && xAxisConfig.position === 'top' ? DEFAULT_AXIS_HEIGHT : 0,
+      bottom:
+        showXAxis && xAxisConfig.position === 'bottom'
+          ? DEFAULT_AXIS_HEIGHT
+          : 0,
+      left:
+        showYAxis && yAxisConfig.position === 'start' ? yAxisConfig.width : 0,
+      right:
+        showYAxis && yAxisConfig.position === 'end' ? yAxisConfig.width : 0,
     };
   }, [
     showXAxis,
     showYAxis,
-    xAxisVisualProps.position,
-    yAxisVisualProps.position,
-    yAxisVisualProps.width,
+    xAxisConfig?.position,
+    yAxisConfig?.position,
+    yAxisConfig?.width,
   ]);
 
   return (
@@ -86,8 +74,8 @@ export const LineChart = ({
       animate={animate}
       magnetRadius={magnetRadius}
     >
-      {showXAxis && <XAxis {...xAxisVisualProps} />}
-      {showYAxis && <YAxis {...yAxisVisualProps} />}
+      {showXAxis && <XAxis {...xAxisConfig} />}
+      {showYAxis && <YAxis {...yAxisConfig} />}
       {series?.map((s) => (
         <Line
           key={s.id}

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/types.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import type { AxisConfigProps, ChartInset, Series } from '../../utils/types';
+import type { ChartInset, Series } from '../../utils/types';
 import type { XAxisProps } from '../Axis/XAxis';
 import type { YAxisProps } from '../Axis/YAxis';
 
@@ -35,12 +35,12 @@ export type LineChartProps = {
    * Combined axis configuration and visual props for the x-axis.
    * Includes scale/domain settings as well as visual options like `showGrid` and `showLine`.
    */
-  xAxis?: Partial<AxisConfigProps> & XAxisProps;
+  xAxis?: XAxisProps;
   /**
    * Combined axis configuration and visual props for the y-axis.
    * Includes scale/domain settings as well as visual options like `showGrid` and `showLine`.
    */
-  yAxis?: Partial<AxisConfigProps> & YAxisProps;
+  yAxis?: YAxisProps;
   /**
    * Width of the chart in pixels.
    * When omitted, the component auto-measures via `onLayout`.

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/utils.test.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import { renderHook } from '@testing-library/react-native';
 
-import type { AxisConfigProps } from '../../utils/types';
+import type { BaseAxisProps } from '../Axis';
 import { ARROW_HEIGHT, ARROW_WIDTH, GAP, LABEL_FONT_SIZE } from './constants';
 import {
   buildArrowPoints,
@@ -124,7 +124,7 @@ const makeContext = () => ({
   getMagneticPoints: () => new Set<number>(),
 });
 
-const noAxisConfig = (): AxisConfigProps | undefined => undefined;
+const noAxisConfig = (): BaseAxisProps | undefined => undefined;
 
 describe('useMagneticRegistration', () => {
   it('registers the data index when magnetic is true', () => {
@@ -153,7 +153,7 @@ describe('useMagneticRegistration', () => {
 
   it('resolves dataX through axis config data when provided', () => {
     const ctx = makeContext();
-    const getXAxisConfig = (): AxisConfigProps => ({
+    const getXAxisConfig = (): BaseAxisProps => ({
       scaleType: 'band',
       data: [100, 200, 300],
     });
@@ -165,7 +165,7 @@ describe('useMagneticRegistration', () => {
 
   it('does not register when axis data exists but does not contain the value', () => {
     const ctx = makeContext();
-    const getXAxisConfig = (): AxisConfigProps => ({
+    const getXAxisConfig = (): BaseAxisProps => ({
       scaleType: 'band',
       data: [100, 200, 300],
     });

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/utils.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/utils.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
-import type { AxisConfigProps, DrawingArea } from '../../utils/types';
+import type { DrawingArea } from '../../utils/types';
+import type { BaseAxisProps } from '../Axis';
 import { LABEL_FONT_SIZE, ARROW_WIDTH, ARROW_HEIGHT, GAP } from './constants';
 import type { MagneticPointsContextValue } from './pointContext/magneticPointsContext';
 
@@ -52,7 +53,7 @@ export const resolveLabel = (
 
 export const resolveDataXToIndex = (
   dataX: number,
-  axisConfig: AxisConfigProps | undefined,
+  axisConfig: BaseAxisProps | undefined,
 ): number | undefined => {
   const axisData = axisConfig?.data;
   if (!axisData || typeof axisData[0] !== 'number') return dataX;
@@ -68,7 +69,7 @@ export const resolveDataXToIndex = (
 export const useMagneticRegistration = (
   magnetic: boolean,
   dataX: number,
-  getXAxisConfig: () => AxisConfigProps | undefined,
+  getXAxisConfig: () => BaseAxisProps | undefined,
   { register, unregister }: MagneticPointsContextValue,
 ): void => {
   useEffect(() => {

--- a/libs/ui-rnative-visualization/src/lib/Components/ReferenceLine/utils.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/ReferenceLine/utils.ts
@@ -1,9 +1,6 @@
 import { getPointOnScale, isCategoricalScale } from '../../utils/scales/scales';
-import type {
-  AxisConfigProps,
-  ChartScaleFunction,
-  DrawingArea,
-} from '../../utils/types';
+import type { ChartScaleFunction, DrawingArea } from '../../utils/types';
+import type { BaseAxisProps } from '../Axis';
 
 import type { LabelAlignment, LabelPosition } from './types';
 
@@ -28,7 +25,7 @@ type ResolvePixelParams = {
   scale: ChartScaleFunction | undefined;
   axis: 'x' | 'y';
   drawingArea: DrawingArea;
-  axisConfig?: AxisConfigProps;
+  axisConfig?: BaseAxisProps;
 };
 
 type LabelParams = {
@@ -95,7 +92,7 @@ export const isPixelWithinDrawingArea = (
  */
 const resolveDataValue = (
   index: number,
-  axisConfig?: AxisConfigProps,
+  axisConfig?: BaseAxisProps,
 ): number | undefined => {
   const data = axisConfig?.data;
   if (!data || data.length === 0) return index;

--- a/libs/ui-rnative-visualization/src/lib/Components/Scrubber/DefaultScrubberTooltip/DefaultScrubberTooltip.test.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Scrubber/DefaultScrubberTooltip/DefaultScrubberTooltip.test.tsx
@@ -148,7 +148,7 @@ describe('DefaultScrubberTooltip', () => {
         scrubberProps: { tooltip: defaultTooltip },
         scrubberContext: scrubberAt(2),
       });
-      expect(getByTestId('chart-tooltip-rect').props.x).toBe(210);
+      expect(getByTestId('chart-tooltip-rect').props.x).toBe(260);
     });
 
     it('flips tooltip left when right side would overflow (index 3)', () => {
@@ -158,7 +158,7 @@ describe('DefaultScrubberTooltip', () => {
         },
         scrubberContext: scrubberAt(3),
       });
-      expect(getByTestId('chart-tooltip-rect').props.x).toBe(145);
+      expect(getByTestId('chart-tooltip-rect').props.x).toBe(220);
     });
 
     it('flips at the rightmost scrubber position (index 4)', () => {
@@ -168,7 +168,7 @@ describe('DefaultScrubberTooltip', () => {
         },
         scrubberContext: scrubberAt(4),
       });
-      expect(getByTestId('chart-tooltip-rect').props.x).toBe(220);
+      expect(getByTestId('chart-tooltip-rect').props.x).toBe(320);
     });
 
     it('custom offset shifts the no-flip tooltip position', () => {
@@ -178,7 +178,7 @@ describe('DefaultScrubberTooltip', () => {
         },
         scrubberContext: scrubberAt(2),
       });
-      expect(getByTestId('chart-tooltip-rect').props.x).toBe(220);
+      expect(getByTestId('chart-tooltip-rect').props.x).toBe(270);
     });
 
     it('wider minWidth can trigger a flip that the default width would not', () => {

--- a/libs/ui-rnative-visualization/src/lib/Components/Scrubber/ScrubberProvider.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Scrubber/ScrubberProvider.tsx
@@ -37,6 +37,7 @@ export function ScrubberProvider({
   enableScrubbing,
   onScrubberPositionChange,
   magnetRadius = 6,
+  style,
 }: Readonly<ScrubberProviderProps>) {
   const [scrubberPosition, setScrubberPosition] = useState<
     number | undefined
@@ -163,7 +164,7 @@ export function ScrubberProvider({
   // context as expected.
   const surface = useMemo(
     () => (
-      <View style={{ width, height }}>
+      <View style={[{ width, height }, style]}>
         {children}
         {enableScrubbing && (
           <GestureDetector gesture={composed}>
@@ -175,7 +176,7 @@ export function ScrubberProvider({
         )}
       </View>
     ),
-    [width, height, children, enableScrubbing, composed],
+    [width, height, style, children, enableScrubbing, composed],
   );
 
   const contextValue = useMemo(

--- a/libs/ui-rnative-visualization/src/lib/Components/Scrubber/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Scrubber/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 import type { DrawingArea } from '../../utils/types';
 
@@ -41,6 +42,12 @@ export type ScrubberProviderProps = {
    * @default 6
    */
   magnetRadius?: number;
+  /**
+   * Optional style applied to the wrapping `View` that holds the chart and the
+   * gesture overlay.Used to offset the(enlarged) SVG group so its drawing area
+   * aligns with the container footprint.
+   */
+  style?: StyleProp<ViewStyle>;
 };
 
 export type ChartTooltipItemData = {

--- a/libs/ui-rnative-visualization/src/lib/Components/Scrubber/utils.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Scrubber/utils.ts
@@ -4,10 +4,10 @@ import {
   isNumericScale,
 } from '../../utils/scales/scales';
 import type {
-  AxisConfigProps,
   CartesianChartContextValue,
   ChartScaleFunction,
 } from '../../utils/types';
+import type { BaseAxisProps } from '../Axis';
 
 export type MagnetEntry = {
   index: number;
@@ -54,7 +54,7 @@ const findClosestIndex = (
 export const getDataIndexFromPosition = (
   pixelX: number,
   scale: ChartScaleFunction,
-  axisConfig: Partial<AxisConfigProps> | undefined,
+  axisConfig: Partial<BaseAxisProps> | undefined,
   dataLength: number,
 ): number => {
   if (dataLength <= 0) return 0;
@@ -121,7 +121,7 @@ export const resolvePixelY = (
 export const resolvePixelX = (
   dataIndex: number,
   getXScale: CartesianChartContextValue['getXScale'],
-  axisConfig?: AxisConfigProps,
+  axisConfig?: BaseAxisProps,
 ): number | undefined => {
   const scale = getXScale();
   if (!scale) return undefined;

--- a/libs/ui-rnative-visualization/src/lib/utils/domain/domain.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/domain/domain.ts
@@ -1,4 +1,5 @@
-import type { AxisBounds, AxisConfigProps, Series } from '../types';
+import type { AxisBounds, BaseAxisProps } from '../../Components/Axis';
+import type { Series } from '../types';
 
 /**
  * Compute the X domain (index-based) from series data and axis config.
@@ -7,7 +8,7 @@ import type { AxisBounds, AxisConfigProps, Series } from '../types';
  */
 export const computeXDomain = (
   series: Series[],
-  axisConfig?: Partial<AxisConfigProps>,
+  axisConfig?: Partial<BaseAxisProps>,
 ): AxisBounds => {
   const axisData = axisConfig?.data;
 
@@ -44,7 +45,7 @@ export const computeXDomain = (
  */
 export const computeYDomain = (
   series: Series[],
-  axisConfig?: Partial<AxisConfigProps>,
+  axisConfig?: Partial<BaseAxisProps>,
 ): AxisBounds => {
   let min = 0;
   let max = 0;
@@ -76,7 +77,7 @@ export const computeYDomain = (
  */
 export const computeDataLength = (
   series: Series[],
-  axisConfig?: Partial<AxisConfigProps>,
+  axisConfig?: Partial<BaseAxisProps>,
 ): number => {
   if (axisConfig?.data && axisConfig.data.length > 0) {
     return axisConfig.data.length;
@@ -86,7 +87,7 @@ export const computeDataLength = (
 
 const applyDomainOverride = (
   autoBounds: AxisBounds,
-  domainOverride?: AxisConfigProps['domain'],
+  domainOverride?: BaseAxisProps['domain'],
 ): AxisBounds => {
   if (!domainOverride) return autoBounds;
 

--- a/libs/ui-rnative-visualization/src/lib/utils/index.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/index.ts
@@ -1,6 +1,4 @@
 export type {
-  AxisBounds,
-  AxisConfigProps,
   CartesianChartContextValue,
   CategoricalScale,
   ChartInset,

--- a/libs/ui-rnative-visualization/src/lib/utils/scales/scales.test.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/scales/scales.test.ts
@@ -53,6 +53,25 @@ describe('getNumericScale', () => {
     expect(range[0]).toBe(20);
     expect(range[1]).toBe(400);
   });
+
+  it('rounds the domain outward when nice is true (default)', () => {
+    const scale = getNumericScale({
+      scaleType: 'linear',
+      domain: { min: 0, max: 3769 },
+      range: { min: 0, max: 400 },
+    });
+    expect(scale.domain()).toEqual([0, 4000]);
+  });
+
+  it('keeps the domain exact when nice is false', () => {
+    const scale = getNumericScale({
+      scaleType: 'linear',
+      domain: { min: 0, max: 3769 },
+      range: { min: 0, max: 400 },
+      nice: false,
+    });
+    expect(scale.domain()).toEqual([0, 3769]);
+  });
 });
 
 describe('getCategoricalScale', () => {

--- a/libs/ui-rnative-visualization/src/lib/utils/scales/scales.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/scales/scales.ts
@@ -1,31 +1,37 @@
 import { scaleBand, scaleLinear, scaleLog } from 'd3-scale';
 
+import type { AxisBounds, BaseAxisProps } from '../../Components/Axis';
 import type {
-  AxisBounds,
-  AxisConfigProps,
   CategoricalScale,
   ChartScaleFunction,
   NumericScale,
 } from '../types';
 
 /**
- * Creates a numeric scale with `.nice()` applied so the domain
- * extends to clean rounded boundaries (e.g. `[4, 98]` → `[0, 100]`).
+ * Creates a numeric scale.
+ *
+ * When `nice` is `true` (default), the domain is rounded outward to clean
+ * boundaries via d3's `.nice()` (e.g. `[4, 98]` → `[0, 100]`). Set `nice` to
+ * `false` to keep the domain exactly as provided so data fills the range
+ * boundary-to-boundary.
  */
 export const getNumericScale = ({
   scaleType,
   domain,
   range,
+  nice = true,
 }: {
   scaleType: 'linear' | 'log';
   domain: AxisBounds;
   range: AxisBounds;
+  nice?: boolean;
 }): NumericScale => {
   const scale = scaleType === 'log' ? scaleLog() : scaleLinear();
-  return scale
-    .domain([domain.min, domain.max])
-    .nice()
-    .range([range.min, range.max]);
+  scale.domain([domain.min, domain.max]);
+  if (nice) {
+    scale.nice();
+  }
+  return scale.range([range.min, range.max]);
 };
 
 export const getCategoricalScale = ({
@@ -52,7 +58,7 @@ export const getCategoricalScale = ({
  * Checks if a scale type config value refers to a band (categorical) scale.
  */
 export const isBandScaleType = (
-  scaleType: AxisConfigProps['scaleType'],
+  scaleType: BaseAxisProps['scaleType'],
 ): scaleType is 'band' => scaleType === 'band';
 
 /**

--- a/libs/ui-rnative-visualization/src/lib/utils/ticks/ticks.test.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/ticks/ticks.test.ts
@@ -36,6 +36,24 @@ describe('getTickValues', () => {
   it('should return full domain for band scales', () => {
     expect(getTickValues(bandScale)).toEqual([0, 1, 2, 3, 4]);
   });
+
+  it('should return numeric axis data verbatim (no d3-invented intermediate ticks)', () => {
+    expect(getTickValues(numericScale, undefined, [0, 2, 4])).toEqual([
+      0, 2, 4,
+    ]);
+  });
+
+  it('should return indices for string axis data', () => {
+    expect(
+      getTickValues(numericScale, undefined, ['Jan', 'Feb', 'Mar']),
+    ).toEqual([0, 1, 2]);
+  });
+
+  it('should prioritize explicit ticks over axis data', () => {
+    expect(
+      getTickValues(numericScale, [10, 20], ['Jan', 'Feb', 'Mar']),
+    ).toEqual([10, 20]);
+  });
 });
 
 describe('getTickPosition', () => {
@@ -119,6 +137,33 @@ describe('buildTicksData', () => {
     });
     expect(result[0].label).toBe('Mon');
     expect(result[1].label).toBe('Tue');
+  });
+
+  it('should derive ticks from numeric axis data (no intermediate ticks)', () => {
+    const result = buildTicksData(numericScale, { data: [0, 2, 4] });
+    expect(result.map((t: { value: number }) => t.value)).toEqual([0, 2, 4]);
+    expect(result.map((t: { label: string }) => t.label)).toEqual([
+      '0',
+      '2',
+      '4',
+    ]);
+  });
+
+  it('should derive ticks from string axis data without intermediate values', () => {
+    const stringScale = getNumericScale({
+      scaleType: 'linear',
+      domain: { min: 0, max: 2 },
+      range: { min: 0, max: 500 },
+    });
+    const result = buildTicksData(stringScale, {
+      data: ['Jan', 'Feb', 'Mar'],
+    });
+    expect(result.map((t: { value: number }) => t.value)).toEqual([0, 1, 2]);
+    expect(result.map((t: { label: string }) => t.label)).toEqual([
+      'Jan',
+      'Feb',
+      'Mar',
+    ]);
   });
 
   it('should apply tick formatter', () => {

--- a/libs/ui-rnative-visualization/src/lib/utils/ticks/ticks.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/ticks/ticks.ts
@@ -1,9 +1,6 @@
+import type { BaseAxisProps } from '../../Components/Axis';
 import { isCategoricalScale, isNumericScale } from '../scales/scales';
-import type {
-  AxisConfigProps,
-  ChartScaleFunction,
-  DrawingArea,
-} from '../types';
+import type { ChartScaleFunction, DrawingArea } from '../types';
 
 export const APPROXIMATE_TICK_COUNT = 5;
 
@@ -15,13 +12,26 @@ export type TickData = {
 
 /**
  * Resolves which numeric tick values should appear on the axis.
- * Explicit ticks take priority, then scale-specific defaults.
+ *
+ * Priority:
+ * 1. Explicit `ticks` provided by the consumer.
+ * 2. Axis `data` — when provided, ticks come from the data itself (numeric
+ *    values for numeric data, indices for string data) so the rendered ticks
+ *    mirror exactly what the consumer asked for, with no d3-invented
+ *    intermediate values.
+ * 3. Scale-specific defaults (band domain, or `scale.ticks()` for numeric).
  */
 export const getTickValues = (
   scale: ChartScaleFunction,
   explicitTicks?: number[],
+  axisData?: BaseAxisProps['data'],
 ): number[] => {
   if (explicitTicks) return explicitTicks;
+  if (axisData && axisData.length > 0) {
+    return typeof axisData[0] === 'number'
+      ? (axisData as number[])
+      : axisData.map((_, i) => i);
+  }
   if (isCategoricalScale(scale)) return scale.domain();
   if (isNumericScale(scale)) return scale.ticks(APPROXIMATE_TICK_COUNT);
   return [];
@@ -47,7 +57,7 @@ export const getTickPosition = (
  */
 export const getTickLabel = (
   tick: number,
-  axisData: AxisConfigProps['data'],
+  axisData: BaseAxisProps['data'],
   formatter?: (value: number | string) => string,
 ): string => {
   const hasStringLabels =
@@ -71,12 +81,12 @@ export const getTickLabel = (
  */
 export const buildTicksData = (
   scale: ChartScaleFunction,
-  axisConfig?: AxisConfigProps,
+  axisConfig?: BaseAxisProps,
   explicitTicks?: number[],
   formatter?: (value: number | string) => string,
 ): TickData[] => {
-  const tickValues = getTickValues(scale, explicitTicks);
   const axisData = axisConfig?.data;
+  const tickValues = getTickValues(scale, explicitTicks, axisData);
 
   return tickValues.map((tick) => ({
     position: getTickPosition(scale, tick),

--- a/libs/ui-rnative-visualization/src/lib/utils/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/types.ts
@@ -1,6 +1,6 @@
 import type { ScaleBand, ScaleLinear, ScaleLogarithmic } from 'd3-scale';
 
-export type AxisBounds = { min: number; max: number };
+import type { BaseAxisProps } from '../Components/Axis';
 
 export type ChartInset = {
   top: number;
@@ -38,29 +38,6 @@ export type Series = {
   stroke: string;
 };
 
-export type AxisConfigProps = {
-  /**
-   * Scale algorithm used by this axis.
-   * @default 'linear'
-   */
-  scaleType?: 'linear' | 'log' | 'band';
-  /**
-   * Explicit data values for band scales or category labels.
-   * For band scales, provides the discrete domain. For numeric scales, string values
-   * are used as tick labels at corresponding indices.
-   */
-  data?: string[] | number[];
-  /**
-   * Fixed domain bounds or a function that adjusts the computed bounds.
-   * A partial object overrides only the specified bound(s).
-   * A function receives the auto-computed bounds and returns adjusted ones.
-   *
-   * The final domain is always rounded to nice boundaries via d3's `.nice()`,
-   * ensuring tick marks land on clean values (e.g. `[4, 98]` becomes `[0, 100]`).
-   */
-  domain?: Partial<AxisBounds> | ((bounds: AxisBounds) => AxisBounds);
-};
-
 export type NumericScale =
   | ScaleLinear<number, number>
   | ScaleLogarithmic<number, number>;
@@ -89,11 +66,11 @@ export type CartesianChartContextValue = {
   /**
    * Returns the x-axis config. Accepts an optional axis ID for future multi-axis support.
    */
-  getXAxisConfig: (id?: string) => AxisConfigProps | undefined;
+  getXAxisConfig: (id?: string) => BaseAxisProps | undefined;
   /**
    * Returns the y-axis config. Accepts an optional axis ID for future multi-axis support.
    */
-  getYAxisConfig: (id?: string) => AxisConfigProps | undefined;
+  getYAxisConfig: (id?: string) => BaseAxisProps | undefined;
   /**
    * Pixel bounds of the drawable region.
    */


### PR DESCRIPTION
## Summary

Split out from [#728](https://github.com/LedgerHQ/lumen/pull/728) so the react-native-visualization axis work lands independently.

- `fix(charts)`: respect `xAxis.data` as the source of truth for tick values — `buildTicksData` derives ticks from the data itself instead of `scale.ticks()`, removing d3-invented intermediate ticks. The `ticks: []` short-circuit is preserved.
- `refactor(charts)`: align the axis API with `react-visualization` — consolidate axis config onto a single `BaseAxisProps` type, add a `nice` opt-out on numeric scales (default `true`), and cap `toScaledPoints` iteration at `xData.length` so a series with more points than the axis has labels no longer overflows the right edge.
- Updates the `app-sandbox-rnative` LineCharts demo accordingly.

## Test plan

- [ ] `nx test ui-rnative-visualization`
- [ ] Verify LineChart in `app-sandbox-rnative` renders ticks from `xAxis.data` and clips series that exceed the axis length

Made with [Cursor](https://cursor.com)