### PR TITLE
feat(Avatar): add appearance prop for background color options

### DIFF
--- a/.nx/version-plans/version-plan-1780905526165.md
+++ b/.nx/version-plans/version-plan-1780905526165.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+feat(Avatar): add appearance prop for background color options

--- a/.nx/version-plans/version-plan-1780905573005.md
+++ b/.nx/version-plans/version-plan-1780905573005.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+feat(Avatar): add appearance prop for background color options

--- a/libs/ui-react/src/lib/Components/Avatar/Avatar.figma.tsx
+++ b/libs/ui-react/src/lib/Components/Avatar/Avatar.figma.tsx
@@ -7,6 +7,10 @@ figma.connect(
   {
     imports: ["import { Avatar } from '@ledgerhq/lumen-ui-react'"],
     props: {
+      appearance: figma.enum('appearance', {
+        gray: 'gray',
+        transparent: 'transparent',
+      }),
       size: figma.enum('size', {
         sm: 'sm',
         md: 'md',
@@ -21,6 +25,7 @@ figma.connect(
     example: (props) => (
       <Avatar
         src='https://example-image.com'
+        appearance={props.appearance}
         size={props.size}
         alt="John Doe's Avatar"
         imgLoading='eager'

--- a/libs/ui-react/src/lib/Components/Avatar/Avatar.mdx
+++ b/libs/ui-react/src/lib/Components/Avatar/Avatar.mdx
@@ -43,6 +43,15 @@ Avatars come in four different sizes:
 
 <Canvas of={AvatarStories.SizeShowcase} />
 
+### Appearance
+
+The `appearance` prop controls the background color of the avatar container.
+
+- **`gray`**: Uses a muted gray background (`bg-muted`)
+- **`transparent`**: Uses a semi-transparent muted background (`bg-muted-transparent`) — default
+
+<Canvas of={AvatarStories.AppearanceShowcase} />
+
 ### States
 
 The Avatar component handles two primary states automatically:

--- a/libs/ui-react/src/lib/Components/Avatar/Avatar.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Avatar/Avatar.stories.tsx
@@ -85,8 +85,8 @@ export const SizeShowcase: Story = {
 
 export const AppearanceShowcase: Story = {
   render: () => (
-    <div className='inline-flex flex-col gap-8 body-2'>
-      <div className='inline-flex gap-16 rounded-lg bg-accent p-8'>
+    <div className='inline-flex flex-col gap-8'>
+      <div className='flex items-center justify-end gap-16'>
         <Avatar
           size='md'
           alt='gray fallback'
@@ -100,7 +100,7 @@ export const AppearanceShowcase: Story = {
           showNotification={false}
         />
       </div>
-      <div className='inline-flex gap-16 rounded-lg bg-accent p-8'>
+      <div className='flex items-center justify-end gap-16'>
         <Avatar
           size='md'
           src={exampleSrc}

--- a/libs/ui-react/src/lib/Components/Avatar/Avatar.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Avatar/Avatar.stories.tsx
@@ -83,6 +83,43 @@ export const SizeShowcase: Story = {
   ),
 };
 
+export const AppearanceShowcase: Story = {
+  render: () => (
+    <div className='inline-flex flex-col gap-8 body-2'>
+      <div className='inline-flex gap-16 rounded-lg bg-accent p-8'>
+        <Avatar
+          size='md'
+          alt='gray fallback'
+          appearance='gray'
+          showNotification={false}
+        />
+        <Avatar
+          size='md'
+          alt='transparent fallback'
+          appearance='transparent'
+          showNotification={false}
+        />
+      </div>
+      <div className='inline-flex gap-16 rounded-lg bg-accent p-8'>
+        <Avatar
+          size='md'
+          src={exampleSrc}
+          alt='gray with image'
+          appearance='gray'
+          showNotification={false}
+        />
+        <Avatar
+          size='md'
+          src={exampleSrc}
+          alt='transparent with image'
+          appearance='transparent'
+          showNotification={false}
+        />
+      </div>
+    </div>
+  ),
+};
+
 export const FallbackShowcase: Story = {
   args: {
     src: 'https://brokenLink.random',

--- a/libs/ui-react/src/lib/Components/Avatar/Avatar.test.tsx
+++ b/libs/ui-react/src/lib/Components/Avatar/Avatar.test.tsx
@@ -40,6 +40,28 @@ describe('Avatar Component', () => {
     expect(svg).toBeInTheDocument();
   });
 
+  it('should render with transparent appearance by default', () => {
+    const { container } = render(<Avatar src={validSrc} />);
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveClass('bg-muted-transparent');
+  });
+
+  it.each([
+    ['transparent', 'bg-muted-transparent'],
+    ['gray', 'bg-muted'],
+  ] as const)(
+    'should render with %s appearance when specified',
+    (appearance, expectedClass) => {
+      const { container } = render(
+        <Avatar src={validSrc} appearance={appearance} />,
+      );
+
+      const wrapper = container.firstChild;
+      expect(wrapper).toHaveClass(expectedClass);
+    },
+  );
+
   it('should render with md size by default', () => {
     const { container } = render(<Avatar src={validSrc} />);
 

--- a/libs/ui-react/src/lib/Components/Avatar/Avatar.tsx
+++ b/libs/ui-react/src/lib/Components/Avatar/Avatar.tsx
@@ -7,9 +7,13 @@ import type { AvatarProps } from './types';
 
 const avatarVariants = {
   root: cva(
-    'relative inline-flex items-center justify-center rounded-full bg-muted-transparent transition-colors',
+    'relative inline-flex items-center justify-center rounded-full transition-colors',
     {
       variants: {
+        appearance: {
+          gray: 'bg-muted',
+          transparent: 'bg-muted-transparent',
+        },
         size: {
           sm: 'size-40 p-4',
           md: 'size-48 p-4',
@@ -18,6 +22,7 @@ const avatarVariants = {
         },
       },
       defaultVariants: {
+        appearance: 'transparent',
         size: 'md',
       },
     },
@@ -61,6 +66,7 @@ export const Avatar = ({
   className,
   src,
   alt,
+  appearance = 'transparent',
   size = 'md',
   imgLoading,
   showNotification: showNotificationProp = false,
@@ -87,7 +93,7 @@ export const Avatar = ({
   const avatarContent = (
     <div
       ref={ref}
-      className={avatarVariants.root({ size, className })}
+      className={avatarVariants.root({ appearance, size, className })}
       role='img'
       aria-label={ariaLabel}
       {...props}

--- a/libs/ui-react/src/lib/Components/Avatar/types.ts
+++ b/libs/ui-react/src/lib/Components/Avatar/types.ts
@@ -12,7 +12,14 @@ export type AvatarProps = {
    */
   alt?: string;
   /**
-   * The size variant of the avatar.
+   * The visual appearance of the avatar background: `gray` or `transparent`.
+   * @optional
+   * @default transparent
+   */
+  appearance?: 'gray' | 'transparent';
+
+  /**
+   * The size variant of the avatar: `sm`, `md`, `lg`, `xl`.
    * @optional
    * @default md
    */

--- a/libs/ui-rnative/src/lib/Components/Avatar/Avatar.figma.tsx
+++ b/libs/ui-rnative/src/lib/Components/Avatar/Avatar.figma.tsx
@@ -7,6 +7,10 @@ figma.connect(
   {
     imports: ["import { Avatar } from '@ledgerhq/lumen-ui-rnative'"],
     props: {
+      appearance: figma.enum('appearance', {
+        gray: 'gray',
+        transparent: 'transparent',
+      }),
       size: figma.enum('size', {
         sm: 'sm',
         md: 'md',
@@ -21,6 +25,7 @@ figma.connect(
     example: (props) => (
       <Avatar
         src='https://example-image.com'
+        appearance={props.appearance}
         size={props.size}
         alt="John Doe's Avatar"
         showNotification={props.showNotification}

--- a/libs/ui-rnative/src/lib/Components/Avatar/Avatar.mdx
+++ b/libs/ui-rnative/src/lib/Components/Avatar/Avatar.mdx
@@ -40,6 +40,15 @@ Avatars come in four different sizes:
 
 <Canvas of={AvatarStories.SizeShowcase} />
 
+### Appearance
+
+The `appearance` prop controls the background color of the avatar container. 
+
+- **`gray`**: Uses a muted gray background
+- **`transparent`**: Uses a semi-transparent muted background — default
+
+<Canvas of={AvatarStories.AppearanceShowcase} />
+
 ### States
 
 The Avatar component handles two primary states automatically:

--- a/libs/ui-rnative/src/lib/Components/Avatar/Avatar.mdx
+++ b/libs/ui-rnative/src/lib/Components/Avatar/Avatar.mdx
@@ -42,7 +42,7 @@ Avatars come in four different sizes:
 
 ### Appearance
 
-The `appearance` prop controls the background color of the avatar container. 
+The `appearance` prop controls the background color of the avatar container.
 
 - **`gray`**: Uses a muted gray background
 - **`transparent`**: Uses a semi-transparent muted background — default

--- a/libs/ui-rnative/src/lib/Components/Avatar/Avatar.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/Avatar/Avatar.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { View, Text, Pressable, Linking } from 'react-native';
 
+import { useTheme } from '../../../styles';
 import { Box } from '../Utility';
 import { Avatar } from './Avatar';
 
@@ -88,6 +89,55 @@ export const SizeShowcase: Story = {
       </View>
     </Box>
   ),
+};
+
+const AppearanceShowcaseRender = () => {
+  const { theme } = useTheme();
+  const accentBg = { backgroundColor: theme.colors.bg.accent, borderRadius: 8 };
+  return (
+    <Box lx={{ gap: 's8' }}>
+      <Box
+        lx={{ flexDirection: 'row', gap: 's16', padding: 's8' }}
+        style={accentBg}
+      >
+        <Avatar
+          alt='gray fallback'
+          size='md'
+          appearance='gray'
+          showNotification={false}
+        />
+        <Avatar
+          alt='transparent fallback'
+          size='md'
+          appearance='transparent'
+          showNotification={false}
+        />
+      </Box>
+      <Box
+        lx={{ flexDirection: 'row', gap: 's16', padding: 's8' }}
+        style={accentBg}
+      >
+        <Avatar
+          src={exampleSrc}
+          alt='gray with image'
+          size='md'
+          appearance='gray'
+          showNotification={false}
+        />
+        <Avatar
+          src={exampleSrc}
+          alt='transparent with image'
+          size='md'
+          appearance='transparent'
+          showNotification={false}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export const AppearanceShowcase: Story = {
+  render: () => <AppearanceShowcaseRender />,
 };
 
 export const FallbackShowcase: Story = {

--- a/libs/ui-rnative/src/lib/Components/Avatar/Avatar.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/Avatar/Avatar.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { View, Text, Pressable, Linking } from 'react-native';
 
-import { useTheme } from '../../../styles';
 import { Box } from '../Utility';
 import { Avatar } from './Avatar';
 
@@ -92,14 +91,9 @@ export const SizeShowcase: Story = {
 };
 
 const AppearanceShowcaseRender = () => {
-  const { theme } = useTheme();
-  const accentBg = { backgroundColor: theme.colors.bg.accent, borderRadius: 8 };
   return (
     <Box lx={{ gap: 's8' }}>
-      <Box
-        lx={{ flexDirection: 'row', gap: 's16', padding: 's8' }}
-        style={accentBg}
-      >
+      <Box lx={{ flexDirection: 'row', gap: 's16', padding: 's8' }}>
         <Avatar
           alt='gray fallback'
           size='md'
@@ -113,10 +107,7 @@ const AppearanceShowcaseRender = () => {
           showNotification={false}
         />
       </Box>
-      <Box
-        lx={{ flexDirection: 'row', gap: 's16', padding: 's8' }}
-        style={accentBg}
-      >
+      <Box lx={{ flexDirection: 'row', gap: 's16', padding: 's8' }}>
         <Avatar
           src={exampleSrc}
           alt='gray with image'

--- a/libs/ui-rnative/src/lib/Components/Avatar/Avatar.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/Avatar/Avatar.test.tsx
@@ -4,7 +4,7 @@ import { render, waitFor } from '@testing-library/react-native';
 import { ThemeProvider } from '../ThemeProvider/ThemeProvider';
 import { Avatar } from './Avatar';
 
-const { sizes } = ledgerLiveThemes.dark;
+const { sizes, colors } = ledgerLiveThemes.dark;
 
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
   <ThemeProvider themes={ledgerLiveThemes} colorScheme='dark' locale='en'>
@@ -32,6 +32,36 @@ describe('Avatar Component', () => {
     );
     getByLabelText('user profile');
   });
+
+  it('should render with transparent appearance by default', () => {
+    const { getByTestId } = render(
+      <TestWrapper>
+        <Avatar testID='avatar-id' />
+      </TestWrapper>,
+    );
+
+    expect(getByTestId('avatar-id').props.style.backgroundColor).toBe(
+      colors.bg.mutedTransparent,
+    );
+  });
+
+  it.each<['transparent' | 'gray', string]>([
+    ['transparent', colors.bg.mutedTransparent],
+    ['gray', colors.bg.muted],
+  ])(
+    'should render with %s appearance when specified',
+    (appearance, expectedColor) => {
+      const { getByTestId } = render(
+        <TestWrapper>
+          <Avatar testID='avatar-id' appearance={appearance} />
+        </TestWrapper>,
+      );
+
+      expect(getByTestId('avatar-id').props.style.backgroundColor).toBe(
+        expectedColor,
+      );
+    },
+  );
 
   it('should render with different sizes', () => {
     const { getByTestId, rerender } = render(

--- a/libs/ui-rnative/src/lib/Components/Avatar/Avatar.tsx
+++ b/libs/ui-rnative/src/lib/Components/Avatar/Avatar.tsx
@@ -7,6 +7,7 @@ import { DotIndicator } from '../DotIndicator';
 import { Box } from '../Utility';
 import type { AvatarProps } from './types';
 
+type Appearance = NonNullable<AvatarProps['appearance']>;
 type Size = NonNullable<AvatarProps['size']>;
 
 const fallbackSizes = {
@@ -23,9 +24,20 @@ const dotSizeMap: Partial<
   md: 'xl',
 };
 
-const useStyles = ({ size }: { size: Size }) => {
+const useStyles = ({
+  appearance,
+  size,
+}: {
+  appearance: Appearance;
+  size: Size;
+}) => {
   return useStyleSheet(
     (t) => {
+      const backgroundColors: Record<Appearance, string> = {
+        gray: t.colors.bg.muted,
+        transparent: t.colors.bg.mutedTransparent,
+      };
+
       const sizeMap = {
         sm: { size: t.sizes.s40, padding: t.spacings.s4 },
         md: { size: t.sizes.s48, padding: t.spacings.s4 },
@@ -39,7 +51,7 @@ const useStyles = ({ size }: { size: Size }) => {
           width: sizeMap[size].size,
           height: sizeMap[size].size,
           borderRadius: 9999,
-          backgroundColor: t.colors.bg.muted,
+          backgroundColor: backgroundColors[appearance],
           alignItems: 'center',
           justifyContent: 'center',
           padding: sizeMap[size].padding,
@@ -52,7 +64,7 @@ const useStyles = ({ size }: { size: Size }) => {
         },
       };
     },
-    [size],
+    [appearance, size],
   );
 };
 
@@ -77,6 +89,7 @@ export const Avatar = ({
   style,
   src,
   alt = 'avatar',
+  appearance = 'transparent',
   size = 'md',
   showNotification: showNotificationProp = false,
   testID,
@@ -86,7 +99,7 @@ export const Avatar = ({
   const { t } = useCommonTranslation();
   const [error, setError] = useState<boolean>(false);
   const shouldFallback = !src || error;
-  const styles = useStyles({ size });
+  const styles = useStyles({ appearance, size });
 
   const resolvedAlt = alt || t('components.avatar.defaultAlt');
 

--- a/libs/ui-rnative/src/lib/Components/Avatar/types.ts
+++ b/libs/ui-rnative/src/lib/Components/Avatar/types.ts
@@ -12,6 +12,12 @@ export type AvatarProps = {
    */
   alt?: string;
   /**
+   * The visual appearance of the avatar background: `gray` or `transparent`.
+   * @optional
+   * @default transparent
+   */
+  appearance?: 'gray' | 'transparent';
+  /**
    * The size variant of the avatar.
    * @optional
    * @default md


### PR DESCRIPTION
<img width="1065" height="431" alt="image" src="https://github.com/user-attachments/assets/e766bfcd-3334-4b93-88eb-cca8772bb321" />
