### PR TITLE
Hotfix/transition line stroke

### DIFF
--- a/.nx/version-plans/version-plan-1781254004171-ui-react-visualization.md
+++ b/.nx/version-plans/version-plan-1781254004171-ui-react-visualization.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react-visualization': patch
+---
+
+fix(LineChart): restore muted grey stroke on transition-loading lines

--- a/.nx/version-plans/version-plan-1781254004171-ui-rnative-visualization.md
+++ b/.nx/version-plans/version-plan-1781254004171-ui-rnative-visualization.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative-visualization': patch
+---
+
+fix(LineChart): restore muted grey stroke on transition-loading lines

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.tsx
@@ -1,3 +1,4 @@
+import { cssVar } from '@ledgerhq/lumen-design-core';
 import { useMemo } from 'react';
 
 import { defaultXAxisProps, defaultYAxisProps } from '../Axis';
@@ -24,6 +25,7 @@ const LineChartLines = ({
   series,
   showArea,
   areaType,
+  stroke,
 }: Readonly<LineChartLinesProps>) => {
   return (
     <>
@@ -31,7 +33,7 @@ const LineChartLines = ({
         <Line
           key={s.id}
           seriesId={s.id}
-          stroke={s.stroke}
+          stroke={stroke ?? s.stroke}
           showArea={showArea}
           areaType={areaType}
         />
@@ -44,7 +46,7 @@ const LineChartTransitionLines = ({
   series,
   showArea,
   areaType,
-}: Readonly<LineChartLinesProps>) => {
+}: Readonly<Omit<LineChartLinesProps, 'stroke'>>) => {
   const { animationStyle, keyframe } = useShimmerAnimation();
 
   return (
@@ -55,6 +57,7 @@ const LineChartTransitionLines = ({
           series={series}
           showArea={showArea}
           areaType={areaType}
+          stroke={cssVar('var(--border-muted-subtle)')}
         />
       </g>
     </>

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.tsx
@@ -14,6 +14,7 @@ import type {
   LineChartContentProps,
   LineChartLinesProps,
   LineChartProps,
+  LineChartTransitionLinesProps,
 } from './types';
 import {
   canRenderLine,
@@ -46,7 +47,7 @@ const LineChartTransitionLines = ({
   series,
   showArea,
   areaType,
-}: Readonly<Omit<LineChartLinesProps, 'stroke'>>) => {
+}: Readonly<LineChartTransitionLinesProps>) => {
   const { animationStyle, keyframe } = useShimmerAnimation();
 
   return (

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/types.ts
@@ -115,6 +115,8 @@ export type LineChartLinesProps = LineSeriesRenderProps & {
   stroke?: string;
 };
 
+export type LineChartTransitionLinesProps = Omit<LineChartLinesProps, 'stroke'>;
+
 export type LineChartContentProps = LineChartLinesProps &
   Required<Pick<LineChartProps, 'showXAxis' | 'showYAxis'>> &
   Pick<LineChartProps, 'children'> & {

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/types.ts
@@ -107,9 +107,13 @@ export type LineChartProps = {
  * sub-components. Derived from {@link LineChartProps} so the option types stay
  * in sync.
  */
-export type LineChartLinesProps = Required<
+type LineSeriesRenderProps = Required<
   Pick<LineChartProps, 'series' | 'showArea' | 'areaType'>
 >;
+
+export type LineChartLinesProps = LineSeriesRenderProps & {
+  stroke?: string;
+};
 
 export type LineChartContentProps = LineChartLinesProps &
   Required<Pick<LineChartProps, 'showXAxis' | 'showYAxis'>> &

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.tsx
@@ -16,6 +16,7 @@ import type {
   LineChartContentProps,
   LineChartLinesProps,
   LineChartProps,
+  LineChartTransitionLinesProps,
 } from './types';
 import {
   canRenderLine,
@@ -50,7 +51,7 @@ const LineChartTransitionLines = ({
   series,
   showArea,
   areaType,
-}: Readonly<Omit<LineChartLinesProps, 'stroke'>>) => {
+}: Readonly<LineChartTransitionLinesProps>) => {
   const { theme } = useTheme();
   const { animatedProps } = useShimmerAnimation();
 

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '@ledgerhq/lumen-ui-rnative';
 import { useMemo } from 'react';
 import Animated from 'react-native-reanimated';
 import { G } from 'react-native-svg';
@@ -28,6 +29,7 @@ const LineChartLines = ({
   series,
   showArea,
   areaType,
+  stroke,
 }: Readonly<LineChartLinesProps>) => {
   return (
     <>
@@ -35,7 +37,7 @@ const LineChartLines = ({
         <Line
           key={s.id}
           seriesId={s.id}
-          stroke={s.stroke}
+          stroke={stroke ?? s.stroke}
           showArea={showArea}
           areaType={areaType}
         />
@@ -48,12 +50,18 @@ const LineChartTransitionLines = ({
   series,
   showArea,
   areaType,
-}: Readonly<LineChartLinesProps>) => {
+}: Readonly<Omit<LineChartLinesProps, 'stroke'>>) => {
+  const { theme } = useTheme();
   const { animatedProps } = useShimmerAnimation();
 
   return (
     <AnimatedG animatedProps={animatedProps}>
-      <LineChartLines series={series} showArea={showArea} areaType={areaType} />
+      <LineChartLines
+        series={series}
+        showArea={showArea}
+        areaType={areaType}
+        stroke={theme.colors.border.mutedSubtle}
+      />
     </AnimatedG>
   );
 };

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/types.ts
@@ -115,6 +115,8 @@ export type LineChartLinesProps = LineSeriesRenderProps & {
   stroke?: string;
 };
 
+export type LineChartTransitionLinesProps = Omit<LineChartLinesProps, 'stroke'>;
+
 export type LineChartContentProps = LineChartLinesProps &
   Required<Pick<LineChartProps, 'showXAxis' | 'showYAxis'>> &
   Pick<LineChartProps, 'children'> & {

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/types.ts
@@ -107,9 +107,13 @@ export type LineChartProps = {
  * sub-components. Derived from {@link LineChartProps} so the option types stay
  * in sync.
  */
-export type LineChartLinesProps = Required<
+type LineSeriesRenderProps = Required<
   Pick<LineChartProps, 'series' | 'showArea' | 'areaType'>
 >;
+
+export type LineChartLinesProps = LineSeriesRenderProps & {
+  stroke?: string;
+};
 
 export type LineChartContentProps = LineChartLinesProps &
   Required<Pick<LineChartProps, 'showXAxis' | 'showYAxis'>> &


### PR DESCRIPTION
## Overview

Transition lines were the same colour as the Chart, passing the 'stroke' property to LineChartLines and the right cssVar at call site fixes it.