### PR TITLE
fix(Banner): add flex-wrap to banner actions

### DIFF
--- a/.nx/version-plans/version-plan-1781529969880-ui-react.md
+++ b/.nx/version-plans/version-plan-1781529969880-ui-react.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+fix(Banner): add flex-wrap to banner actions

--- a/.nx/version-plans/version-plan-1781529969880-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1781529969880-ui-rnative.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+fix(Banner): add flex-wrap to banner actions

--- a/libs/ui-react/src/lib/Components/Banner/Banner.tsx
+++ b/libs/ui-react/src/lib/Components/Banner/Banner.tsx
@@ -97,7 +97,7 @@ export const Banner = ({
           )}
         </div>
         {(primaryAction || secondaryAction) && (
-          <div className='flex gap-4'>
+          <div className='flex flex-wrap gap-4'>
             {primaryAction}
             {secondaryAction}
           </div>

--- a/libs/ui-rnative/src/lib/Components/Banner/Banner.tsx
+++ b/libs/ui-rnative/src/lib/Components/Banner/Banner.tsx
@@ -81,6 +81,7 @@ const useStyles = ({ appearance }: { appearance: Appearance }) => {
         ]),
         actionsWrapper: {
           flexDirection: 'row',
+          flexWrap: 'wrap',
           gap: t.spacings.s4,
         },
       };


### PR DESCRIPTION
Closes [DLS-755](https://ledgerhq.atlassian.net/browse/DLS-755).

### Demo

#### Both regular
<img width="465" height="141" alt="image" src="https://github.com/user-attachments/assets/31aa2990-ac96-408c-994d-92798334657d" />

#### Both overflowing
<img width="464" height="223" alt="image" src="https://github.com/user-attachments/assets/3da18231-c645-4d5b-a285-b774ba7608e9" />

#### Only primary overflowing
<img width="463" height="204" alt="image" src="https://github.com/user-attachments/assets/c3731e80-4b2c-4fdc-b63f-a6e5268f0656" />

#### Only secondary overflowing
<img width="467" height="206" alt="image" src="https://github.com/user-attachments/assets/6f68a49d-6017-4527-9e79-7ff6d6a5859b" />

[DLS-755]: https://ledgerhq.atlassian.net/browse/DLS-755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