### PR TITLE
[D]DLS-784-feat(LineChart): Add null/missing data support

### DIFF
--- a/.nx/version-plans/version-plan-1781615760000-ui-react-visualization.md
+++ b/.nx/version-plans/version-plan-1781615760000-ui-react-visualization.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react-visualization': patch
+---
+
+feat(LineChart): add connectNulls and render gaps at null values

--- a/.nx/version-plans/version-plan-1781620140000-ui-react-visualization.md
+++ b/.nx/version-plans/version-plan-1781620140000-ui-react-visualization.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react-visualization': patch
+---
+
+feat(Axis): add showLabels prop to hide x/y axis tick labels

--- a/libs/ui-react-visualization/src/lib/Components/Axis/Axis.types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Axis/Axis.types.ts
@@ -25,6 +25,12 @@ export type BaseAxisProps = {
    */
   showTickMark?: boolean;
   /**
+   * Whether to render the tick labels along the axis.
+   * Set to `false` to keep ticks/grid while hiding their text labels.
+   * @default true
+   */
+  showLabels?: boolean;
+  /**
    * Explicit tick positions along the axis.
    * When omitted, ticks are computed automatically from the scale.
    */

--- a/libs/ui-react-visualization/src/lib/Components/Axis/XAxis/XAxis.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Axis/XAxis/XAxis.stories.tsx
@@ -90,6 +90,19 @@ export const TickLabelFormatter: Story = {
   },
 };
 
