### PR TITLE
[M][D]DLS-648-chore(eslint): enhance ESLint configuration

### DIFF
--- a/.nx/version-plans/version-plan-1781798209362-ui-react.md
+++ b/.nx/version-plans/version-plan-1781798209362-ui-react.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+refactor: enforce eqeqeq and no-negated-condition lint rules

--- a/.nx/version-plans/version-plan-1781798209363-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1781798209363-ui-rnative.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+refactor: enforce eqeqeq/no-negated-condition rules and replace deprecated MutableRefObject with RefObject

--- a/.nx/version-plans/version-plan-1781798209364-ui-react-visualization.md
+++ b/.nx/version-plans/version-plan-1781798209364-ui-react-visualization.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react-visualization': patch
+---
+
+refactor: enforce eqeqeq and no-negated-condition lint rules

--- a/.nx/version-plans/version-plan-1781798209365-ui-rnative-visualization.md
+++ b/.nx/version-plans/version-plan-1781798209365-ui-rnative-visualization.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative-visualization': patch
+---
+
+refactor: enforce eqeqeq and no-negated-condition lint rules

--- a/.nx/version-plans/version-plan-1781798209366-utils-shared.md
+++ b/.nx/version-plans/version-plan-1781798209366-utils-shared.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-utils-shared': patch
+---
+
+refactor: invert negated condition in textFormatter per no-negated-condition rule

--- a/.nx/version-plans/version-plan-1781798209367-design-core.md
+++ b/.nx/version-plans/version-plan-1781798209367-design-core.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-design-core': patch
+---
+
+refactor: enforce eqeqeq and no-negated-condition lint rules in figma tooling

--- a/apps/app-sandbox-rnative/src/app/blocks/LineCharts.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/LineCharts.tsx
@@ -301,7 +301,7 @@ const MissingData = () => (
           title: missingDataPages[i],
           items: missingDataSeries.map((series) => ({
             label: series.label,
-            value: series.data[i] == null ? '—' : `${series.data[i]}`,
+            value: series.data[i] === null ? '—' : `${series.data[i]}`,
           })),
         })}
       />

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,7 +71,9 @@ export const sharedConfig = defineConfig(
       /**
        * Others
        */
+      'eqeqeq': ['error', 'always', { null: 'ignore' }],
       'default-param-last': 'error',
+      'no-negated-condition': 'error',
       'no-unused-vars': 'off',
       'no-restricted-imports': [
         'error',
@@ -91,6 +93,16 @@ export const sharedConfig = defineConfig(
               name: 'react-native',
               importNames: ['Animated', 'Easing', 'LayoutAnimation'],
               message: 'Prefer react-native-reanimated for animations.',
+            },
+            {
+              name: 'react',
+              importNames: ['ElementRef'],
+              message: 'ElementRef is deprecated. Use ComponentRef<T> instead.',
+            },
+            {
+              name: 'react',
+              importNames: ['MutableRefObject'],
+              message: 'MutableRefObject is deprecated. Use RefObject instead.',
             },
           ],
         },

