### PR TITLE
[D]DLS-809-feat(Point): clamp Point label inside drawing area

### DIFF
--- a/.nx/version-plans/version-plan-1781697456925.md
+++ b/.nx/version-plans/version-plan-1781697456925.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react-visualization': patch
+---
+
+feat(Point): add clamping logic to the Point label

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
@@ -176,7 +176,7 @@ describe('Point', () => {
     );
   });
 
-  it('centres a long edge label when clampLabelToBounds is false', () => {
+  it("centres a long edge label when labelAlignment is 'center'", () => {
     const labelSpy = vi.fn(({ x, y, children }: PointLabelProps) => (
       <text x={x} y={y}>
         {children}
@@ -188,7 +188,7 @@ describe('Point', () => {
         dataX={0}
         dataY={10}
         label='A long edge label'
-        clampLabelToBounds={false}
+        labelAlignment='center'
         LabelComponent={labelSpy}
       />,
     );

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.test.tsx
@@ -154,6 +154,51 @@ describe('Point', () => {
     expect(bottomY).toBeGreaterThan(topY);
   });
 
+  it('anchors a long label inward at the left edge by default', () => {
+    const labelSpy = vi.fn(({ x, y, children }: PointLabelProps) => (
+      <text x={x} y={y}>
+        {children}
+      </text>
+    ));
+
+    renderInChart(
+      <Point
+        dataX={0}
+        dataY={10}
+        label='A long edge label'
+        LabelComponent={labelSpy}
+      />,
+    );
+
+    expect(labelSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ textAnchor: 'start' }),
+      undefined,
+    );
+  });
+
+  it('centres a long edge label when clampLabelToBounds is false', () => {
+    const labelSpy = vi.fn(({ x, y, children }: PointLabelProps) => (
+      <text x={x} y={y}>
+        {children}
+      </text>
+    ));
+
+    renderInChart(
+      <Point
+        dataX={0}
+        dataY={10}
+        label='A long edge label'
+        clampLabelToBounds={false}
+        LabelComponent={labelSpy}
+      />,
+    );
+
+    expect(labelSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ textAnchor: 'middle' }),
+      undefined,
+    );
+  });
+
   it('does not render arrow when showLabelArrow is false', () => {
     const { queryByTestId } = renderInChart(
       <Point dataX={2} dataY={30} label='Peak' showLabelArrow={false} />,

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -73,7 +73,7 @@ export function Point({
   size = DEFAULT_SIZE,
   onClick,
   magnetic = false,
-  clampLabelToBounds = true,
+  labelAlignment = 'auto',
 }: Readonly<PointProps>) {
   const { pixel, drawingArea, revealStyle, isVisible } = usePointGeometry({
     dataX,
@@ -96,7 +96,7 @@ export function Point({
         labelPosition,
         showLabelArrow,
         area: drawingArea,
-        clamp: clampLabelToBounds,
+        alignment: labelAlignment,
       })
     : null;
 

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -1,6 +1,6 @@
 import { cssVar } from '@ledgerhq/lumen-design-core';
 
-import { DEFAULT_SIZE, STROKE_WIDTH } from './constants';
+import { DEFAULT_SIZE, LABEL_FONT_SIZE, STROKE_WIDTH } from './constants';
 import type {
   PointArrowProps,
   PointLabelProps,
@@ -22,7 +22,7 @@ export function PointLabel({
       dominantBaseline={dominantBaseline}
       style={{
         fill: cssVar('var(--text-base)'),
-        fontSize: cssVar('var(--font-style-body-4-size)'),
+        fontSize: LABEL_FONT_SIZE,
         fontWeight: cssVar('var(--font-style-body-4-weight-medium)'),
         fontFamily: cssVar('var(--font-family-font)'),
         ...style,
@@ -114,7 +114,7 @@ export function Point({
       {!hidePoint && (
         <PointMarker x={pixel.x} y={pixel.y} size={size} color={color} />
       )}
-      {labelGeometry?.renderArrow && (
+      {isLabelVisible && showLabelArrow && (
         <PointArrow
           x={pixel.x}
           y={pixel.y}

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -86,19 +86,19 @@ export function Point({
   }
 
   const labelText = resolveLabel(label, dataX);
-  const labelGeometry =
-    labelText != null
-      ? computeLabelGeometry({
-          text: labelText,
-          pixelX: pixel.x,
-          pixelY: pixel.y,
-          size,
-          labelPosition,
-          showLabelArrow,
-          area: drawingArea,
-          clamp: clampLabelToBounds,
-        })
-      : null;
+  const isLabelVisible = labelText !== undefined;
+  const labelGeometry = isLabelVisible
+    ? computeLabelGeometry({
+        text: labelText,
+        pixelX: pixel.x,
+        pixelY: pixel.y,
+        size,
+        labelPosition,
+        showLabelArrow,
+        area: drawingArea,
+        clamp: clampLabelToBounds,
+      })
+    : null;
 
   const Label = LabelComponent ?? PointLabel;
 

--- a/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-react-visualization/src/lib/Components/Point/Point.tsx
@@ -1,20 +1,14 @@
 import { cssVar } from '@ledgerhq/lumen-design-core';
-import { useMemo } from 'react';
 
-import { projectPoint } from '../../utils/scales/scales';
-import { useCartesianChartContext } from '../CartesianChart/context';
-import { usePointReveal } from '../CartesianChart/RevealAnimation';
 import { DEFAULT_SIZE, STROKE_WIDTH } from './constants';
-import { useMagneticPointsContext } from './pointContext';
-
-import type { PointLabelProps, PointProps } from './types';
-import {
-  buildArrowPoints,
-  computeLabelY,
-  isWithinBounds,
-  resolveLabel,
-  useMagneticRegistration,
-} from './utils';
+import type {
+  PointArrowProps,
+  PointLabelProps,
+  PointMarkerProps,
+  PointProps,
+} from './types';
+import { usePointGeometry } from './usePointGeometry';
+import { buildArrowPoints, computeLabelGeometry, resolveLabel } from './utils';
 
 export function PointLabel({
   style,
@@ -38,6 +32,35 @@ export function PointLabel({
   );
 }
 
+function PointMarker({ x, y, size, color }: Readonly<PointMarkerProps>) {
+  const radius = size / 2;
+  const fill = color ?? cssVar('var(--background-muted-strong)');
+
+  return (
+    <circle
+      data-testid='point-circle'
+      cx={x}
+      cy={y}
+      r={radius}
+      style={{
+        fill,
+        stroke: cssVar('var(--background-canvas)'),
+      }}
+      strokeWidth={STROKE_WIDTH}
+    />
+  );
+}
+
+function PointArrow({ x, y, size, position }: Readonly<PointArrowProps>) {
+  return (
+    <polygon
+      data-testid='point-arrow'
+      points={buildArrowPoints(x, y, size / 2, position)}
+      style={{ fill: cssVar('var(--text-base)') }}
+    />
+  );
+}
+
 export function Point({
   dataX,
   dataY,
@@ -50,34 +73,32 @@ export function Point({
   size = DEFAULT_SIZE,
   onClick,
   magnetic = false,
+  clampLabelToBounds = true,
 }: Readonly<PointProps>) {
-  const { getXScale, getYScale, getXAxisConfig, drawingArea } =
-    useCartesianChartContext();
-  const magneticContext = useMagneticPointsContext();
+  const { pixel, drawingArea, revealStyle, isVisible } = usePointGeometry({
+    dataX,
+    dataY,
+    magnetic,
+  });
 
-  useMagneticRegistration(magnetic, dataX, getXAxisConfig, magneticContext);
-
-  const xScale = getXScale();
-  const yScale = getYScale();
-
-  const radius = size / 2;
-  const fill = color ?? cssVar('var(--background-muted-strong)');
-
-  const pixel = useMemo(() => {
-    if (!xScale || !yScale) return undefined;
-    return projectPoint(dataX, dataY, xScale, yScale);
-  }, [dataX, dataY, xScale, yScale]);
-
-  const revealStyle = usePointReveal();
-
-  if (!pixel || !isWithinBounds(pixel.x, pixel.y, drawingArea)) {
+  if (!isVisible || !pixel) {
     return null;
   }
 
-  const resolvedLabel = resolveLabel(label, dataX);
-  const hasLabel = resolvedLabel != null;
-  const renderArrow = showLabelArrow && hasLabel;
-  const labelY = computeLabelY(pixel.y, radius, labelPosition, renderArrow);
+  const labelText = resolveLabel(label, dataX);
+  const labelGeometry =
+    labelText != null
+      ? computeLabelGeometry({
+          text: labelText,
+          pixelX: pixel.x,
+          pixelY: pixel.y,
+          size,
+          labelPosition,
+          showLabelArrow,
+          area: drawingArea,
+          clamp: clampLabelToBounds,
+        })
+      : null;
 
   const Label = LabelComponent ?? PointLabel;
 
@@ -91,28 +112,23 @@ export function Point({
       }}
     >
       {!hidePoint && (
-        <circle
-          data-testid='point-circle'
-          cx={pixel.x}
-          cy={pixel.y}
-          r={radius}
-          style={{
-            fill,
-            stroke: cssVar('var(--background-canvas)'),
-          }}
-          strokeWidth={STROKE_WIDTH}
+        <PointMarker x={pixel.x} y={pixel.y} size={size} color={color} />
+      )}
+      {labelGeometry?.renderArrow && (
+        <PointArrow
+          x={pixel.x}
+          y={pixel.y}
+          size={size}
+          position={labelPosition}
         />
       )}
-      {renderArrow && (
-        <polygon
-          data-testid='point-arrow'
-          points={buildArrowPoints(pixel.x, pixel.y, radius, labelPosition)}
-          style={{ fill: cssVar('var(--text-base)') }}
-        />
-      )}
-      {resolvedLabel != null && (
-        <Label x={pixel.x} y={labelY}>
-          {resolvedLabel}
+      {labelText != null && labelGeometry && (
+        <Label
+          x={labelGeometry.x}
+          y={labelGeometry.y}
+          textAnchor={labelGeometry.textAnchor}
+        >
+          {labelText}
         </Label>
       )}
     </g>

--- a/libs/ui-react-visualization/src/lib/Components/Point/constants.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/constants.ts
@@ -4,3 +4,4 @@ export const ARROW_WIDTH = 6;
 export const ARROW_HEIGHT = 4;
 export const GAP = 4;
 export const LABEL_FONT_SIZE = 10;
+export const LABEL_CHAR_WIDTH_RATIO = 0.6;

--- a/libs/ui-react-visualization/src/lib/Components/Point/constants.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/constants.ts
@@ -4,4 +4,5 @@ export const ARROW_WIDTH = 6;
 export const ARROW_HEIGHT = 4;
 export const GAP = 4;
 export const LABEL_FONT_SIZE = 10;
+/** Approximate width of a character in the label font, as a ratio of the font size. */
 export const LABEL_CHAR_WIDTH_RATIO = 0.6;

--- a/libs/ui-react-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/types.ts
@@ -9,6 +9,15 @@ export type PointLabelProps = {
 export type PointLabelComponent = ComponentType<PointLabelProps>;
 
 /**
+ * Horizontal alignment strategy for a point's label.
+ *
+ * - `'auto'`: keep the label inside the drawing area, anchoring it to the
+ *   nearest edge when it would overflow.
+ * - `'center'`: always centre the label on the point.
+ */
+export type LabelAlignment = 'center' | 'auto';
+
+/**
  * Pixel position and styling inputs shared by the point's rendered glyphs. Each
  * glyph picks the subset it needs and derives its own pixel geometry (e.g.
  * radius from `size`).
@@ -101,11 +110,12 @@ export type PointProps = {
    */
   magnetic?: boolean;
   /**
-   * Keeps the label inside the chart's drawing area near the left/right edges.
-   * When the label would overflow an edge, it is anchored to that edge and
-   * grows inward instead of being clipped. The arrow keeps pointing at the
-   * exact data point. Set to `false` to always centre the label on the point.
-   * @default true
+   * Horizontal alignment of the label relative to the chart's drawing area.
+   * With `'auto'`, a label that would overflow the left/right edge is anchored
+   * to that edge and grows inward instead of being clipped, while the arrow
+   * keeps pointing at the exact data point. Use `'center'` to always centre the
+   * label on the point.
+   * @default 'auto'
    */
-  clampLabelToBounds?: boolean;
+  labelAlignment?: LabelAlignment;
 };

--- a/libs/ui-react-visualization/src/lib/Components/Point/types.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/types.ts
@@ -8,6 +8,29 @@ export type PointLabelProps = {
 
 export type PointLabelComponent = ComponentType<PointLabelProps>;
 
+/**
+ * Pixel position and styling inputs shared by the point's rendered glyphs. Each
+ * glyph picks the subset it needs and derives its own pixel geometry (e.g.
+ * radius from `size`).
+ */
+type PointGlyphProps = {
+  x: number;
+  y: number;
+  size: number;
+  color?: string;
+  position: 'top' | 'bottom';
+};
+
+export type PointMarkerProps = Pick<
+  PointGlyphProps,
+  'x' | 'y' | 'size' | 'color'
+>;
+
+export type PointArrowProps = Pick<
+  PointGlyphProps,
+  'x' | 'y' | 'size' | 'position'
+>;
+
 export type PointProps = {
   /**
    * X coordinate in data space (index or explicit value).
@@ -77,4 +100,12 @@ export type PointProps = {
    * @default false
    */
   magnetic?: boolean;
+  /**
+   * Keeps the label inside the chart's drawing area near the left/right edges.
+   * When the label would overflow an edge, it is anchored to that edge and
+   * grows inward instead of being clipped. The arrow keeps pointing at the
+   * exact data point. Set to `false` to always centre the label on the point.
+   * @default true
+   */
+  clampLabelToBounds?: boolean;
 };

--- a/libs/ui-react-visualization/src/lib/Components/Point/usePointGeometry.test.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/usePointGeometry.test.ts
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { BaseAxisProps } from '../Axis';
+import { useMagneticRegistration } from './usePointGeometry';
+
+const makeContext = () => ({
+  register: vi.fn(),
+  unregister: vi.fn(),
+  version: 0,
+  getMagneticPoints: () => new Set<number>(),
+});
+
+const noAxisConfig = (): BaseAxisProps | undefined => undefined;
+
+describe('useMagneticRegistration', () => {
+  it('registers the data index when magnetic is true', () => {
+    const ctx = makeContext();
+    renderHook(() => useMagneticRegistration(true, 3, noAxisConfig, ctx));
+
+    expect(ctx.register).toHaveBeenCalledWith(3);
+  });
+
+  it('does not register when magnetic is false', () => {
+    const ctx = makeContext();
+    renderHook(() => useMagneticRegistration(false, 3, noAxisConfig, ctx));
+
+    expect(ctx.register).not.toHaveBeenCalled();
+  });
+
+  it('unregisters on unmount', () => {
+    const ctx = makeContext();
+    const { unmount } = renderHook(() =>
+      useMagneticRegistration(true, 3, noAxisConfig, ctx),
+    );
+
+    unmount();
+    expect(ctx.unregister).toHaveBeenCalledWith(3);
+  });
+
+  it('resolves dataX through axis config data when provided', () => {
+    const ctx = makeContext();
+    const getXAxisConfig = (): BaseAxisProps => ({
+      scaleType: 'band',
+      data: [100, 200, 300],
+    });
+
+    renderHook(() => useMagneticRegistration(true, 200, getXAxisConfig, ctx));
+
+    expect(ctx.register).toHaveBeenCalledWith(1);
+  });
+
+  it('does not register when axis data exists but does not contain the value', () => {
+    const ctx = makeContext();
+    const getXAxisConfig = (): BaseAxisProps => ({
+      scaleType: 'band',
+      data: [100, 200, 300],
+    });
+
+    renderHook(() => useMagneticRegistration(true, 999, getXAxisConfig, ctx));
+
+    expect(ctx.register).not.toHaveBeenCalled();
+  });
+
+  it('re-registers when dataX changes', () => {
+    const ctx = makeContext();
+    const { rerender } = renderHook(
+      ({ dataX }) => useMagneticRegistration(true, dataX, noAxisConfig, ctx),
+      { initialProps: { dataX: 2 } },
+    );
+
+    expect(ctx.register).toHaveBeenCalledWith(2);
+
+    rerender({ dataX: 4 });
+
+    expect(ctx.unregister).toHaveBeenCalledWith(2);
+    expect(ctx.register).toHaveBeenCalledWith(4);
+  });
+
+  it('unregisters and stops when magnetic switches to false', () => {
+    const ctx = makeContext();
+    const { rerender } = renderHook(
+      ({ magnetic }) => useMagneticRegistration(magnetic, 3, noAxisConfig, ctx),
+      { initialProps: { magnetic: true } },
+    );
+
+    expect(ctx.register).toHaveBeenCalledWith(3);
+
+    rerender({ magnetic: false });
+
+    expect(ctx.unregister).toHaveBeenCalledWith(3);
+  });
+});

--- a/libs/ui-react-visualization/src/lib/Components/Point/usePointGeometry.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/usePointGeometry.ts
@@ -1,0 +1,77 @@
+import { type CSSProperties, useEffect, useMemo } from 'react';
+
+import { projectPoint } from '../../utils/scales/scales';
+import type { DrawingArea } from '../../utils/types';
+import type { BaseAxisProps } from '../Axis';
+import { useCartesianChartContext } from '../CartesianChart/context';
+import { usePointReveal } from '../CartesianChart/RevealAnimation';
+import { useMagneticPointsContext } from './pointContext';
+import type { MagneticPointsContextValue } from './pointContext/magneticPointsContext';
+import { isWithinBounds, resolveDataXToIndex } from './utils';
+
+type Pixel = { x: number; y: number };
+
+type UsePointGeometryParams = {
+  dataX: number;
+  dataY: number;
+  magnetic: boolean;
+};
+
+type PointGeometry = {
+  pixel: Pixel | undefined;
+  drawingArea: DrawingArea;
+  revealStyle: CSSProperties | undefined;
+  isVisible: boolean;
+};
+
+/**
+ * Resolves a point's chart geometry and behaviour: projects its data
+ * coordinates to pixels, registers it as a magnetic snap target when enabled,
+ * exposes the reveal-animation style, and reports whether it falls inside the
+ * drawing area.
+ */
+export const usePointGeometry = ({
+  dataX,
+  dataY,
+  magnetic,
+}: UsePointGeometryParams): PointGeometry => {
+  const { getXScale, getYScale, getXAxisConfig, drawingArea } =
+    useCartesianChartContext();
+  const magneticContext = useMagneticPointsContext();
+
+  useMagneticRegistration(magnetic, dataX, getXAxisConfig, magneticContext);
+
+  const xScale = getXScale();
+  const yScale = getYScale();
+
+  const pixel = useMemo(() => {
+    if (!xScale || !yScale) return undefined;
+    return projectPoint(dataX, dataY, xScale, yScale);
+  }, [dataX, dataY, xScale, yScale]);
+
+  const revealStyle = usePointReveal();
+
+  const isVisible =
+    pixel !== undefined && isWithinBounds(pixel.x, pixel.y, drawingArea);
+
+  return { pixel, drawingArea, revealStyle, isVisible };
+};
+
+/**
+ * Registers/unregisters a data index as a magnetic snap target
+ * when the Point has `magnetic` enabled.
+ */
+export const useMagneticRegistration = (
+  magnetic: boolean,
+  dataX: number,
+  getXAxisConfig: () => BaseAxisProps | undefined,
+  { register, unregister }: MagneticPointsContextValue,
+): void => {
+  useEffect(() => {
+    if (!magnetic) return;
+    const index = resolveDataXToIndex(dataX, getXAxisConfig());
+    if (index === undefined) return;
+    register(index);
+    return () => unregister(index);
+  }, [magnetic, dataX, getXAxisConfig, register, unregister]);
+};

--- a/libs/ui-react-visualization/src/lib/Components/Point/utils.test.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/utils.test.ts
@@ -1,14 +1,12 @@
-import { renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import type { BaseAxisProps } from '../Axis';
 import { ARROW_HEIGHT, ARROW_WIDTH, GAP, LABEL_FONT_SIZE } from './constants';
 import {
   buildArrowPoints,
+  computeLabelX,
   computeLabelY,
   isWithinBounds,
   resolveLabel,
-  useMagneticRegistration,
 } from './utils';
 
 describe('isWithinBounds', () => {
@@ -117,90 +115,46 @@ describe('computeLabelY', () => {
   });
 });
 
-const makeContext = () => ({
-  register: vi.fn(),
-  unregister: vi.fn(),
-  version: 0,
-  getMagneticPoints: () => new Set<number>(),
-});
+describe('computeLabelX', () => {
+  const area = { x: 100, y: 0, width: 200, height: 100 };
+  const halfArrow = ARROW_WIDTH / 2;
 
-const noAxisConfig = (): BaseAxisProps | undefined => undefined;
-
-describe('useMagneticRegistration', () => {
-  it('registers the data index when magnetic is true', () => {
-    const ctx = makeContext();
-    renderHook(() => useMagneticRegistration(true, 3, noAxisConfig, ctx));
-
-    expect(ctx.register).toHaveBeenCalledWith(3);
-  });
-
-  it('does not register when magnetic is false', () => {
-    const ctx = makeContext();
-    renderHook(() => useMagneticRegistration(false, 3, noAxisConfig, ctx));
-
-    expect(ctx.register).not.toHaveBeenCalled();
-  });
-
-  it('unregisters on unmount', () => {
-    const ctx = makeContext();
-    const { unmount } = renderHook(() =>
-      useMagneticRegistration(true, 3, noAxisConfig, ctx),
-    );
-
-    unmount();
-    expect(ctx.unregister).toHaveBeenCalledWith(3);
-  });
-
-  it('resolves dataX through axis config data when provided', () => {
-    const ctx = makeContext();
-    const getXAxisConfig = (): BaseAxisProps => ({
-      scaleType: 'band',
-      data: [100, 200, 300],
+  it('centres the label on the point when clamping is disabled', () => {
+    expect(computeLabelX(105, 'A very long label', area, false, true)).toEqual({
+      x: 105,
+      textAnchor: 'middle',
     });
-
-    renderHook(() => useMagneticRegistration(true, 200, getXAxisConfig, ctx));
-
-    expect(ctx.register).toHaveBeenCalledWith(1);
   });
 
-  it('does not register when axis data exists but does not contain the value', () => {
-    const ctx = makeContext();
-    const getXAxisConfig = (): BaseAxisProps => ({
-      scaleType: 'band',
-      data: [100, 200, 300],
+  it('centres the label on the point when it fits inside the bounds', () => {
+    expect(computeLabelX(200, 'Peak', area, true, true)).toEqual({
+      x: 200,
+      textAnchor: 'middle',
     });
-
-    renderHook(() => useMagneticRegistration(true, 999, getXAxisConfig, ctx));
-
-    expect(ctx.register).not.toHaveBeenCalled();
   });
 
-  it('re-registers when dataX changes', () => {
-    const ctx = makeContext();
-    const { rerender } = renderHook(
-      ({ dataX }) => useMagneticRegistration(true, dataX, noAxisConfig, ctx),
-      { initialProps: { dataX: 2 } },
-    );
-
-    expect(ctx.register).toHaveBeenCalledWith(2);
-
-    rerender({ dataX: 4 });
-
-    expect(ctx.unregister).toHaveBeenCalledWith(2);
-    expect(ctx.register).toHaveBeenCalledWith(4);
+  it('anchors near the left edge, offset by half the arrow width from the point', () => {
+    expect(computeLabelX(105, 'Long label', area, true, true)).toEqual({
+      x: 105 - halfArrow,
+      textAnchor: 'start',
+    });
   });
 
-  it('unregisters and stops when magnetic switches to false', () => {
-    const ctx = makeContext();
-    const { rerender } = renderHook(
-      ({ magnetic }) => useMagneticRegistration(magnetic, 3, noAxisConfig, ctx),
-      { initialProps: { magnetic: true } },
-    );
+  it('anchors near the right edge, offset by half the arrow width from the point', () => {
+    expect(computeLabelX(295, 'Long label', area, true, true)).toEqual({
+      x: 295 + halfArrow,
+      textAnchor: 'end',
+    });
+  });
 
-    expect(ctx.register).toHaveBeenCalledWith(3);
-
-    rerender({ magnetic: false });
-
-    expect(ctx.unregister).toHaveBeenCalledWith(3);
+  it('omits the arrow offset when no arrow is rendered', () => {
+    expect(computeLabelX(105, 'Long label', area, true, false)).toEqual({
+      x: 105,
+      textAnchor: 'start',
+    });
+    expect(computeLabelX(295, 'Long label', area, true, false)).toEqual({
+      x: 295,
+      textAnchor: 'end',
+    });
   });
 });

--- a/libs/ui-react-visualization/src/lib/Components/Point/utils.test.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/utils.test.ts
@@ -120,39 +120,41 @@ describe('computeLabelX', () => {
   const halfArrow = ARROW_WIDTH / 2;
 
   it('centres the label on the point when clamping is disabled', () => {
-    expect(computeLabelX(105, 'A very long label', area, false, true)).toEqual({
+    expect(
+      computeLabelX(105, 'A very long label', area, 'center', true),
+    ).toEqual({
       x: 105,
       textAnchor: 'middle',
     });
   });
 
   it('centres the label on the point when it fits inside the bounds', () => {
-    expect(computeLabelX(200, 'Peak', area, true, true)).toEqual({
+    expect(computeLabelX(200, 'Peak', area, 'auto', true)).toEqual({
       x: 200,
       textAnchor: 'middle',
     });
   });
 
   it('anchors near the left edge, offset by half the arrow width from the point', () => {
-    expect(computeLabelX(105, 'Long label', area, true, true)).toEqual({
+    expect(computeLabelX(105, 'Long label', area, 'auto', true)).toEqual({
       x: 105 - halfArrow,
       textAnchor: 'start',
     });
   });
 
   it('anchors near the right edge, offset by half the arrow width from the point', () => {
-    expect(computeLabelX(295, 'Long label', area, true, true)).toEqual({
+    expect(computeLabelX(295, 'Long label', area, 'auto', true)).toEqual({
       x: 295 + halfArrow,
       textAnchor: 'end',
     });
   });
 
   it('omits the arrow offset when no arrow is rendered', () => {
-    expect(computeLabelX(105, 'Long label', area, true, false)).toEqual({
+    expect(computeLabelX(105, 'Long label', area, 'auto', false)).toEqual({
       x: 105,
       textAnchor: 'start',
     });
-    expect(computeLabelX(295, 'Long label', area, true, false)).toEqual({
+    expect(computeLabelX(295, 'Long label', area, 'auto', false)).toEqual({
       x: 295,
       textAnchor: 'end',
     });

--- a/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
@@ -7,6 +7,7 @@ import {
   LABEL_CHAR_WIDTH_RATIO,
   LABEL_FONT_SIZE,
 } from './constants';
+import type { LabelAlignment } from './types';
 
 export type LabelTextAnchor = 'start' | 'middle' | 'end';
 
@@ -77,10 +78,10 @@ export const computeLabelX = (
   pixelX: number,
   label: string,
   area: DrawingArea,
-  clamp: boolean,
+  alignment: LabelAlignment,
   hasArrow: boolean,
 ): { x: number; textAnchor: LabelTextAnchor } => {
-  if (!clamp) {
+  if (alignment === 'center') {
     return { x: pixelX, textAnchor: 'middle' };
   }
 
@@ -127,7 +128,7 @@ export const computeLabelGeometry = ({
   labelPosition,
   showLabelArrow,
   area,
-  clamp,
+  alignment,
 }: {
   text: string;
   pixelX: number;
@@ -136,7 +137,7 @@ export const computeLabelGeometry = ({
   labelPosition: 'top' | 'bottom';
   showLabelArrow: boolean;
   area: DrawingArea;
-  clamp: boolean;
+  alignment: LabelAlignment;
 }): {
   x: number;
   y: number;
@@ -147,7 +148,7 @@ export const computeLabelGeometry = ({
     pixelX,
     text,
     area,
-    clamp,
+    alignment,
     showLabelArrow,
   );
   const y = computeLabelY(pixelY, size / 2, labelPosition, showLabelArrow);

--- a/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
@@ -1,9 +1,14 @@
-import { useEffect } from 'react';
-
 import type { DrawingArea } from '../../utils/types';
 import type { BaseAxisProps } from '../Axis';
-import { ARROW_HEIGHT, ARROW_WIDTH, GAP, LABEL_FONT_SIZE } from './constants';
-import type { MagneticPointsContextValue } from './pointContext/magneticPointsContext';
+import {
+  ARROW_HEIGHT,
+  ARROW_WIDTH,
+  GAP,
+  LABEL_CHAR_WIDTH_RATIO,
+  LABEL_FONT_SIZE,
+} from './constants';
+
+type LabelTextAnchor = 'start' | 'middle' | 'end';
 
 export const isWithinBounds = (
   px: number,
@@ -63,22 +68,33 @@ export const resolveDataXToIndex = (
 };
 
 /**
- * Registers/unregisters a data index as a magnetic snap target
- * when the Point has `magnetic` enabled.
+ * Computes the label's horizontal placement, keeping it inside the drawing area
+ * near the left/right edges. Centred on the point when it fits; otherwise
+ * anchored to the edge and aligned with the arrow's outer vertex (offset by half
+ * the arrow width from the point, when an arrow is rendered).
  */
-export const useMagneticRegistration = (
-  magnetic: boolean,
-  dataX: number,
-  getXAxisConfig: () => BaseAxisProps | undefined,
-  { register, unregister }: MagneticPointsContextValue,
-): void => {
-  useEffect(() => {
-    if (!magnetic) return;
-    const index = resolveDataXToIndex(dataX, getXAxisConfig());
-    if (index === undefined) return;
-    register(index);
-    return () => unregister(index);
-  }, [magnetic, dataX, getXAxisConfig, register, unregister]);
+export const computeLabelX = (
+  pixelX: number,
+  label: string,
+  area: DrawingArea,
+  clamp: boolean,
+  hasArrow: boolean,
+): { x: number; textAnchor: LabelTextAnchor } => {
+  if (!clamp) {
+    return { x: pixelX, textAnchor: 'middle' };
+  }
+
+  const halfWidth =
+    (label.length * LABEL_FONT_SIZE * LABEL_CHAR_WIDTH_RATIO) / 2;
+  const arrowOffset = hasArrow ? ARROW_WIDTH / 2 : 0;
+
+  if (pixelX - halfWidth < area.x) {
+    return { x: pixelX - arrowOffset, textAnchor: 'start' };
+  }
+  if (pixelX + halfWidth > area.x + area.width) {
+    return { x: pixelX + arrowOffset, textAnchor: 'end' };
+  }
+  return { x: pixelX, textAnchor: 'middle' };
 };
 
 /**
@@ -95,4 +111,46 @@ export const computeLabelY = (
   return labelPosition === 'top'
     ? pixelY - radius - arrowOffset - GAP
     : pixelY + radius + arrowOffset + GAP + LABEL_FONT_SIZE;
+};
+
+/**
+ * Computes where a point's label and its connector arrow are drawn: the
+ * (optionally clamped) horizontal placement, the vertical baseline, and whether
+ * the arrow is rendered. Label content is resolved separately via
+ * {@link resolveLabel}.
+ */
+export const computeLabelGeometry = ({
+  text,
+  pixelX,
+  pixelY,
+  size,
+  labelPosition,
+  showLabelArrow,
+  area,
+  clamp,
+}: {
+  text: string;
+  pixelX: number;
+  pixelY: number;
+  size: number;
+  labelPosition: 'top' | 'bottom';
+  showLabelArrow: boolean;
+  area: DrawingArea;
+  clamp: boolean;
+}): {
+  x: number;
+  y: number;
+  textAnchor: LabelTextAnchor;
+  renderArrow: boolean;
+} => {
+  const { x, textAnchor } = computeLabelX(
+    pixelX,
+    text,
+    area,
+    clamp,
+    showLabelArrow,
+  );
+  const y = computeLabelY(pixelY, size / 2, labelPosition, showLabelArrow);
+
+  return { x, y, textAnchor, renderArrow: showLabelArrow };
 };

--- a/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
@@ -8,7 +8,7 @@ import {
   LABEL_FONT_SIZE,
 } from './constants';
 
-type LabelTextAnchor = 'start' | 'middle' | 'end';
+export type LabelTextAnchor = 'start' | 'middle' | 'end';
 
 export const isWithinBounds = (
   px: number,

--- a/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
+++ b/libs/ui-react-visualization/src/lib/Components/Point/utils.ts
@@ -115,9 +115,8 @@ export const computeLabelY = (
 };
 
 /**
- * Computes where a point's label and its connector arrow are drawn: the
- * (optionally clamped) horizontal placement, the vertical baseline, and whether
- * the arrow is rendered. Label content is resolved separately via
+ * Computes where a point's label is drawn: the (optionally clamped) horizontal
+ * placement and the vertical baseline. Label content is resolved separately via
  * {@link resolveLabel}.
  */
 export const computeLabelGeometry = ({
@@ -142,7 +141,6 @@ export const computeLabelGeometry = ({
   x: number;
   y: number;
   textAnchor: LabelTextAnchor;
-  renderArrow: boolean;
 } => {
   const { x, textAnchor } = computeLabelX(
     pixelX,
@@ -153,5 +151,5 @@ export const computeLabelGeometry = ({
   );
   const y = computeLabelY(pixelY, size / 2, labelPosition, showLabelArrow);
 
-  return { x, y, textAnchor, renderArrow: showLabelArrow };
+  return { x, y, textAnchor };
 };


### PR DESCRIPTION
## Overview
Add clamping logic to the `Point` label so it always stays inside the drawing
area, even when the point sits at the chart's edges. Previously, a label
centered on an edge point would overflow the chart horizontally.
When a centered label would overflow, it is anchored to the edge and grows
inward; the arrow keeps pointing at the exact data point. The behavior is
controlled by a new `labelAlignment` prop (default `true`) so consumers can
opt out.
Also refactored `Point` to separate concerns:
- Extracted chart/behavior logic into a `usePointGeometry` hook (projection,
  magnetic registration, reveal style, in-bounds gating).
- Split the label computation into content (`resolveLabel`) and geometry
  (`computeLabelGeometry`).
- Kept pure helpers in `utils.ts` and React hooks alongside the component.


---

<img width="132" height="306" alt="Screenshot 2026-06-16 at 20 29 26" src="https://github.com/user-attachments/assets/6f9fbd9f-4ca7-45a7-911e-355bf5eebd51" />
