### PR TITLE
[M]DLS-784-feat(LineChart): Add null/missing data support

### DIFF
--- a/.nx/version-plans/version-plan-1781698020000-ui-rnative-visualization.md
+++ b/.nx/version-plans/version-plan-1781698020000-ui-rnative-visualization.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative-visualization': patch
+---
+
+feat(LineChart): add connectNulls and render gaps at null values

--- a/.nx/version-plans/version-plan-1781698080000-ui-rnative-visualization.md
+++ b/.nx/version-plans/version-plan-1781698080000-ui-rnative-visualization.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative-visualization': patch
+---
+
+feat(Axis): add showLabels prop to hide x/y axis tick labels

--- a/apps/app-sandbox-rnative/src/app/blocks/LineCharts.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/LineCharts.tsx
@@ -29,6 +29,8 @@ export const LineCharts = () => (
     <MultipleSeriesWithArea />
     <CustomLines />
     <CustomDomain />
+    <MissingData />
+    <HiddenAxisLabels />
     <PointMinMax />
     <PointAllDataPoints />
     <PointLabelFunction />
@@ -68,6 +70,32 @@ const multiSeries = [
 ];
 
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep'];
+
+const missingDataPages = [
+  'Page A',
+  'Page B',
+  'Page C',
+  'Page D',
+  'Page E',
+  'Page F',
+  'Page G',
+];
+
+const missingDataSeries = [
+  {
+    id: 'pageViews',
+    label: 'Page Views',
+    stroke: '#44D7B6',
+    connectNulls: true,
+    data: [2400, 1398, null, 3908, 4800, 3800, 4300],
+  },
+  {
+    id: 'uniqueVisitors',
+    label: 'Unique Visitors',
+    stroke: '#7B61FF',
+    data: [4000, 3000, null, 2780, 1890, 2390, 3490],
+  },
+] satisfies Series[];
 
 const Section = ({
   title,
@@ -251,6 +279,45 @@ const CustomDomain = () => (
         showGrid: true,
         domain: { min: 0, max: 100 },
       }}
+    />
+  </Section>
+);
+
+const MissingData = () => (
+  <Section title='Missing data (connectNulls per-series)'>
+    <LineChart
+      series={missingDataSeries}
+      height={200}
+      showArea
+      showXAxis
+      showYAxis
+      enableScrubbing
+      xAxis={{ data: missingDataPages, showLine: true }}
+      yAxis={{ showGrid: true, showLabels: false }}
+    >
+      <Scrubber
+        showBeacons
+        tooltip={(i) => ({
+          title: missingDataPages[i],
+          items: missingDataSeries.map((series) => ({
+            label: series.label,
+            value: series.data[i] == null ? '—' : `${series.data[i]}`,
+          })),
+        })}
+      />
+    </LineChart>
+  </Section>
+);
+
+const HiddenAxisLabels = () => (
+  <Section title='Hidden axis labels (showLabels: false)'>
+    <LineChart
+      series={sampleSeries}
+      height={125}
+      showXAxis
+      showYAxis
+      xAxis={{ showLine: true, showGrid: true, showLabels: false }}
+      yAxis={{ showGrid: true, showLabels: false }}
     />
   </Section>
 );

--- a/libs/ui-rnative-visualization/src/lib/Components/Axis/Axis.types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Axis/Axis.types.ts
@@ -25,6 +25,12 @@ export type BaseAxisProps = {
    */
   showTickMark?: boolean;
   /**
+   * Whether to render the text labels at each tick position.
+   * When false, tick marks, grid lines, and the baseline still render.
+   * @default true
+   */
+  showLabels?: boolean;
+  /**
    * Explicit tick positions along the axis.
    * When omitted, ticks are computed automatically from the scale.
    */

--- a/libs/ui-rnative-visualization/src/lib/Components/Axis/XAxis/XAxis.test.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Axis/XAxis/XAxis.test.tsx
@@ -75,6 +75,18 @@ describe('XAxis', () => {
     getByText('4');
   });
 
+  it('hides tick labels when showLabels is false but keeps tick marks', () => {
+    const { queryByText, toJSON } = renderXAxis({
+      ticks: [0, 2, 4],
+      showTickMark: true,
+      showLabels: false,
+    });
+    expect(queryByText('0')).toBeNull();
+    expect(queryByText('2')).toBeNull();
+    expect(queryByText('4')).toBeNull();
+    expect(toJSON()).toBeTruthy();
+  });
+
   it('does not render axis when width is 0', () => {
     const { queryByText } = render(
       <ThemeProvider themes={ledgerLiveThemes} colorScheme='light'>

--- a/libs/ui-rnative-visualization/src/lib/Components/Axis/XAxis/XAxis.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Axis/XAxis/XAxis.tsx
@@ -18,6 +18,7 @@ export const XAxis = ({
   showGrid = false,
   showLine = false,
   showTickMark = false,
+  showLabels = true,
   ticks: ticksProp,
   tickLabelFormatter,
 }: XAxisProps) => {
@@ -92,20 +93,21 @@ export const XAxis = ({
           />
         ))}
 
-      {ticksData.map((tick, i) => (
-        <SvgText
-          key={`label-${tick.value}-${i}`}
-          x={tick.position}
-          y={labelY}
-          dy={labelDy}
-          textAnchor='middle'
-          fill={textFill}
-          fontSize={fontSize}
-          fontFamily={theme.fontFamilies.sans}
-        >
-          {tick.label}
-        </SvgText>
-      ))}
+      {showLabels &&
+        ticksData.map((tick, i) => (
+          <SvgText
+            key={`label-${tick.value}-${i}`}
+            x={tick.position}
+            y={labelY}
+            dy={labelDy}
+            textAnchor='middle'
+            fill={textFill}
+            fontSize={fontSize}
+            fontFamily={theme.fontFamilies.sans}
+          >
+            {tick.label}
+          </SvgText>
+        ))}
     </G>
   );
 };

--- a/libs/ui-rnative-visualization/src/lib/Components/Axis/YAxis/YAxis.test.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Axis/YAxis/YAxis.test.tsx
@@ -75,6 +75,18 @@ describe('YAxis', () => {
     getByText('50');
   });
 
+  it('hides tick labels when showLabels is false but keeps tick marks', () => {
+    const { queryByText, toJSON } = renderYAxis({
+      ticks: [10, 30, 50],
+      showTickMark: true,
+      showLabels: false,
+    });
+    expect(queryByText('10')).toBeNull();
+    expect(queryByText('30')).toBeNull();
+    expect(queryByText('50')).toBeNull();
+    expect(toJSON()).toBeTruthy();
+  });
+
   it('does not render axis when height is 0', () => {
     const { queryByText } = render(
       <ThemeProvider themes={ledgerLiveThemes} colorScheme='light'>

--- a/libs/ui-rnative-visualization/src/lib/Components/Axis/YAxis/YAxis.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Axis/YAxis/YAxis.tsx
@@ -17,6 +17,7 @@ export const YAxis = ({
   showGrid = false,
   showLine = false,
   showTickMark = false,
+  showLabels = true,
   gridLineStyle = 'dashed',
   ticks: ticksProp,
   tickLabelFormatter,
@@ -91,20 +92,21 @@ export const YAxis = ({
           />
         ))}
 
-      {ticksData.map((tick, i) => (
-        <SvgText
-          key={`label-${tick.value}-${i}`}
-          x={labelX}
-          y={tick.position}
-          dy={labelDy}
-          textAnchor={position === 'start' ? 'end' : 'start'}
-          fill={textFill}
-          fontSize={theme.typographies.body4.fontSize}
-          fontFamily={theme.fontFamilies.sans}
-        >
-          {tick.label}
-        </SvgText>
-      ))}
+      {showLabels &&
+        ticksData.map((tick, i) => (
+          <SvgText
+            key={`label-${tick.value}-${i}`}
+            x={labelX}
+            y={tick.position}
+            dy={labelDy}
+            textAnchor={position === 'start' ? 'end' : 'start'}
+            fill={textFill}
+            fontSize={theme.typographies.body4.fontSize}
+            fontFamily={theme.fontFamilies.sans}
+          >
+            {tick.label}
+          </SvgText>
+        ))}
     </G>
   );
 };

--- a/libs/ui-rnative-visualization/src/lib/Components/Line/Line.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Line/Line.tsx
@@ -16,6 +16,7 @@ export const Line = ({
   showArea = false,
   areaType: _areaType = 'gradient',
   curve,
+  connectNulls,
 }: LineProps) => {
   const { getXScale, getYScale, getXAxisConfig, drawingArea, seriesMap } =
     useCartesianChartContext();
@@ -31,13 +32,21 @@ export const Line = ({
   const resolvedStroke =
     stroke ?? seriesData?.stroke ?? theme.colors.border.muted;
   const resolvedCurve = curve ?? seriesData?.curve;
+  const resolvedConnectNulls =
+    connectNulls ?? seriesData?.connectNulls ?? false;
 
   const points = useMemo(
     () =>
       seriesData?.data && xScale && yScale && isNumericScale(yScale)
-        ? toScaledPoints(seriesData.data, xScale, yScale, xAxisConfig?.data)
+        ? toScaledPoints(
+            seriesData.data,
+            xScale,
+            yScale,
+            xAxisConfig?.data,
+            resolvedConnectNulls,
+          )
         : null,
-    [seriesData, xScale, yScale, xAxisConfig],
+    [seriesData, xScale, yScale, xAxisConfig, resolvedConnectNulls],
   );
 
   const linePath = useMemo(

--- a/libs/ui-rnative-visualization/src/lib/Components/Line/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Line/types.ts
@@ -30,4 +30,11 @@ export type LineProps = {
    * @default 'bump'
    */
   curve?: CurveType;
+  /**
+   * When true, skips null values and draws a continuous line across gaps.
+   * When false, null values create gaps in the line.
+   * When omitted, falls back to the `connectNulls` defined on the series.
+   * @default false
+   */
+  connectNulls?: boolean;
 };

--- a/libs/ui-rnative-visualization/src/lib/Components/Line/utils.test.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Line/utils.test.ts
@@ -44,15 +44,27 @@ describe('toScaledPoints', () => {
     expect(points![points!.length - 1][0]).toBe(800);
   });
 
-  it('skips null values without affecting the cap', () => {
+  it('keeps null values as holes by default so the line breaks', () => {
     const data: (number | null)[] = [10, null, 30, 40, 50, 60, 70, 80, 90];
     const xData = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
 
     const points = toScaledPoints(data, xScale, yScale, xData);
 
     expect(points).not.toBeNull();
-    expect(points).toHaveLength(7);
+    expect(points).toHaveLength(8);
+    expect(points![1][1]).toBeNull();
     expect(points![points!.length - 1][0]).toBe((800 / 7) * 7);
+  });
+
+  it('skips null values when connectNulls is true', () => {
+    const data: (number | null)[] = [10, null, 30, 40, 50, 60, 70, 80, 90];
+    const xData = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+
+    const points = toScaledPoints(data, xScale, yScale, xData, true);
+
+    expect(points).not.toBeNull();
+    expect(points).toHaveLength(7);
+    expect(points!.every((p) => p[1] !== null)).toBe(true);
   });
 
   it('uses numeric xData values as the x input', () => {
@@ -126,5 +138,27 @@ describe('buildLinePath', () => {
     const path = buildLinePath(points, 'unknown' as never);
 
     expect(path).toBe(buildLinePath(points));
+  });
+
+  it('breaks the path into segments at null holes', () => {
+    const gapped: [number, number | null][] = [
+      [0, 100],
+      [50, 80],
+      [100, null],
+      [150, 60],
+      [200, 40],
+    ];
+
+    const path = buildLinePath(gapped, 'linear');
+
+    expect(path).not.toBeNull();
+    expect(path!.match(/M/g)).toHaveLength(2);
+    expect(path).toBe('M0,100L50,80M150,60L200,40');
+  });
+
+  it('draws a single continuous segment when there are no holes', () => {
+    const path = buildLinePath(points, 'linear');
+
+    expect(path!.match(/M/g)).toHaveLength(1);
   });
 });

--- a/libs/ui-rnative-visualization/src/lib/Components/Line/utils.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/Line/utils.ts
@@ -20,7 +20,7 @@ import type {
   NumericScale,
 } from '../../utils/types';
 
-type Point = [x: number, y: number];
+type Point = [x: number, y: number | null];
 
 /**
  * Maps the public `CurveType` values to their d3-shape curve factories.
@@ -41,8 +41,7 @@ const getCurveFactory = (curve: CurveType = DEFAULT_CURVE): CurveFactory =>
   CURVE_FACTORIES[curve] ?? CURVE_FACTORIES[DEFAULT_CURVE];
 
 /**
- * Project series data into scaled [x, y] pixel coordinates, skipping any
- * non-finite entries.
+ * Project series data into scaled [x, y] pixel coordinates.
  *
  * When `xData` contains numeric values, those values are fed into the scale
  * instead of the array index so the points honour a numeric X domain.
@@ -50,19 +49,28 @@ const getCurveFactory = (curve: CurveType = DEFAULT_CURVE): CurveFactory =>
  * When `xData` is provided, iteration is capped at `xData.length` so a series
  * with more points than the axis has labels does not overflow past the right
  * edge of the chart. The axis is treated as authoritative for the X domain.
+ *
+ * Non-finite values (e.g. `null`) are handled according to `connectNulls`:
+ * - `false` (default): kept as `[x, null]` holes so the line/area break into
+ *   gaps via the generators' `.defined()` check.
+ * - `true`: skipped entirely so the line is drawn continuously across gaps.
  */
 export const toScaledPoints = (
   data: (number | null)[],
   xScale: ChartScaleFunction,
   yScale: NumericScale,
   xData?: readonly (string | number)[],
+  connectNulls = false,
 ): Point[] | null => {
   const pts: Point[] = [];
   const limit = xData ? Math.min(data.length, xData.length) : data.length;
+  let finiteCount = 0;
 
   for (let i = 0; i < limit; i++) {
     const value = data[i];
-    if (!isFiniteNumber(value)) continue;
+    const isFiniteValue = isFiniteNumber(value);
+
+    if (!isFiniteValue && connectNulls) continue;
 
     const xInput =
       xData && typeof xData[i] === 'number' ? (xData[i] as number) : i;
@@ -70,12 +78,17 @@ export const toScaledPoints = (
     const x = isCategoricalScale(xScale)
       ? (xScale(xInput) ?? 0) + xScale.bandwidth() / 2
       : xScale(xInput);
-    const y = yScale(value);
 
-    pts.push([x as number, y]);
+    if (!isFiniteValue) {
+      pts.push([x as number, null]);
+      continue;
+    }
+
+    pts.push([x as number, yScale(value)]);
+    finiteCount++;
   }
 
-  return pts.length >= 2 ? pts : null;
+  return finiteCount >= 2 ? pts : null;
 };
 
 /**
@@ -87,8 +100,9 @@ export const buildLinePath = (
 ): string | null => {
   return (
     line<Point>()
+      .defined((d) => d[1] !== null)
       .x((d) => d[0])
-      .y((d) => d[1])
+      .y((d) => d[1] as number)
       .curve(getCurveFactory(curve))(points) ?? null
   );
 };
@@ -105,9 +119,10 @@ export const buildAreaPath = (
 
   return (
     area<Point>()
+      .defined((d) => d[1] !== null)
       .x((d) => d[0])
       .y0(yBottom)
-      .y1((d) => d[1])
+      .y1((d) => d[1] as number)
       .curve(getCurveFactory(curve))(points) ?? null
   );
 };

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.test.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.test.tsx
@@ -319,4 +319,75 @@ describe('LineChart', () => {
       expect(queryByTestId('chart-empty-label')).toBeNull();
     });
   });
+
+  describe('null gaps and connectNulls', () => {
+    const gappedSeries = [
+      {
+        id: 'gapped',
+        stroke: '#000',
+        data: [10, 20, null, 40, 50],
+        curve: 'linear' as const,
+      },
+    ];
+
+    const countMoves = (d: string): number => d.match(/M/g)?.length ?? 0;
+
+    it('breaks the line into segments at null values by default', () => {
+      const { getByTestId } = render(
+        <LineChartWrapper>
+          <LineChart series={gappedSeries} width={400} height={200} />
+        </LineChartWrapper>,
+      );
+
+      const d = getByTestId('line-path').props.d as string;
+      expect(countMoves(d)).toBe(2);
+    });
+
+    it('connects across nulls when connectNulls is set on the chart', () => {
+      const { getByTestId } = render(
+        <LineChartWrapper>
+          <LineChart
+            series={gappedSeries}
+            width={400}
+            height={200}
+            connectNulls
+          />
+        </LineChartWrapper>,
+      );
+
+      const d = getByTestId('line-path').props.d as string;
+      expect(countMoves(d)).toBe(1);
+    });
+
+    it('honours connectNulls set per-series', () => {
+      const { getByTestId } = render(
+        <LineChartWrapper>
+          <LineChart
+            series={[{ ...gappedSeries[0], connectNulls: true }]}
+            width={400}
+            height={200}
+          />
+        </LineChartWrapper>,
+      );
+
+      const d = getByTestId('line-path').props.d as string;
+      expect(countMoves(d)).toBe(1);
+    });
+
+    it('lets the chart-level prop override the per-series value', () => {
+      const { getByTestId } = render(
+        <LineChartWrapper>
+          <LineChart
+            series={[{ ...gappedSeries[0], connectNulls: true }]}
+            width={400}
+            height={200}
+            connectNulls={false}
+          />
+        </LineChartWrapper>,
+      );
+
+      const d = getByTestId('line-path').props.d as string;
+      expect(countMoves(d)).toBe(2);
+    });
+  });
 });

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/LineChart.tsx
@@ -31,6 +31,7 @@ const LineChartLines = ({
   showArea,
   areaType,
   stroke,
+  connectNulls,
 }: Readonly<LineChartLinesProps>) => {
   return (
     <>
@@ -41,6 +42,7 @@ const LineChartLines = ({
           stroke={stroke ?? s.stroke}
           showArea={showArea}
           areaType={areaType}
+          connectNulls={connectNulls}
         />
       ))}
     </>
@@ -51,6 +53,7 @@ const LineChartTransitionLines = ({
   series,
   showArea,
   areaType,
+  connectNulls,
 }: Readonly<LineChartTransitionLinesProps>) => {
   const { theme } = useTheme();
   const { animatedProps } = useShimmerAnimation();
@@ -62,6 +65,7 @@ const LineChartTransitionLines = ({
         showArea={showArea}
         areaType={areaType}
         stroke={theme.colors.border.mutedSubtle}
+        connectNulls={connectNulls}
       />
     </AnimatedG>
   );
@@ -76,6 +80,7 @@ const LineChartContent = ({
   xAxisConfig,
   yAxisConfig,
   isTransitionLoading,
+  connectNulls,
   children,
 }: Readonly<LineChartContentProps>) => {
   return (
@@ -87,12 +92,14 @@ const LineChartContent = ({
           series={series}
           showArea={showArea}
           areaType={areaType}
+          connectNulls={connectNulls}
         />
       ) : (
         <LineChartLines
           series={series}
           showArea={showArea}
           areaType={areaType}
+          connectNulls={connectNulls}
         />
       )}
       {children}
@@ -118,6 +125,7 @@ export const LineChart = ({
   magnetRadius,
   loading = false,
   emptyLabel = 'No data',
+  connectNulls,
 }: Readonly<LineChartProps>) => {
   const xAxisConfig = {
     ...defaultXAxisProps,
@@ -191,6 +199,7 @@ export const LineChart = ({
           xAxisConfig={xAxisConfig}
           yAxisConfig={yAxisConfig}
           isTransitionLoading={isTransitionLoading}
+          connectNulls={connectNulls}
         >
           {children}
         </LineChartContent>

--- a/libs/ui-rnative-visualization/src/lib/Components/LineChart/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/Components/LineChart/types.ts
@@ -100,6 +100,13 @@ export type LineChartProps = {
    * @default 'No data'
    */
   emptyLabel?: string;
+  /**
+   * Chart-wide override controlling how null values are handled across all lines.
+   * When true, skips null values and draws continuous lines across gaps.
+   * When false, null values create gaps in the lines.
+   * When omitted, each series' own `connectNulls` value is used (defaulting to `false`).
+   */
+  connectNulls?: boolean;
 };
 
 /**
@@ -111,9 +118,10 @@ type LineSeriesRenderProps = Required<
   Pick<LineChartProps, 'series' | 'showArea' | 'areaType'>
 >;
 
-export type LineChartLinesProps = LineSeriesRenderProps & {
-  stroke?: string;
-};
+export type LineChartLinesProps = LineSeriesRenderProps &
+  Pick<LineChartProps, 'connectNulls'> & {
+    stroke?: string;
+  };
 
 export type LineChartTransitionLinesProps = Omit<LineChartLinesProps, 'stroke'>;
 

--- a/libs/ui-rnative-visualization/src/lib/utils/types.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/types.ts
@@ -62,6 +62,13 @@ export type Series = {
    * @default 'bump'
    */
   curve?: CurveType;
+  /**
+   * When true, skips null values and draws a continuous line across gaps.
+   * When false (default), null values create gaps in the line.
+   * Overridden by the chart-level `connectNulls` prop when that is set.
+   * @default false
+   */
+  connectNulls?: boolean;
 };
 
 export type NumericScale =


### PR DESCRIPTION
## Overview

Introduce null data handling with the connectNulls prop. It can either be passed to LineChart (chart-wide) or specified on an individual series object (per-series).

By default, null entries in a series' data create gaps in the line and area. With connectNulls, those nulls are skipped so the line is drawn continuously across the gap.

---

<img width="352" height="433" alt="Screenshot 2026-06-15 at 10 08 30" src="https://github.com/user-attachments/assets/f1426f51-0d02-4da1-bf19-c98b898bf7ca" />