--- a/libs/design-core/tools/figma/downloadSvgs.ts
+++ b/libs/design-core/tools/figma/downloadSvgs.ts
@@ -26,10 +26,10 @@ type ConfigFileData = {
 
 const createDir = (dir: string): Promise<void> => {
   return new Promise<void>((resolve) => {
-    if (!fs.existsSync(dir)) {
-      fs.mkdir(dir, null, () => resolve());
-    } else {
+    if (fs.existsSync(dir)) {
       resolve();
+    } else {
+      fs.mkdir(dir, null, () => resolve());
     }
   });
 };

--- a/libs/design-core/tools/figma/tokenFilesFromLocalVariables.ts
+++ b/libs/design-core/tools/figma/tokenFilesFromLocalVariables.ts
@@ -66,7 +66,7 @@ function rgbToHex({ r, g, b, ...rest }: RGB | RGBA) {
   };
 
   const hex = [toHex(r), toHex(g), toHex(b)].join('');
-  return `#${hex}` + (a !== 1 ? toHex(a) : '');
+  return `#${hex}` + (a === 1 ? '' : toHex(a));
 }
 
 export default function tokenFilesFromLocalVariables(

--- a/libs/ui-react-visualization/src/lib/utils/domain/domain.ts
+++ b/libs/ui-react-visualization/src/lib/utils/domain/domain.ts
@@ -55,13 +55,13 @@ export const computeYDomain = (
     if (!s.data) continue;
     for (const v of s.data) {
       if (v !== null && v !== undefined) {
-        if (!hasValue) {
+        if (hasValue) {
+          if (v < min) min = v;
+          if (v > max) max = v;
+        } else {
           min = v;
           max = v;
           hasValue = true;
-        } else {
-          if (v < min) min = v;
-          if (v > max) max = v;
         }
       }
     }

--- a/libs/ui-react/src/lib/Components/AmountDisplay/AmountDisplay.tsx
+++ b/libs/ui-react/src/lib/Components/AmountDisplay/AmountDisplay.tsx
@@ -95,7 +95,7 @@ const DigitStrip = memo(({ value, animate, widths }: DigitStripProps) => {
         }}
       >
         {DIGITS.map((d, i) => (
-          <span inert={d !== value ? true : false} key={i}>
+          <span inert={d === value ? false : true} key={i}>
             {d}
           </span>
         ))}

--- a/libs/ui-react/src/lib/Components/SearchInput/SearchInput.stories.tsx
+++ b/libs/ui-react/src/lib/Components/SearchInput/SearchInput.stories.tsx
@@ -220,7 +220,7 @@ export const DebouncedSearchInput: Story = {
               <div>
                 <p className='mb-8 body-3 text-muted'>
                   Found {filteredResults.length} result
-                  {filteredResults.length !== 1 ? 's' : ''} for "{searchQuery}"
+                  {filteredResults.length === 1 ? '' : 's'} for "{searchQuery}"
                 </p>
                 <div className='space-y-4'>
                   {filteredResults.map((result) => (

--- a/libs/ui-react/src/lib/Components/Select/Select.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.tsx
@@ -131,13 +131,13 @@ const SelectInputTrigger = ({
     consumerName: 'SelectInputTrigger',
     contextRequired: true,
   });
-  const hasValue = selectedValue != null && selectedValue !== '';
+  const hasValue = selectedValue !== null && selectedValue !== '';
 
   return (
     <Combobox.Trigger
       ref={ref}
       data-slot='select-trigger'
-      data-placeholder={!hasValue ? '' : undefined}
+      data-placeholder={hasValue ? undefined : ''}
       className={cn(triggerStyles, className)}
       {...props}
     >

--- a/libs/ui-react/src/lib/Components/Select/useSelectItems/useSelectItems.ts
+++ b/libs/ui-react/src/lib/Components/Select/useSelectItems/useSelectItems.ts
@@ -66,7 +66,7 @@ export function useSelectItems<TMeta extends MetaShape = MetaShape>({
     : null;
 
   const isGrouped = useMemo(
-    () => items.some((item) => item.group != null),
+    () => items.some((item) => item.group !== undefined),
     [items],
   );
 

--- a/libs/ui-react/src/lib/Components/TextInput/TextInput.stories.tsx
+++ b/libs/ui-react/src/lib/Components/TextInput/TextInput.stories.tsx
@@ -241,9 +241,9 @@ export const WithError: Story = {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           helperText={
-            !isValidEmail ? 'Please enter a valid email address' : undefined
+            isValidEmail ? undefined : 'Please enter a valid email address'
           }
-          status={!isValidEmail ? 'error' : undefined}
+          status={isValidEmail ? undefined : 'error'}
         />
         <div className='mt-12 body-3 text-muted'>
           Try typing a valid email address or clicking the clear button to

--- a/libs/ui-rnative-visualization/src/lib/Components/Point/Point.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Point/Point.tsx
@@ -75,7 +75,7 @@ export function Point({
   }
 
   const resolvedLabel = resolveLabel(label, dataX);
-  const hasLabel = resolvedLabel != null;
+  const hasLabel = resolvedLabel !== undefined;
   const renderArrow = showLabelArrow && hasLabel;
   const labelY = computeLabelY(pixel.y, radius, labelPosition, renderArrow);
 
@@ -101,7 +101,7 @@ export function Point({
           fill={theme.colors.text.base}
         />
       )}
-      {resolvedLabel != null && (
+      {resolvedLabel !== undefined && (
         <Label x={pixel.x} y={labelY}>
           {resolvedLabel}
         </Label>

--- a/libs/ui-rnative-visualization/src/lib/utils/domain/domain.ts
+++ b/libs/ui-rnative-visualization/src/lib/utils/domain/domain.ts
@@ -55,13 +55,13 @@ export const computeYDomain = (
     if (!s.data) continue;
     for (const v of s.data) {
       if (v !== null && v !== undefined) {
-        if (!hasValue) {
+        if (hasValue) {
+          if (v < min) min = v;
+          if (v > max) max = v;
+        } else {
           min = v;
           max = v;
           hasValue = true;
-        } else {
-          if (v < min) min = v;
-          if (v > max) max = v;
         }
       }
     }

--- a/libs/ui-rnative/src/lib/Components/BaseInput/BaseInput.tsx
+++ b/libs/ui-rnative/src/lib/Components/BaseInput/BaseInput.tsx
@@ -88,10 +88,10 @@ export const BaseInput = ({
   );
 
   const handleClear = () => {
-    if (!isControlled) {
-      setUncontrolledValue('');
-    } else {
+    if (isControlled) {
       onChangeTextProp?.('');
+    } else {
+      setUncontrolledValue('');
     }
     props.onClear?.();
   };

--- a/libs/ui-rnative/src/lib/Components/OptionList/useOptionList/useOptionListItems.ts
+++ b/libs/ui-rnative/src/lib/Components/OptionList/useOptionList/useOptionListItems.ts
@@ -23,7 +23,7 @@ const groupByField = <TMeta extends MetaShape = MetaShape>(
 };
 
 const hasGroups = (items: OptionListItemData[]): boolean =>
-  items.some((item) => item.group != null);
+  items.some((item) => item.group !== undefined);
 
 export const defaultLabelFilter = (
   item: OptionListItemData,

--- a/libs/ui-rnative/src/lib/Components/Slot/Slot.tsx
+++ b/libs/ui-rnative/src/lib/Components/Slot/Slot.tsx
@@ -2,6 +2,7 @@ import type {
   ComponentRef,
   ComponentPropsWithoutRef,
   ComponentPropsWithRef,
+  RefObject,
 } from 'react';
 import { isValidElement, cloneElement } from 'react';
 import type {
@@ -110,7 +111,7 @@ function composeRefs<T>(...refs: (React.Ref<T> | undefined)[]) {
       if (typeof ref === 'function') {
         ref(node);
       } else if (ref != null) {
-        (ref as React.MutableRefObject<T>).current = node;
+        (ref as RefObject<T>).current = node;
       }
     });
 }

--- a/libs/ui-rnative/src/lib/Components/Tooltip/GlobalTooltipContext.tsx
+++ b/libs/ui-rnative/src/lib/Components/Tooltip/GlobalTooltipContext.tsx
@@ -1,5 +1,5 @@
 import { createSafeContext } from '@ledgerhq/lumen-utils-shared';
-import type { ReactNode } from 'react';
+import type { ReactNode, RefObject } from 'react';
 import { useState, useCallback, useRef, useMemo } from 'react';
 
 export type TooltipData = {
@@ -11,8 +11,8 @@ export type TooltipData = {
 
 type GlobalTooltipBottomSheetContextValue = {
   currentTooltip: TooltipData | null;
-  showTooltipRef: React.MutableRefObject<(data: TooltipData) => void>;
-  hideTooltipRef: React.MutableRefObject<() => void>;
+  showTooltipRef: RefObject<(data: TooltipData) => void>;
+  hideTooltipRef: RefObject<() => void>;
 };
 
 const [GlobalTooltipContextProvider, _useGlobalTooltipSafeContext] =

--- a/libs/ui-rnative/src/lib/Components/Utility/Gradient/utils/resolveGradientColor.ts
+++ b/libs/ui-rnative/src/lib/Components/Utility/Gradient/utils/resolveGradientColor.ts
@@ -42,13 +42,13 @@ export const processGradientStops = (
     // Auto-spread offsets if not provided
     // For n stops: 0, 1/(n-1), 2/(n-1), ..., 1
     const offset =
-      stop.offset !== undefined
-        ? stop.offset
-        : stopCount === 1
+      stop.offset === undefined
+        ? stopCount === 1
           ? DEFAULT_OFFSET
-          : index / (stopCount - 1);
+          : index / (stopCount - 1)
+        : stop.offset;
 
-    const opacity = stop.opacity !== undefined ? stop.opacity : DEFAULT_OPACITY;
+    const opacity = stop.opacity === undefined ? DEFAULT_OPACITY : stop.opacity;
 
     return {
       color: resolvedColor,

--- a/libs/ui-rnative/src/lib/Components/Utility/Gradient/utils/resolveGradientColor.ts
+++ b/libs/ui-rnative/src/lib/Components/Utility/Gradient/utils/resolveGradientColor.ts
@@ -43,9 +43,8 @@ export const processGradientStops = (
     // For n stops: 0, 1/(n-1), 2/(n-1), ..., 1
     const autoOffset =
       stopCount === 1 ? DEFAULT_OFFSET : index / (stopCount - 1);
-    const offset = stop.offset === undefined ? autoOffset : stop.offset;
-
-    const opacity = stop.opacity === undefined ? DEFAULT_OPACITY : stop.opacity;
+    const offset = stop.offset ?? autoOffset;
+    const opacity = stop.opacity ?? DEFAULT_OPACITY;
 
     return {
       color: resolvedColor,

--- a/libs/ui-rnative/src/lib/Components/Utility/Gradient/utils/resolveGradientColor.ts
+++ b/libs/ui-rnative/src/lib/Components/Utility/Gradient/utils/resolveGradientColor.ts
@@ -41,12 +41,9 @@ export const processGradientStops = (
 
     // Auto-spread offsets if not provided
     // For n stops: 0, 1/(n-1), 2/(n-1), ..., 1
-    const offset =
-      stop.offset === undefined
-        ? stopCount === 1
-          ? DEFAULT_OFFSET
-          : index / (stopCount - 1)
-        : stop.offset;
+    const autoOffset =
+      stopCount === 1 ? DEFAULT_OFFSET : index / (stopCount - 1);
+    const offset = stop.offset === undefined ? autoOffset : stop.offset;
 
     const opacity = stop.opacity === undefined ? DEFAULT_OPACITY : stop.opacity;
 

--- a/libs/ui-rnative/src/lib/utils/startTransition/startTransition.ts
+++ b/libs/ui-rnative/src/lib/utils/startTransition/startTransition.ts
@@ -2,11 +2,11 @@ import { startTransition as reactStartTransition } from 'react';
 import { RuntimeConstants } from '../constants';
 
 export const startTransition = (callback: React.TransitionFunction): void => {
-  if (!RuntimeConstants.isBrowser) {
-    // Pass-through function
-    callback();
-  } else {
+  if (RuntimeConstants.isBrowser) {
     // Proxy to react.startTransition
     reactStartTransition(callback);
+  } else {
+    // Pass-through function
+    callback();
   }
 };

--- a/libs/utils-shared/src/lib/inputFormatter/textFormatter.ts
+++ b/libs/utils-shared/src/lib/inputFormatter/textFormatter.ts
@@ -61,7 +61,12 @@ export function textFormatter(
   }
 
   const firstDot = cleaned.indexOf('.');
-  if (firstDot !== -1) {
+  if (firstDot === -1) {
+    // No decimal point, just apply integer length limit
+    if (maxIntegerLength > 0 && cleaned.length > maxIntegerLength) {
+      cleaned = cleaned.slice(0, maxIntegerLength);
+    }
+  } else {
     // Split integer and decimal parts
     let integerPart = cleaned.slice(0, firstDot);
     let decimalPart = cleaned.slice(firstDot + 1).replace(/\./g, '');
@@ -84,11 +89,6 @@ export function textFormatter(
         : hasTrailingDot
           ? `${integerPart}.`
           : integerPart;
-  } else {
-    // No decimal point, just apply integer length limit
-    if (maxIntegerLength > 0 && cleaned.length > maxIntegerLength) {
-      cleaned = cleaned.slice(0, maxIntegerLength);
-    }
   }
 
   return thousandsSeparator ? formatThousands(cleaned) : cleaned;


### PR DESCRIPTION
## Overview

- Add 'eqeqeq' ESLint rule to avoid using '==', loosening the rule with {null: ignore} to still allow doing 'a != null' that checks for both null and undefined.
- Add 'no-negated-condition' to prevent SonarCloud code smells on unexpected negated conditions.
- Add both deprecated `ElementRef` and `MutableRefObject` React types to the
  restricted-imports list, and remove all remaining instances from the codebase
  (`MutableRefObject<T>` → `RefObject<T>` in `Slot.tsx` and `GlobalTooltipContext.tsx`).
- Apply the new rules across the codebase: migrate `==`/`!=` to strict equality
  (keeping `!= null` where both nullish values are intended) and invert negated
  conditions flagged by `no-negated-condition`.