### PR TITLE
[D]DLS-656-fix(AmountDisplay): Fix overflow cut

### DIFF
--- a/.nx/version-plans/version-plan-1780926284593.md
+++ b/.nx/version-plans/version-plan-1780926284593.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+fix(AmountDisplay): overflow cut on DigitStrip

--- a/libs/ui-react/src/lib/Components/AmountDisplay/AmountDisplay.tsx
+++ b/libs/ui-react/src/lib/Components/AmountDisplay/AmountDisplay.tsx
@@ -79,7 +79,7 @@ const DigitStrip = memo(({ value, animate, widths }: DigitStripProps) => {
   return (
     <div
       className={cn(
-        'relative overflow-hidden mask-fade-y',
+        'relative overflow-x-visible overflow-y-clip mask-fade-y mask-no-clip [-webkit-mask-clip:no-clip]',
         animate && 'transition-[width] duration-600',
       )}
       style={{ width: width + 'px' }}


### PR DESCRIPTION
## Overview

Fix the overflow cut by combining overflow-x-visible and overflow-y-clip, and since these are not sufficient because the mask-fade-y still confines painting to the border box, had to add mask-no-clip. The webkit attribute is for older browsers support.