+/**
+ * `showLabels={false}` hides the tick text while keeping grid lines and tick
+ * marks, useful when the values are conveyed elsewhere (e.g. a scrubber tooltip).
+ */
+export const HideLabels: Story = {
+  args: {
+    data: monthLabels,
+    showGrid: true,
+    showTickMark: true,
+    showLabels: false,
+  },
+};
+
 /** `ticks` pins explicit positions instead of the auto-computed set. */
 export const CustomTicks: Story = {
   args: {

--- a/libs/ui-react-visualization/src/lib/Components/Axis/XAxis/XAxis.test.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Axis/XAxis/XAxis.test.tsx
@@ -101,6 +101,17 @@ describe('XAxis', () => {
     expect(labels[1].textContent).toBe('v4');
   });
 
+  it('hides tick labels when showLabels is false but keeps tick marks', () => {
+    const { getByTestId } = renderXAxis({
+      showLabels: false,
+      showTickMark: true,
+      ticks: [0, 2, 4],
+    });
+    const axis = getByTestId('x-axis');
+    expect(axis.querySelectorAll('text')).toHaveLength(0);
+    expect(axis.querySelectorAll('line')).toHaveLength(3);
+  });
+
   it('returns null when drawing area width is 0', () => {
     const { queryByTestId } = render(
       <CartesianChart series={sampleSeries} width={0} height={200}>

--- a/libs/ui-react-visualization/src/lib/Components/Axis/XAxis/XAxis.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Axis/XAxis/XAxis.tsx
@@ -13,6 +13,7 @@ export function XAxis({
   showGrid = false,
   showLine = false,
   showTickMark = false,
+  showLabels = true,
   ticks: ticksProp,
   tickLabelFormatter,
 }: XAxisProps) {
@@ -82,22 +83,23 @@ export function XAxis({
           />
         ))}
 
-      {ticksData.map((tick, i) => (
-        <text
-          key={`label-${tick.value}-${i}`}
-          x={tick.position}
-          y={labelY}
-          textAnchor='middle'
-          dominantBaseline={position === 'top' ? 'auto' : 'hanging'}
-          style={{
-            fill: cssVar('var(--text-muted)'),
-            fontSize: cssVar('var(--font-style-body-4-size)'),
-            fontFamily: cssVar('var(--font-family-font)'),
-          }}
-        >
-          {tick.label}
-        </text>
-      ))}
+      {showLabels &&
+        ticksData.map((tick, i) => (
+          <text
+            key={`label-${tick.value}-${i}`}
+            x={tick.position}
+            y={labelY}
+            textAnchor='middle'
+            dominantBaseline={position === 'top' ? 'auto' : 'hanging'}
+            style={{
+              fill: cssVar('var(--text-muted)'),
+              fontSize: cssVar('var(--font-style-body-4-size)'),
+              fontFamily: cssVar('var(--font-family-font)'),
+            }}
+          >
+            {tick.label}
+          </text>
+        ))}
     </g>
   );
 }

--- a/libs/ui-react-visualization/src/lib/Components/Axis/YAxis/YAxis.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Axis/YAxis/YAxis.stories.tsx
@@ -74,6 +74,18 @@ export const TickLabelFormatter: Story = {
 };
 
 /**
+ * `showLabels={false}` hides the tick text while keeping grid lines. Pair it
+ * with `width: 0` to also reclaim the horizontal space the labels would use.
+ */
+export const HideLabels: Story = {
+  args: {
+    showGrid: true,
+    showLabels: false,
+    width: 0,
+  },
+};
+
+/**
  * A fixed `domain` of `{ min, max }` pins the value range mapped onto the axis,
  * independent of the data's own extent.
  */

--- a/libs/ui-react-visualization/src/lib/Components/Axis/YAxis/YAxis.test.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Axis/YAxis/YAxis.test.tsx
@@ -104,6 +104,17 @@ describe('YAxis', () => {
     expect(labels[1].textContent).toBe('$50');
   });
 
+  it('hides tick labels when showLabels is false but keeps tick marks', () => {
+    const { getByTestId } = renderYAxis({
+      showLabels: false,
+      showTickMark: true,
+      ticks: [10, 50],
+    });
+    const axis = getByTestId('y-axis');
+    expect(axis.querySelectorAll('text')).toHaveLength(0);
+    expect(axis.querySelectorAll('line')).toHaveLength(2);
+  });
+
   it('returns null when drawing area height is 0', () => {
     const { queryByTestId } = render(
       <CartesianChart series={sampleSeries} width={400} height={0}>

--- a/libs/ui-react-visualization/src/lib/Components/Axis/YAxis/YAxis.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Axis/YAxis/YAxis.tsx
@@ -13,6 +13,7 @@ export function YAxis({
   showGrid = false,
   showLine = false,
   showTickMark = false,
+  showLabels = true,
   ticks: ticksProp,
   tickLabelFormatter,
 }: YAxisProps) {
@@ -82,22 +83,23 @@ export function YAxis({
           />
         ))}
 
-      {ticksData.map((tick, i) => (
-        <text
-          key={`label-${tick.value}-${i}`}
-          x={labelX}
-          y={tick.position}
-          textAnchor={position === 'start' ? 'end' : 'start'}
-          dominantBaseline='central'
-          style={{
-            fill: cssVar('var(--text-muted)'),
-            fontSize: cssVar('var(--font-style-body-4-size)'),
-            fontFamily: cssVar('var(--font-family-font)'),
-          }}
-        >
-          {tick.label}
-        </text>
-      ))}
+      {showLabels &&
+        ticksData.map((tick, i) => (
+          <text
+            key={`label-${tick.value}-${i}`}
+            x={labelX}
+            y={tick.position}
+            textAnchor={position === 'start' ? 'end' : 'start'}
+            dominantBaseline='central'
+            style={{
+              fill: cssVar('var(--text-muted)'),
+              fontSize: cssVar('var(--font-style-body-4-size)'),
+              fontFamily: cssVar('var(--font-family-font)'),
+            }}
+          >
+            {tick.label}
+          </text>
+        ))}
     </g>
   );
 }

--- a/libs/ui-react-visualization/src/lib/Components/Line/Line.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Line/Line.tsx
@@ -18,6 +18,7 @@ export function Line({
   showArea = false,
   areaType: _areaType = 'gradient',
   curve,
+  connectNulls,
 }: LineProps) {
   const { getXScale, getYScale, getXAxisConfig, drawingArea, seriesMap } =
     useCartesianChartContext();
@@ -32,13 +33,21 @@ export function Line({
   const resolvedStroke =
     (stroke ?? seriesData?.stroke) || LINE_DEFAULT_STROKE_COLOR;
   const resolvedCurve = curve ?? seriesData?.curve;
+  const resolvedConnectNulls =
+    connectNulls ?? seriesData?.connectNulls ?? false;
 
   const points = useMemo(
     () =>
       seriesData?.data && xScale && yScale && isNumericScale(yScale)
-        ? toScaledPoints(seriesData.data, xScale, yScale, xAxisConfig?.data)
+        ? toScaledPoints(
+            seriesData.data,
+            xScale,
+            yScale,
+            xAxisConfig?.data,
+            resolvedConnectNulls,
+          )
         : null,
-    [seriesData, xScale, yScale, xAxisConfig],
+    [seriesData, xScale, yScale, xAxisConfig, resolvedConnectNulls],
   );
 
   const linePath = useMemo(

--- a/libs/ui-react-visualization/src/lib/Components/Line/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Line/types.ts
@@ -30,4 +30,11 @@ export type LineProps = {
    * @default 'bump'
    */
   curve?: CurveType;
+  /**
+   * When true, skips null values and draws a continuous line across gaps.
+   * When false, null values create gaps in the line.
+   * When omitted, falls back to the `connectNulls` defined on the series.
+   * @default false
+   */
+  connectNulls?: boolean;
 };

--- a/libs/ui-react-visualization/src/lib/Components/Line/utils.test.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Line/utils.test.ts
@@ -44,14 +44,28 @@ describe('toScaledPoints', () => {
     expect(points![points!.length - 1][0]).toBe(800);
   });
 
-  it('skips null values without affecting the cap', () => {
+  it('keeps null values as holes by default (gaps)', () => {
     const data: (number | null)[] = [10, null, 30, 40, 50, 60, 70, 80, 90];
     const xData = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
 
     const points = toScaledPoints(data, xScale, yScale, xData);
 
     expect(points).not.toBeNull();
+    expect(points).toHaveLength(xData.length);
+    expect(points![1][1]).toBeNull();
+    expect(points![1][0]).toBeCloseTo(800 / 7);
+    expect(points![points!.length - 1][0]).toBe((800 / 7) * 7);
+  });
+
+  it('skips null values when connectNulls is true', () => {
+    const data: (number | null)[] = [10, null, 30, 40, 50, 60, 70, 80, 90];
+    const xData = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+
+    const points = toScaledPoints(data, xScale, yScale, xData, true);
+
+    expect(points).not.toBeNull();
     expect(points).toHaveLength(7);
+    expect(points!.every(([, y]) => y !== null)).toBe(true);
     expect(points![points!.length - 1][0]).toBe((800 / 7) * 7);
   });
 
@@ -126,5 +140,26 @@ describe('buildLinePath', () => {
     const path = buildLinePath(points, 'unknown' as never);
 
     expect(path).toBe(buildLinePath(points));
+  });
+
+  it('breaks the path into segments around null holes', () => {
+    const gapped: [number, number | null][] = [
+      [0, 100],
+      [25, 20],
+      [50, null],
+      [75, 60],
+      [100, 40],
+    ];
+
+    const path = buildLinePath(gapped, 'linear');
+
+    expect(path).toBe('M0,100L25,20M75,60L100,40');
+    expect(path?.match(/M/g)).toHaveLength(2);
+  });
+
+  it('draws a single continuous segment when there are no holes', () => {
+    const path = buildLinePath(points, 'linear');
+
+    expect(path?.match(/M/g)).toHaveLength(1);
   });
 });

--- a/libs/ui-react-visualization/src/lib/Components/Line/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Line/utils.ts
@@ -68,9 +68,9 @@ export const toScaledPoints = (
 
   for (let i = 0; i < limit; i++) {
     const value = data[i];
-    const isFinite = isFiniteNumber(value);
+    const isFiniteValue = isFiniteNumber(value);
 
-    if (!isFinite && connectNulls) continue;
+    if (!isFiniteValue && connectNulls) continue;
 
     const xInput =
       xData && typeof xData[i] === 'number' ? (xData[i] as number) : i;
@@ -79,12 +79,12 @@ export const toScaledPoints = (
       ? (xScale(xInput) ?? 0) + xScale.bandwidth() / 2
       : xScale(xInput);
 
-    if (!isFinite) {
+    if (!isFiniteValue) {
       pts.push([x as number, null]);
       continue;
     }
 
-    pts.push([x as number, yScale(value as number)]);
+    pts.push([x as number, yScale(value)]);
     finiteCount++;
   }
 

--- a/libs/ui-react-visualization/src/lib/Components/Line/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Line/utils.ts
@@ -50,7 +50,7 @@ const getCurveFactory = (curve: CurveType = DEFAULT_CURVE): CurveFactory =>
  * with more points than the axis has labels does not overflow past the right
  * edge of the chart. The axis is treated as authoritative for the X domain.
  *
- * Non-finite values (e.g. `null`) are handled according to `connectNulls`:
+ * Null values (and other non-finite numbers) are handled according to `connectNulls`:
  * - `false` (default): kept as `[x, null]` holes so the line/area break into
  *   gaps via the generators' `.defined()` check.
  * - `true`: skipped entirely so the line is drawn continuously across gaps.

--- a/libs/ui-react-visualization/src/lib/Components/Line/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Line/utils.ts
@@ -102,7 +102,7 @@ export const buildLinePath = (
     line<Point>()
       .defined((d) => d[1] !== null)
       .x((d) => d[0])
-      .y((d) => d[1] ?? 0)
+      .y((d) => d[1] as number)
       .curve(getCurveFactory(curve))(points) ?? null
   );
 };
@@ -122,7 +122,7 @@ export const buildAreaPath = (
       .defined((d) => d[1] !== null)
       .x((d) => d[0])
       .y0(yBottom)
-      .y1((d) => d[1] ?? 0)
+      .y1((d) => d[1] as number)
       .curve(getCurveFactory(curve))(points) ?? null
   );
 };

--- a/libs/ui-react-visualization/src/lib/Components/Line/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Line/utils.ts
@@ -20,7 +20,7 @@ import type {
   NumericScale,
 } from '../../utils/types';
 
-type Point = [x: number, y: number];
+type Point = [x: number, y: number | null];
 
 /**
  * Maps the public `CurveType` values to their d3-shape curve factories.
@@ -41,7 +41,7 @@ const getCurveFactory = (curve: CurveType = DEFAULT_CURVE): CurveFactory =>
   CURVE_FACTORIES[curve] ?? CURVE_FACTORIES[DEFAULT_CURVE];
 
 /**
- * Project series data into scaled [x, y] pixel coordinates, skipping nulls.
+ * Project series data into scaled [x, y] pixel coordinates.
  *
  * When `xData` contains numeric values, those values are fed into the scale
  * instead of the array index so the points honour a numeric X domain.
@@ -49,19 +49,28 @@ const getCurveFactory = (curve: CurveType = DEFAULT_CURVE): CurveFactory =>
  * When `xData` is provided, iteration is capped at `xData.length` so a series
  * with more points than the axis has labels does not overflow past the right
  * edge of the chart. The axis is treated as authoritative for the X domain.
+ *
+ * Non-finite values (e.g. `null`) are handled according to `connectNulls`:
+ * - `false` (default): kept as `[x, null]` holes so the line/area break into
+ *   gaps via the generators' `.defined()` check.
+ * - `true`: skipped entirely so the line is drawn continuously across gaps.
  */
 export const toScaledPoints = (
   data: (number | null)[],
   xScale: ChartScaleFunction,
   yScale: NumericScale,
   xData?: readonly (string | number)[],
+  connectNulls = false,
 ): Point[] | null => {
   const pts: Point[] = [];
   const limit = xData ? Math.min(data.length, xData.length) : data.length;
+  let finiteCount = 0;
 
   for (let i = 0; i < limit; i++) {
     const value = data[i];
-    if (!isFiniteNumber(value)) continue;
+    const isFinite = isFiniteNumber(value);
+
+    if (!isFinite && connectNulls) continue;
 
     const xInput =
       xData && typeof xData[i] === 'number' ? (xData[i] as number) : i;
@@ -69,12 +78,17 @@ export const toScaledPoints = (
     const x = isCategoricalScale(xScale)
       ? (xScale(xInput) ?? 0) + xScale.bandwidth() / 2
       : xScale(xInput);
-    const y = yScale(value);
 
-    pts.push([x as number, y]);
+    if (!isFinite) {
+      pts.push([x as number, null]);
+      continue;
+    }
+
+    pts.push([x as number, yScale(value as number)]);
+    finiteCount++;
   }
 
-  return pts.length >= 2 ? pts : null;
+  return finiteCount >= 2 ? pts : null;
 };
 
 /**
@@ -86,8 +100,9 @@ export const buildLinePath = (
 ): string | null => {
   return (
     line<Point>()
+      .defined((d) => d[1] !== null)
       .x((d) => d[0])
-      .y((d) => d[1])
+      .y((d) => d[1] ?? 0)
       .curve(getCurveFactory(curve))(points) ?? null
   );
 };
@@ -104,9 +119,10 @@ export const buildAreaPath = (
 
   return (
     area<Point>()
+      .defined((d) => d[1] !== null)
       .x((d) => d[0])
       .y0(yBottom)
-      .y1((d) => d[1])
+      .y1((d) => d[1] ?? 0)
       .curve(getCurveFactory(curve))(points) ?? null
   );
 };

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.test.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.test.tsx
@@ -166,6 +166,83 @@ describe('LineChart', () => {
     expect(clipPathEl).toBeNull();
   });
 
+  describe('null gaps and connectNulls', () => {
+    const gappedSeries = [
+      {
+        id: 'gapped',
+        stroke: '#000',
+        data: [10, 20, null, 40, 50],
+      },
+    ];
+
+    const linePathD = (container: HTMLElement): string =>
+      container.querySelector('[data-testid="line-path"]')?.getAttribute('d') ??
+      '';
+
+    it('breaks the line into multiple segments at null values by default', () => {
+      const { container } = render(
+        <LineChartWrapper series={gappedSeries} width={400} height={200} />,
+      );
+
+      expect(linePathD(container).match(/M/g)).toHaveLength(2);
+    });
+
+    it('draws a single continuous segment when connectNulls is true', () => {
+      const { container } = render(
+        <LineChartWrapper
+          series={gappedSeries}
+          width={400}
+          height={200}
+          connectNulls
+        />,
+      );
+
+      expect(linePathD(container).match(/M/g)).toHaveLength(1);
+    });
+
+    it('honours connectNulls per series', () => {
+      const { getAllByTestId } = render(
+        <LineChartWrapper
+          series={[
+            {
+              id: 'connected',
+              stroke: '#000',
+              data: [10, 20, null, 40, 50],
+              connectNulls: true,
+            },
+            { id: 'gapped', stroke: '#111', data: [50, 40, null, 20, 10] },
+          ]}
+          width={400}
+          height={200}
+        />,
+      );
+
+      const paths = getAllByTestId('line-path');
+      expect(paths[0].getAttribute('d')?.match(/M/g)).toHaveLength(1);
+      expect(paths[1].getAttribute('d')?.match(/M/g)).toHaveLength(2);
+    });
+
+    it('lets the chart-level connectNulls override the per-series value', () => {
+      const { container } = render(
+        <LineChartWrapper
+          series={[
+            {
+              id: 'gapped',
+              stroke: '#000',
+              data: [10, 20, null, 40, 50],
+              connectNulls: false,
+            },
+          ]}
+          width={400}
+          height={200}
+          connectNulls
+        />,
+      );
+
+      expect(linePathD(container).match(/M/g)).toHaveLength(1);
+    });
+  });
+
   describe('loading and empty states', () => {
     it('renders the shimmering placeholder with no data while loading (state 1)', () => {
       const { getByTestId, queryByTestId, container } = render(

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/LineChart.tsx
@@ -26,6 +26,7 @@ const LineChartLines = ({
   series,
   showArea,
   areaType,
+  connectNulls,
   stroke,
 }: Readonly<LineChartLinesProps>) => {
   return (
@@ -37,6 +38,7 @@ const LineChartLines = ({
           stroke={stroke ?? s.stroke}
           showArea={showArea}
           areaType={areaType}
+          connectNulls={connectNulls}
         />
       ))}
     </>
@@ -47,6 +49,7 @@ const LineChartTransitionLines = ({
   series,
   showArea,
   areaType,
+  connectNulls,
 }: Readonly<LineChartTransitionLinesProps>) => {
   const { animationStyle, keyframe } = useShimmerAnimation();
 
@@ -58,6 +61,7 @@ const LineChartTransitionLines = ({
           series={series}
           showArea={showArea}
           areaType={areaType}
+          connectNulls={connectNulls}
           stroke={cssVar('var(--border-muted-subtle)')}
         />
       </g>
@@ -69,6 +73,7 @@ const LineChartContent = ({
   series,
   showArea,
   areaType,
+  connectNulls,
   showXAxis,
   showYAxis,
   xAxisConfig,
@@ -85,12 +90,14 @@ const LineChartContent = ({
           series={series}
           showArea={showArea}
           areaType={areaType}
+          connectNulls={connectNulls}
         />
       ) : (
         <LineChartLines
           series={series}
           showArea={showArea}
           areaType={areaType}
+          connectNulls={connectNulls}
         />
       )}
       {children}
@@ -102,6 +109,7 @@ export function LineChart({
   series,
   showArea = false,
   areaType = 'gradient',
+  connectNulls,
   showXAxis = false,
   showYAxis = false,
   xAxis,
@@ -184,6 +192,7 @@ export function LineChart({
           series={series ?? []}
           showArea={showArea}
           areaType={areaType}
+          connectNulls={connectNulls}
           showXAxis={showXAxis}
           showYAxis={showYAxis}
           xAxisConfig={xAxisConfig}

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/__stories__/LineChart.mdx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/__stories__/LineChart.mdx
@@ -76,10 +76,11 @@ here over time.
 
 <Canvas of={LineChartStories.CustomLine} />
 
-## Data
+## Missing Data
 
-Each series' `data` array defines the y-values, one per index. `null` entries
-render as gaps in the line.
+By default, null values in data create gaps in a line.
+Use `connectNulls` to skip null values and draw a continuous line.
+Note that scrubber beacons and points are still only shown at non-null data values.
 
 <Canvas of={LineChartStories.MissingData} />
 

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/__stories__/LineChart.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/__stories__/LineChart.stories.tsx
@@ -19,6 +19,9 @@ import {
   CHART_HEIGHT,
   CHART_WIDTH,
   curveSeries,
+  formatScrubberValue,
+  missingDataPages,
+  missingDataSeries,
   monthLabels,
   multiSeries,
   sampleSeries,
@@ -36,13 +39,6 @@ import {
   type Period,
   usdFormatter,
 } from './cryptoChartData';
-
-const integerFormatter = new Intl.NumberFormat('en-US', {
-  maximumFractionDigits: 0,
-});
-
-const formatScrubberValue = (value: number | null): string =>
-  value === null ? '—' : integerFormatter.format(value);
 
 const meta = {
   component: LineChart,
@@ -122,64 +118,29 @@ export const CustomLine: Story = {
  * the missing index shows no beacon for the broken series.
  */
 export const MissingData: Story = {
-  render: () => {
-    const pages = [
-      'Page A',
-      'Page B',
-      'Page C',
-      'Page D',
-      'Page E',
-      'Page F',
-      'Page G',
-    ];
-    const pageViews = [2400, 1398, null, 3908, 4800, 3800, 4300];
-    const uniqueVisitors = [4000, 3000, null, 2780, 1890, 2390, 3490];
-
-    return (
-      <LineChart
-        width={CHART_WIDTH}
-        height={CHART_HEIGHT}
-        enableScrubbing
-        showArea
-        showXAxis
-        showYAxis
-        series={[
-          {
-            id: 'pageViews',
-            label: 'Page Views',
-            stroke: cssVar('var(--background-success-strong)'),
-            data: pageViews,
-            connectNulls: true,
-          },
-          {
-            id: 'uniqueVisitors',
-            label: 'Unique Visitors',
-            stroke: cssVar('var(--background-accent)'),
-            data: uniqueVisitors,
-          },
-        ]}
-        xAxis={{ data: pages }}
-        yAxis={{ showGrid: true, showLabels: false }}
-      >
-        <Scrubber
-          showBeacons
-          tooltip={(dataIndex) => ({
-            title: pages[dataIndex],
-            items: [
-              {
-                label: 'Page Views',
-                value: formatScrubberValue(pageViews[dataIndex]),
-              },
-              {
-                label: 'Unique Visitors',
-                value: formatScrubberValue(uniqueVisitors[dataIndex]),
-              },
-            ],
-          })}
-        />
-      </LineChart>
-    );
+  args: {
+    series: missingDataSeries,
+    enableScrubbing: true,
+    showArea: true,
+    showXAxis: true,
+    showYAxis: true,
+    xAxis: { data: missingDataPages },
+    yAxis: { showGrid: true, showLabels: false },
   },
+  render: (args) => (
+    <LineChart {...args}>
+      <Scrubber
+        showBeacons
+        tooltip={(dataIndex) => ({
+          title: missingDataPages[dataIndex],
+          items: missingDataSeries.map((series) => ({
+            label: series.label,
+            value: formatScrubberValue(series.data[dataIndex]),
+          })),
+        })}
+      />
+    </LineChart>
+  ),
 };
 
 /**

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/__stories__/LineChart.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/__stories__/LineChart.stories.tsx
@@ -37,6 +37,13 @@ import {
   usdFormatter,
 } from './cryptoChartData';
 
+const integerFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0,
+});
+
+const formatScrubberValue = (value: number | null): string =>
+  value === null ? '—' : integerFormatter.format(value);
+
 const meta = {
   component: LineChart,
   title: 'Visualization/LineChart',
@@ -105,19 +112,73 @@ export const CustomLine: Story = {
 };
 
 /**
- * `null` entries in a series' `data` render as gaps in the line, so missing
- * samples don't get interpolated over.
+ * Null handling end-to-end. `null` entries in a series' `data` create gaps in
+ * the line (and area) by default, so missing samples are not interpolated over
+ * — see "Unique Visitors". Setting `connectNulls` on a series skips its nulls
+ * and draws a continuous line across the gap instead — see "Page Views".
+ *
+ * `connectNulls` can also be set chart-wide on `<LineChart>` to override every
+ * series at once. Either way, scrubber beacons only land on non-null values, so
+ * the missing index shows no beacon for the broken series.
  */
 export const MissingData: Story = {
-  args: {
-    series: [
-      {
-        id: 'prices',
-        stroke: STORIES_STROKE_COLOR,
-        data: [10, 22, 29, null, null, 45, 22, 52, 21, 4, 68, 20, 21, 58],
-      },
-    ],
-    showArea: true,
+  render: () => {
+    const pages = [
+      'Page A',
+      'Page B',
+      'Page C',
+      'Page D',
+      'Page E',
+      'Page F',
+      'Page G',
+    ];
+    const pageViews = [2400, 1398, null, 3908, 4800, 3800, 4300];
+    const uniqueVisitors = [4000, 3000, null, 2780, 1890, 2390, 3490];
+
+    return (
+      <LineChart
+        width={CHART_WIDTH}
+        height={CHART_HEIGHT}
+        enableScrubbing
+        showArea
+        showXAxis
+        showYAxis
+        series={[
+          {
+            id: 'pageViews',
+            label: 'Page Views',
+            stroke: cssVar('var(--background-success-strong)'),
+            data: pageViews,
+            connectNulls: true,
+          },
+          {
+            id: 'uniqueVisitors',
+            label: 'Unique Visitors',
+            stroke: cssVar('var(--background-accent)'),
+            data: uniqueVisitors,
+          },
+        ]}
+        xAxis={{ data: pages }}
+        yAxis={{ showGrid: true, showLabels: false }}
+      >
+        <Scrubber
+          showBeacons
+          tooltip={(dataIndex) => ({
+            title: pages[dataIndex],
+            items: [
+              {
+                label: 'Page Views',
+                value: formatScrubberValue(pageViews[dataIndex]),
+              },
+              {
+                label: 'Unique Visitors',
+                value: formatScrubberValue(uniqueVisitors[dataIndex]),
+              },
+            ],
+          })}
+        />
+      </LineChart>
+    );
   },
 };
 
@@ -436,9 +497,8 @@ export const Interactive: Story = {
             ticks: model?.yTicks,
             showTickMark: false,
             showGrid: true,
-            // Below is a hack to hide the y-axis labels. A showLabels prop is coming soon.
+            showLabels: false,
             width: 0,
-            tickLabelFormatter: () => '',
           }}
           onScrubberPositionChange={setScrubberIndex}
         >

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/__stories__/LineChart.stories.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/__stories__/LineChart.stories.tsx
@@ -284,11 +284,11 @@ export const Empty: Story = {
 export const Loading: Story = {
   render: () => (
     <div className='flex flex-wrap gap-24'>
-      <div className='flex max-w-400 flex-col gap-8'>
+      <div className='flex w-400 flex-col gap-8'>
         <LineChart series={[]} width={CHART_WIDTH} height={150} loading />
         <span className='body-3 text-muted'>Without data</span>
       </div>
-      <div className='flex max-w-400 flex-col gap-8'>
+      <div className='flex w-400 flex-col gap-8'>
         <LineChart
           series={sampleSeries}
           width={CHART_WIDTH}

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/__stories__/chartStoryFixtures.ts
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/__stories__/chartStoryFixtures.ts
@@ -120,6 +120,46 @@ export const denseSeries = [
   { id: 'prices', stroke: STORIES_STROKE_COLOR, data: denseData },
 ] satisfies Series[];
 
+/**
+ * Two-series dataset with a shared `null` index, for the missing-data /
+ * `connectNulls` story: `pageViews` opts into `connectNulls` (bridges the gap)
+ * while `uniqueVisitors` keeps the default (breaks at the null). Declared with
+ * `satisfies` so `data` stays `(number | null)[]` for tooltip index lookups.
+ */
+export const missingDataPages = [
+  'Page A',
+  'Page B',
+  'Page C',
+  'Page D',
+  'Page E',
+  'Page F',
+  'Page G',
+];
+
+export const missingDataSeries = [
+  {
+    id: 'pageViews',
+    label: 'Page Views',
+    stroke: cssVar('var(--background-success-strong)'),
+    data: [2400, 1398, null, 3908, 4800, 3800, 4300],
+    connectNulls: true,
+  },
+  {
+    id: 'uniqueVisitors',
+    label: 'Unique Visitors',
+    stroke: cssVar('var(--background-accent)'),
+    data: [4000, 3000, null, 2780, 1890, 2390, 3490],
+  },
+] satisfies Series[];
+
+/** Formats a (possibly null) scrubber value, rendering an em-dash for gaps. */
+const integerFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0,
+});
+
+export const formatScrubberValue = (value: number | null): string =>
+  value === null ? '—' : integerFormatter.format(value);
+
 /** Month labels aligned to the 14-point `sampleSeries`, for axis/scrubber stories. */
 export const monthLabels = [
   'Jan',

--- a/libs/ui-react-visualization/src/lib/Components/LineChart/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/LineChart/types.ts
@@ -22,6 +22,12 @@ export type LineChartProps = {
    */
   areaType?: 'gradient';
   /**
+   * Chart-wide override for null handling. When set, it applies to every line
+   * and overrides any per-series `connectNulls`. When omitted, each series
+   * follows its own `connectNulls` (default `false`, i.e. gaps at nulls).
+   */
+  connectNulls?: boolean;
+  /**
    * Whether to render an x-axis.
    * @default false
    */
@@ -111,9 +117,10 @@ type LineSeriesRenderProps = Required<
   Pick<LineChartProps, 'series' | 'showArea' | 'areaType'>
 >;
 
-export type LineChartLinesProps = LineSeriesRenderProps & {
-  stroke?: string;
-};
+export type LineChartLinesProps = LineSeriesRenderProps &
+  Pick<LineChartProps, 'connectNulls'> & {
+    stroke?: string;
+  };
 
 export type LineChartTransitionLinesProps = Omit<LineChartLinesProps, 'stroke'>;
 

--- a/libs/ui-react-visualization/src/lib/utils/types.ts
+++ b/libs/ui-react-visualization/src/lib/utils/types.ts
@@ -61,6 +61,13 @@ export type Series = {
    * @default 'bump'
    */
   curve?: CurveType;
+  /**
+   * When true, skips null values and draws a continuous line across gaps.
+   * When false (default), null values create gaps in the line.
+   * Overridden by the chart-level `connectNulls` prop when that is set.
+   * @default false
+   */
+  connectNulls?: boolean;
 };
 
 export type NumericScale =


### PR DESCRIPTION
## Overview

Introduce null data handling with the `connectNulls` prop. It can either be passed to `LineChart` (chart-wide) or specified on an individual `series` object (per-series).

By default, `null` entries in a series' `data` create **gaps** in the line and area. With `connectNulls`, those nulls are skipped so the line is drawn **continuously across the gap**.

<img width="1026" height="546" alt="Screenshot 2026-06-12 at 16 56 16" src="https://github.com/user-attachments/assets/e30bd626-1ead-464d-9b80-10ee98753aad" />

## Resolution order
`connectNulls` is resolved with the following precedence (first defined wins):
1. `connectNulls` on `LineChart` — chart-wide override applied to every line.
2. `connectNulls` on the `series` object — per-series setting.
3. `false` (default) — nulls render as gaps.
## Changes
- **`connectNulls` on `LineChart`** (`LineChartProps`): chart-wide override. When set, it applies to every line and overrides any per-series value.
- **`connectNulls` on `series`** (`Series`): per-series opt-in, used when no chart-level value is provided.
- **`Line`**: resolves `connectNulls` (prop → series → `false`) and forwards it to the point projection. Threaded through `LineChartContent`, `LineChartLines`, and `LineChartTransitionLines`.
- **`toScaledPoints`**: when `connectNulls` is `true`, non-finite values (e.g. `null`) are skipped entirely; when `false`, they are kept as `[x, null]` holes so the line/area generators break into gaps via their `.defined()` check.
- **Axis `showLabels`** (`BaseAxisProps`): new prop (default `true`) to hide tick text labels while keeping ticks/grid, on both `XAxis` and `YAxis`.
