### PR TITLE
[M]DLS-656-fix(AmountDisplay): Fix overflow cut

### DIFF
--- a/.nx/version-plans/version-plan-1780926189833.md
+++ b/.nx/version-plans/version-plan-1780926189833.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+fix(AmountDisplay): overflow cut on DigitStrip

--- a/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.test.tsx
@@ -31,6 +31,7 @@ describe('AmountDisplay', () => {
       accessibilityValue?: { text?: string };
       [key: string]: unknown;
     };
+    findAll: (predicate: (node: TestNode) => boolean) => TestNode[];
   };
 
   const getDigitStripValues = (): number[] => {
@@ -54,6 +55,19 @@ describe('AmountDisplay', () => {
         (node: TestNode) =>
           (node.props.style as { width?: unknown } | undefined)?.width,
       );
+  };
+
+  const getDigitStripContainers = (): TestNode[] => {
+    return screen.root.findAll(
+      (node: TestNode) =>
+        typeof node.type !== 'function' &&
+        node.props.accessibilityValue?.text !== undefined,
+    );
+  };
+
+  const getStyleOverflow = (node: TestNode): unknown => {
+    const style = node.props.style as { overflow?: unknown } | undefined;
+    return style?.overflow;
   };
 
   it('renders with basic formatter', () => {
@@ -281,6 +295,41 @@ describe('AmountDisplay', () => {
     expect(widths.length).toBeGreaterThan(0);
     widths.forEach((width) => {
       expect(typeof width).toBe('number');
+    });
+  });
+
+  describe('digit strip clipping', () => {
+    it('does not set overflow:hidden on the digit strip container', () => {
+      const formatter = createFormatter();
+      render(
+        <TestWrapper>
+          <AmountDisplay value={1234.56} formatter={formatter} />
+        </TestWrapper>,
+      );
+
+      const containers = getDigitStripContainers();
+      expect(containers.length).toBeGreaterThan(0);
+      containers.forEach((container) => {
+        expect(getStyleOverflow(container)).not.toBe('hidden');
+      });
+    });
+
+    it('clips overflow on an inner wrapper inside each digit strip', () => {
+      const formatter = createFormatter();
+      render(
+        <TestWrapper>
+          <AmountDisplay value={1234.56} formatter={formatter} />
+        </TestWrapper>,
+      );
+
+      const containers = getDigitStripContainers();
+      expect(containers.length).toBeGreaterThan(0);
+      containers.forEach((container) => {
+        const clippingWrapper = container.findAll(
+          (node: TestNode) => getStyleOverflow(node) === 'hidden',
+        );
+        expect(clippingWrapper.length).toBeGreaterThan(0);
+      });
     });
   });
 });

--- a/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.tsx
+++ b/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.tsx
@@ -164,6 +164,12 @@ const useAnimatedDigitStrip = ({
   return { animatedStyle };
 };
 
+// Horizontal breathing room for the clip box so glyphs that are slightly wider
+// than the measured `targetWidth` are not cut on their left/right edges. RN has
+// no per-axis overflow, so we extend the clip box horizontally while keeping the
+// vertical clip tight to `lineHeight`
+const HORIZONTAL_CLIP_PADDING = 8;
+
 const DigitStrip = memo(
   ({ value, textStyle, animate, widths }: DigitStripProps) => {
     const targetWidth = widths[value];
@@ -181,25 +187,36 @@ const DigitStrip = memo(
       <Animated.View
         style={{
           height: lineHeight,
-          overflow: 'hidden',
           width: animate ? width : targetWidth,
         }}
         accessibilityValue={{ text: String(value) }}
       >
-        <Animated.View style={[animatedStyle, { alignItems: 'center' }]}>
-          {DIGITS.map((d) => (
-            <Text
-              allowFontScaling={false}
-              key={d}
-              style={[
-                textStyle,
-                RuntimeConstants.isAndroid && { height: lineHeight },
-              ]}
-            >
-              {d}
-            </Text>
-          ))}
-        </Animated.View>
+        <View
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: -HORIZONTAL_CLIP_PADDING,
+            right: -HORIZONTAL_CLIP_PADDING,
+            overflow: 'hidden',
+            alignItems: 'center',
+          }}
+        >
+          <Animated.View style={[animatedStyle, { alignItems: 'center' }]}>
+            {DIGITS.map((d) => (
+              <Text
+                allowFontScaling={false}
+                key={d}
+                style={[
+                  textStyle,
+                  RuntimeConstants.isAndroid && { height: lineHeight },
+                ]}
+              >
+                {d}
+              </Text>
+            ))}
+          </Animated.View>
+        </View>
       </Animated.View>
     );
   },

--- a/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.tsx
+++ b/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.tsx
@@ -193,6 +193,7 @@ const DigitStrip = memo(
       >
         <View
           style={{
+            pointerEvents: 'none',
             position: 'absolute',
             top: 0,
             bottom: 0,

--- a/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.tsx
+++ b/libs/ui-rnative/src/lib/Components/AmountDisplay/AmountDisplay.tsx
@@ -192,8 +192,8 @@ const DigitStrip = memo(
         accessibilityValue={{ text: String(value) }}
       >
         <View
+          pointerEvents='none'
           style={{
-            pointerEvents: 'none',
             position: 'absolute',
             top: 0,
             bottom: 0,


### PR DESCRIPTION
## Overview

Fix the overflow cut by removing top level Animated.View overflow hidden property, and add an extra wrapping View than applies left and right overflow margins to leave room for larger digits and not cut them during the animation.