### PR TITLE
BREAKING_CHANGE: add type-safety for compound components

### DIFF
--- a/.nx/version-plans/version-plan-1781871906856-ui-react.md
+++ b/.nx/version-plans/version-plan-1781871906856-ui-react.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+feat(ui-react): add type-safety for compound components

--- a/.nx/version-plans/version-plan-1781871906856-ui-react.md
+++ b/.nx/version-plans/version-plan-1781871906856-ui-react.md
@@ -3,3 +3,9 @@
 ---
 
 feat(ui-react): add type-safety for compound components
+
+Note: the generics on `Select` components now take the value union `T` as the first parameter, followed by `TMeta` (previously `TMeta` was the only parameter).
+
+This enables type-safe `value` inference across the compound components. Normal usage (no explicit type arguments) and the new `createSelect` factory are unaffected.
+
+If you previously passed the meta type explicitly, e.g. `SelectItemData<MyMeta>`, move it to the second slot: `SelectItemData<string, MyMeta>`.

--- a/.nx/version-plans/version-plan-1781871906856-ui-react.md
+++ b/.nx/version-plans/version-plan-1781871906856-ui-react.md
@@ -2,9 +2,9 @@
 '@ledgerhq/lumen-ui-react': patch
 ---
 
-feat(ui-react): add type-safety for compound components
+BREAKING_CHANGE(ui-react): add type-safety for compound components
 
-Note: the generics on `Select` components now take the value union `T` as the first parameter, followed by `TMeta` (previously `TMeta` was the only parameter).
+The generics on `Select` components now take the value union `T` as the first parameter, followed by `TMeta` (previously `TMeta` was the only parameter).
 
 This enables type-safe `value` inference across the compound components. Normal usage (no explicit type arguments) and the new `createSelect` factory are unaffected.
 

--- a/.nx/version-plans/version-plan-1781871906856-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1781871906856-ui-rnative.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+feat(ui-rnative): add type-safety for compound components

--- a/.nx/version-plans/version-plan-1781871906856-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1781871906856-ui-rnative.md
@@ -4,7 +4,7 @@
 
 feat(ui-rnative): add type-safety for compound components
 
-Note: the generics on `OptionListItemData`, `OptionListProps`, `OptionListItemGroup`, `OptionListContentProps` and related types now take the value union `T` as the first parameter, followed by `TMeta` (previously `TMeta` was the only parameter).
+Note: the generics on `OptionList` components now take the value union `T` as the first parameter, followed by `TMeta` (previously `TMeta` was the only parameter).
 
 This enables type-safe `value` inference across the compound components. Normal usage (no explicit type arguments) and the new `createOptionList` factory are unaffected. 
 

--- a/.nx/version-plans/version-plan-1781871906856-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1781871906856-ui-rnative.md
@@ -3,3 +3,9 @@
 ---
 
 feat(ui-rnative): add type-safety for compound components
+
+Note: the generics on `OptionListItemData`, `OptionListProps`, `OptionListItemGroup`, `OptionListContentProps` and related types now take the value union `T` as the first parameter, followed by `TMeta` (previously `TMeta` was the only parameter).
+
+This enables type-safe `value` inference across the compound components. Normal usage (no explicit type arguments) and the new `createOptionList` factory are unaffected. 
+
+If you previously passed the meta type explicitly, e.g. `OptionListItemData<MyMeta>`, move it to the second slot: `OptionListItemData<string, MyMeta>`.

--- a/.nx/version-plans/version-plan-1781871906856-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1781871906856-ui-rnative.md
@@ -2,9 +2,9 @@
 '@ledgerhq/lumen-ui-rnative': patch
 ---
 
-feat(ui-rnative): add type-safety for compound components
+BREAKING_CHANGE(ui-rnative): add type-safety for compound components
 
-Note: the generics on `OptionList` components now take the value union `T` as the first parameter, followed by `TMeta` (previously `TMeta` was the only parameter).
+The generics on `OptionList` components now take the value union `T` as the first parameter, followed by `TMeta` (previously `TMeta` was the only parameter).
 
 This enables type-safe `value` inference across the compound components. Normal usage (no explicit type arguments) and the new `createOptionList` factory are unaffected. 
 

--- a/apps/app-sandbox-rnative/src/app/blocks/OptionLists.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/OptionLists.tsx
@@ -21,7 +21,10 @@ import {
 } from '@ledgerhq/lumen-ui-rnative';
 import { useState } from 'react';
 
-const CURRENCIES: OptionListItemData<{ ticker: string; icon: string }>[] = [
+const CURRENCIES: OptionListItemData<
+  string,
+  { ticker: string; icon: string }
+>[] = [
   {
     value: 'btc',
     label: 'Bitcoin',
@@ -105,7 +108,7 @@ const CurrencySelectExample = () => {
   );
 };
 
-const FOODS: OptionListItemData<{ group: string }>[] = [
+const FOODS: OptionListItemData<string, { group: string }>[] = [
   { value: 'apple', label: 'Apple', group: 'Fruits' },
   { value: 'banana', label: 'Banana', group: 'Fruits' },
   { value: 'orange', label: 'Orange', group: 'Fruits' },
@@ -158,11 +161,14 @@ const GroupedSelectExample = () => {
   );
 };
 
-const NETWORKS: OptionListItemData<{
-  ticker: string;
-  icon: string;
-  tag: string;
-}>[] = [
+const NETWORKS: OptionListItemData<
+  string,
+  {
+    ticker: string;
+    icon: string;
+    tag: string;
+  }
+>[] = [
   {
     value: 'ethereum',
     label: 'Ethereum',
@@ -260,10 +266,13 @@ const NetworkSelectExample = () => {
   );
 };
 
-const SEARCHABLE_CURRENCIES: OptionListItemData<{
-  ticker: string;
-  icon: string;
-}>[] = [
+const SEARCHABLE_CURRENCIES: OptionListItemData<
+  string,
+  {
+    ticker: string;
+    icon: string;
+  }
+>[] = [
   { value: 'btc', label: 'Bitcoin', meta: { ticker: 'BTC', icon: 'bitcoin' } },
   {
     value: 'eth',

--- a/apps/app-sandbox-rnative/src/app/blocks/OptionLists.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/OptionLists.tsx
@@ -2,16 +2,7 @@ import CryptoIconNative from '@ledgerhq/crypto-icons/native';
 import type { OptionListItemData } from '@ledgerhq/lumen-ui-rnative';
 import {
   MediaButton,
-  OptionList,
-  OptionListContent,
-  OptionListEmptyState,
-  OptionListItem,
-  OptionListItemLeading,
-  OptionListItemContent,
-  OptionListItemText,
-  OptionListItemDescription,
-  OptionListItemContentRow,
-  OptionListSearch,
+  createOptionList,
   Tag,
   Box,
   useBottomSheetRef,
@@ -21,10 +12,20 @@ import {
 } from '@ledgerhq/lumen-ui-rnative';
 import { useState } from 'react';
 
-const CURRENCIES: OptionListItemData<
-  string,
-  { ticker: string; icon: string }
->[] = [
+type Currency = 'btc' | 'eth';
+type CryptoMeta = { ticker: string; icon: string };
+
+const {
+  OptionList: CurrencyList,
+  OptionListContent: CurrencyListContent,
+  OptionListItem: CurrencyListItem,
+  OptionListItemLeading: CurrencyListItemLeading,
+  OptionListItemContent: CurrencyListItemContent,
+  OptionListItemText: CurrencyListItemText,
+  OptionListItemDescription: CurrencyListItemDescription,
+} = createOptionList<Currency, CryptoMeta>();
+
+const CURRENCIES: OptionListItemData<Currency, CryptoMeta>[] = [
   {
     value: 'btc',
     label: 'Bitcoin',
@@ -38,22 +39,19 @@ const CURRENCIES: OptionListItemData<
 ];
 
 const CurrencySelectExample = () => {
-  const [value, setValue] = useState<string | null>(null);
+  const [value, setValue] = useState<Currency | null>(null);
   const bottomSheetRef = useBottomSheetRef();
 
   const selected = CURRENCIES.find((c) => c.value === value);
-  const selectedMeta = selected?.meta as
-    | { ticker: string; icon: string }
-    | undefined;
 
   return (
     <Box>
       <MediaButton
         leadingContent={
-          selectedMeta ? (
+          selected?.meta ? (
             <CryptoIconNative
-              ledgerId={selectedMeta.icon}
-              ticker={selectedMeta.ticker}
+              ledgerId={selected.meta.icon}
+              ticker={selected.meta.ticker}
               size={32}
             />
           ) : undefined
@@ -71,7 +69,7 @@ const CurrencySelectExample = () => {
       >
         <BottomSheetView>
           <BottomSheetHeader title='Select currency' />
-          <OptionList
+          <CurrencyList
             items={CURRENCIES}
             value={value}
             onValueChange={(v) => {
@@ -79,36 +77,45 @@ const CurrencySelectExample = () => {
               bottomSheetRef.current?.dismiss();
             }}
           >
-            <OptionListContent
-              renderItem={(item) => {
-                const meta = item.meta as { ticker: string; icon: string };
-                return (
-                  <OptionListItem value={item.value}>
-                    <OptionListItemLeading>
+            <CurrencyListContent
+              renderItem={({ value, label, meta }) =>
+                meta ? (
+                  <CurrencyListItem value={value}>
+                    <CurrencyListItemLeading>
                       <CryptoIconNative
                         ledgerId={meta.icon}
                         ticker={meta.ticker}
                         size={32}
                       />
-                    </OptionListItemLeading>
-                    <OptionListItemContent>
-                      <OptionListItemText>{item.label}</OptionListItemText>
-                      <OptionListItemDescription>
+                    </CurrencyListItemLeading>
+                    <CurrencyListItemContent>
+                      <CurrencyListItemText>{label}</CurrencyListItemText>
+                      <CurrencyListItemDescription>
                         {meta.ticker}
-                      </OptionListItemDescription>
-                    </OptionListItemContent>
-                  </OptionListItem>
-                );
-              }}
+                      </CurrencyListItemDescription>
+                    </CurrencyListItemContent>
+                  </CurrencyListItem>
+                ) : null
+              }
             />
-          </OptionList>
+          </CurrencyList>
         </BottomSheetView>
       </BottomSheet>
     </Box>
   );
 };
 
-const FOODS: OptionListItemData<string, { group: string }>[] = [
+type Food = 'apple' | 'banana' | 'orange' | 'carrot' | 'broccoli' | 'spinach';
+
+const {
+  OptionList: FoodList,
+  OptionListContent: FoodListContent,
+  OptionListItem: FoodListItem,
+  OptionListItemContent: FoodListItemContent,
+  OptionListItemText: FoodListItemText,
+} = createOptionList<Food>();
+
+const FOODS: OptionListItemData<Food>[] = [
   { value: 'apple', label: 'Apple', group: 'Fruits' },
   { value: 'banana', label: 'Banana', group: 'Fruits' },
   { value: 'orange', label: 'Orange', group: 'Fruits' },
@@ -118,7 +125,7 @@ const FOODS: OptionListItemData<string, { group: string }>[] = [
 ];
 
 const GroupedSelectExample = () => {
-  const [value, setValue] = useState<string | null>(null);
+  const [value, setValue] = useState<Food | null>(null);
   const bottomSheetRef = useBottomSheetRef();
 
   return (
@@ -137,7 +144,7 @@ const GroupedSelectExample = () => {
       >
         <BottomSheetView>
           <BottomSheetHeader title='Pick a food' />
-          <OptionList
+          <FoodList
             items={FOODS}
             value={value}
             onValueChange={(v) => {
@@ -145,30 +152,37 @@ const GroupedSelectExample = () => {
               bottomSheetRef.current?.dismiss();
             }}
           >
-            <OptionListContent
+            <FoodListContent
               renderItem={(item) => (
-                <OptionListItem value={item.value}>
-                  <OptionListItemContent>
-                    <OptionListItemText>{item.label}</OptionListItemText>
-                  </OptionListItemContent>
-                </OptionListItem>
+                <FoodListItem value={item.value}>
+                  <FoodListItemContent>
+                    <FoodListItemText>{item.label}</FoodListItemText>
+                  </FoodListItemContent>
+                </FoodListItem>
               )}
             />
-          </OptionList>
+          </FoodList>
         </BottomSheetView>
       </BottomSheet>
     </Box>
   );
 };
 
-const NETWORKS: OptionListItemData<
-  string,
-  {
-    ticker: string;
-    icon: string;
-    tag: string;
-  }
->[] = [
+type Network = 'ethereum' | 'polygon' | 'arbitrum' | 'optimism';
+type NetworkMeta = { ticker: string; icon: string; tag: string };
+
+const {
+  OptionList: NetworkList,
+  OptionListContent: NetworkListContent,
+  OptionListItem: NetworkListItem,
+  OptionListItemLeading: NetworkListItemLeading,
+  OptionListItemContent: NetworkListItemContent,
+  OptionListItemContentRow: NetworkListItemContentRow,
+  OptionListItemText: NetworkListItemText,
+  OptionListItemDescription: NetworkListItemDescription,
+} = createOptionList<Network, NetworkMeta>();
+
+const NETWORKS: OptionListItemData<Network, NetworkMeta>[] = [
   {
     value: 'ethereum',
     label: 'Ethereum',
@@ -192,7 +206,7 @@ const NETWORKS: OptionListItemData<
 ];
 
 const NetworkSelectExample = () => {
-  const [value, setValue] = useState<string | null>(null);
+  const [value, setValue] = useState<Network | null>(null);
   const bottomSheetRef = useBottomSheetRef();
 
   const selected = NETWORKS.find((n) => n.value === value);
@@ -222,7 +236,7 @@ const NetworkSelectExample = () => {
       >
         <BottomSheetView>
           <BottomSheetHeader title='Select network' />
-          <OptionList
+          <NetworkList
             items={NETWORKS}
             value={value}
             onValueChange={(v) => {
@@ -230,48 +244,62 @@ const NetworkSelectExample = () => {
               bottomSheetRef.current?.dismiss();
             }}
           >
-            <OptionListContent
-              renderItem={(item) => {
-                const meta = item.meta as {
-                  ticker: string;
-                  icon: string;
-                  tag: string;
-                };
-                return (
-                  <OptionListItem value={item.value}>
-                    <OptionListItemLeading>
+            <NetworkListContent
+              renderItem={({ value, label, meta }) =>
+                meta ? (
+                  <NetworkListItem value={value}>
+                    <NetworkListItemLeading>
                       <CryptoIconNative
                         ledgerId={meta.icon}
                         ticker={meta.ticker}
                         size={32}
                       />
-                    </OptionListItemLeading>
-                    <OptionListItemContent>
-                      <OptionListItemContentRow>
-                        <OptionListItemText>{item.label}</OptionListItemText>
+                    </NetworkListItemLeading>
+                    <NetworkListItemContent>
+                      <NetworkListItemContentRow>
+                        <NetworkListItemText>{label}</NetworkListItemText>
                         <Tag label={meta.tag} appearance='gray' size='sm' />
-                      </OptionListItemContentRow>
-                      <OptionListItemDescription>
+                      </NetworkListItemContentRow>
+                      <NetworkListItemDescription>
                         {meta.ticker}
-                      </OptionListItemDescription>
-                    </OptionListItemContent>
-                  </OptionListItem>
-                );
-              }}
+                      </NetworkListItemDescription>
+                    </NetworkListItemContent>
+                  </NetworkListItem>
+                ) : null
+              }
             />
-          </OptionList>
+          </NetworkList>
         </BottomSheetView>
       </BottomSheet>
     </Box>
   );
 };
 
+type SearchableCurrency =
+  | 'btc'
+  | 'eth'
+  | 'sol'
+  | 'ada'
+  | 'dot'
+  | 'matic'
+  | 'xrp'
+  | 'doge';
+
+const {
+  OptionList: SearchableCurrencyList,
+  OptionListContent: SearchableCurrencyListContent,
+  OptionListItem: SearchableCurrencyListItem,
+  OptionListItemLeading: SearchableCurrencyListItemLeading,
+  OptionListItemContent: SearchableCurrencyListItemContent,
+  OptionListItemText: SearchableCurrencyListItemText,
+  OptionListItemDescription: SearchableCurrencyListItemDescription,
+  OptionListSearch: SearchableCurrencyListSearch,
+  OptionListEmptyState: SearchableCurrencyListEmptyState,
+} = createOptionList<SearchableCurrency, CryptoMeta>();
+
 const SEARCHABLE_CURRENCIES: OptionListItemData<
-  string,
-  {
-    ticker: string;
-    icon: string;
-  }
+  SearchableCurrency,
+  CryptoMeta
 >[] = [
   { value: 'btc', label: 'Bitcoin', meta: { ticker: 'BTC', icon: 'bitcoin' } },
   {
@@ -279,16 +307,8 @@ const SEARCHABLE_CURRENCIES: OptionListItemData<
     label: 'Ethereum',
     meta: { ticker: 'ETH', icon: 'ethereum' },
   },
-  {
-    value: 'sol',
-    label: 'Solana',
-    meta: { ticker: 'SOL', icon: 'solana' },
-  },
-  {
-    value: 'ada',
-    label: 'Cardano',
-    meta: { ticker: 'ADA', icon: 'cardano' },
-  },
+  { value: 'sol', label: 'Solana', meta: { ticker: 'SOL', icon: 'solana' } },
+  { value: 'ada', label: 'Cardano', meta: { ticker: 'ADA', icon: 'cardano' } },
   {
     value: 'dot',
     label: 'Polkadot',
@@ -299,11 +319,7 @@ const SEARCHABLE_CURRENCIES: OptionListItemData<
     label: 'Polygon',
     meta: { ticker: 'MATIC', icon: 'polygon' },
   },
-  {
-    value: 'xrp',
-    label: 'XRP',
-    meta: { ticker: 'XRP', icon: 'ripple' },
-  },
+  { value: 'xrp', label: 'XRP', meta: { ticker: 'XRP', icon: 'ripple' } },
   {
     value: 'doge',
     label: 'Dogecoin',
@@ -312,22 +328,19 @@ const SEARCHABLE_CURRENCIES: OptionListItemData<
 ];
 
 const SearchableSelectExample = () => {
-  const [value, setValue] = useState<string | null>(null);
+  const [value, setValue] = useState<SearchableCurrency | null>(null);
   const bottomSheetRef = useBottomSheetRef();
 
   const selected = SEARCHABLE_CURRENCIES.find((c) => c.value === value);
-  const selectedMeta = selected?.meta as
-    | { ticker: string; icon: string }
-    | undefined;
 
   return (
     <Box>
       <MediaButton
         leadingContent={
-          selectedMeta ? (
+          selected?.meta ? (
             <CryptoIconNative
-              ledgerId={selectedMeta.icon}
-              ticker={selectedMeta.ticker}
+              ledgerId={selected.meta.icon}
+              ticker={selected.meta.ticker}
               size={32}
             />
           ) : undefined
@@ -345,7 +358,7 @@ const SearchableSelectExample = () => {
       >
         <BottomSheetView>
           <BottomSheetHeader title='Select currency' />
-          <OptionList
+          <SearchableCurrencyList
             items={SEARCHABLE_CURRENCIES}
             value={value}
             onValueChange={(v) => {
@@ -353,34 +366,35 @@ const SearchableSelectExample = () => {
               bottomSheetRef.current?.dismiss();
             }}
           >
-            <OptionListSearch placeholder='Search currencies' />
-            <OptionListContent
-              renderItem={(item) => {
-                const meta = item.meta as { ticker: string; icon: string };
-                return (
-                  <OptionListItem value={item.value}>
-                    <OptionListItemLeading>
+            <SearchableCurrencyListSearch placeholder='Search currencies' />
+            <SearchableCurrencyListContent
+              renderItem={({ value, label, meta }) =>
+                meta ? (
+                  <SearchableCurrencyListItem value={value}>
+                    <SearchableCurrencyListItemLeading>
                       <CryptoIconNative
                         ledgerId={meta.icon}
                         ticker={meta.ticker}
                         size={32}
                       />
-                    </OptionListItemLeading>
-                    <OptionListItemContent>
-                      <OptionListItemText>{item.label}</OptionListItemText>
-                      <OptionListItemDescription>
+                    </SearchableCurrencyListItemLeading>
+                    <SearchableCurrencyListItemContent>
+                      <SearchableCurrencyListItemText>
+                        {label}
+                      </SearchableCurrencyListItemText>
+                      <SearchableCurrencyListItemDescription>
                         {meta.ticker}
-                      </OptionListItemDescription>
-                    </OptionListItemContent>
-                  </OptionListItem>
-                );
-              }}
+                      </SearchableCurrencyListItemDescription>
+                    </SearchableCurrencyListItemContent>
+                  </SearchableCurrencyListItem>
+                ) : null
+              }
             />
-            <OptionListEmptyState
+            <SearchableCurrencyListEmptyState
               title='No currencies found'
               description='Try a different search term'
             />
-          </OptionList>
+          </SearchableCurrencyList>
         </BottomSheetView>
       </BottomSheet>
     </Box>

--- a/apps/app-sandbox-rnative/src/app/blocks/SegmentedControls.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/SegmentedControls.tsx
@@ -1,20 +1,26 @@
 import {
   Box,
+  createSegmentedControl,
   DotCount,
-  SegmentedControl,
-  SegmentedControlButton,
   Text,
 } from '@ledgerhq/lumen-ui-rnative';
 import { Code, Eye, EyeCross } from '@ledgerhq/lumen-ui-rnative/symbols';
 import { useState } from 'react';
 
+type ViewType = 'preview' | 'raw' | 'blame';
+
+const { SegmentedControl, SegmentedControlButton } =
+  createSegmentedControl<ViewType>();
+
 export const SegmentedControls = () => {
-  const [fitState, setFitState] = useState('preview');
-  const [fixedState, setFixedState] = useState('preview');
-  const [iconsState, setIconsState] = useState('preview');
-  const [trailingState, setTrailingState] = useState('preview');
-  const [preSelectedFitState, setPreSelectedFitState] = useState('blame');
-  const [preSelectedFixedState, setPreSelectedFixedState] = useState('blame');
+  const [fitState, setFitState] = useState<ViewType>('preview');
+  const [fixedState, setFixedState] = useState<ViewType>('preview');
+  const [iconsState, setIconsState] = useState<ViewType>('preview');
+  const [trailingState, setTrailingState] = useState<ViewType>('preview');
+  const [preSelectedFitState, setPreSelectedFitState] =
+    useState<ViewType>('blame');
+  const [preSelectedFixedState, setPreSelectedFixedState] =
+    useState<ViewType>('blame');
 
   return (
     <Box lx={{ gap: 's24', width: 'full' }}>

--- a/apps/app-sandbox-rnative/src/app/blocks/TabBars.tsx
+++ b/apps/app-sandbox-rnative/src/app/blocks/TabBars.tsx
@@ -1,4 +1,4 @@
-import { Box, TabBar, TabBarItem } from '@ledgerhq/lumen-ui-rnative';
+import { Box, createTabBar } from '@ledgerhq/lumen-ui-rnative';
 import {
   Home,
   HomeFill,
@@ -11,8 +11,12 @@ import {
 } from '@ledgerhq/lumen-ui-rnative/symbols';
 import { useState } from 'react';
 
+type Route = 'home' | 'swap' | 'card' | 'help';
+
+const { TabBar, TabBarItem } = createTabBar<Route>();
+
 export function ExampleTabBar() {
-  const [active, setActive] = useState('home');
+  const [active, setActive] = useState<Route>('home');
 
   return (
     <Box

--- a/libs/ui-react/src/lib/Components/Menu/Menu.mdx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.mdx
@@ -267,8 +267,6 @@ function MyComponent() {
 
 The non-radio Menu pieces (`Menu`, `MenuTrigger`, `MenuContent`, `MenuItem`, `MenuCheckboxItem`, ...) carry no value union. Import them as-is alongside the factory output.
 
-<Canvas of={MenuStories.TypedRadioGroup} />
-
 ```tsx
 import {
   createMenuRadioGroup,

--- a/libs/ui-react/src/lib/Components/Menu/Menu.mdx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.mdx
@@ -225,6 +225,8 @@ function MyComponent() {
 
 ### With Radio Items
 
+> **Recommended:** prefer the [type-safe radio group](#type-safe-radio-group) below. It shares one literal union between the group's `value` and each item's `value`.
+
 ```tsx
 import {
   Menu,
@@ -258,6 +260,53 @@ function MyComponent() {
   );
 }
 ```
+
+### Type-safe radio group
+
+`MenuRadioGroup` and `MenuRadioItem` communicate via context, so TypeScript cannot connect the group's `value` to each item's `value` on its own. A typo compiles, and the wrong item (or none) shows the check. `createMenuRadioGroup<T>()` ties them together via one literal union.
+
+The non-radio Menu pieces (`Menu`, `MenuTrigger`, `MenuContent`, `MenuItem`, `MenuCheckboxItem`, ...) carry no value union. Import them as-is alongside the factory output.
+
+<Canvas of={MenuStories.TypedRadioGroup} />
+
+```tsx
+import {
+  createMenuRadioGroup,
+  Menu,
+  MenuTrigger,
+  MenuContent,
+  MenuGroup,
+  MenuLabel,
+} from '@ledgerhq/lumen-ui-react';
+
+type Position = 'top' | 'bottom' | 'left' | 'right';
+
+const PositionMenu = createMenuRadioGroup<Position>();
+
+function Example() {
+  const [position, setPosition] = React.useState<Position>('bottom');
+
+  return (
+    <Menu>
+      <MenuTrigger render={<Button>Position</Button>} />
+      <MenuContent>
+        <MenuGroup>
+          <MenuLabel>Panel Position</MenuLabel>
+          <PositionMenu.MenuRadioGroup value={position} onValueChange={setPosition}>
+            <PositionMenu.MenuRadioItem value='top'>Top</PositionMenu.MenuRadioItem>
+            <PositionMenu.MenuRadioItem value='bottom'>Bottom</PositionMenu.MenuRadioItem>
+            <PositionMenu.MenuRadioItem value='left'>Left</PositionMenu.MenuRadioItem>
+            <PositionMenu.MenuRadioItem value='right'>Right</PositionMenu.MenuRadioItem>
+            {/* <PositionMenu.MenuRadioItem value='wrong' /> ts(2322) */}
+          </PositionMenu.MenuRadioGroup>
+        </MenuGroup>
+      </MenuContent>
+    </Menu>
+  );
+}
+```
+
+Zero runtime cost, as `createMenuRadioGroup` is a type-only wrapper.
 
 ### With Submenus
 

--- a/libs/ui-react/src/lib/Components/Menu/Menu.mdx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.mdx
@@ -295,7 +295,6 @@ function Example() {
             <PositionMenu.MenuRadioItem value='bottom'>Bottom</PositionMenu.MenuRadioItem>
             <PositionMenu.MenuRadioItem value='left'>Left</PositionMenu.MenuRadioItem>
             <PositionMenu.MenuRadioItem value='right'>Right</PositionMenu.MenuRadioItem>
-            {/* <PositionMenu.MenuRadioItem value='wrong' /> ts(2322) */}
           </PositionMenu.MenuRadioGroup>
         </MenuGroup>
       </MenuContent>

--- a/libs/ui-react/src/lib/Components/Menu/Menu.mdx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.mdx
@@ -304,8 +304,6 @@ function Example() {
 }
 ```
 
-Zero runtime cost, as `createMenuRadioGroup` is a type-only wrapper.
-
 ### With Submenus
 
 ```tsx

--- a/libs/ui-react/src/lib/Components/Menu/Menu.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.stories.tsx
@@ -4,6 +4,7 @@ import { MoreVertical } from '../../Symbols/Icons/MoreVertical';
 import { Button } from '../Button/Button';
 import { IconButton } from '../IconButton';
 import {
+  createMenuRadioGroup,
   Menu,
   MenuTrigger,
   MenuContent,
@@ -382,6 +383,49 @@ export const CompleteExample: Story = {
           </MenuSub>
           <MenuSeparator />
           <MenuItem>Log out</MenuItem>
+        </MenuContent>
+      </Menu>
+    );
+  },
+};
+
+type Position = 'top' | 'bottom' | 'left' | 'right';
+const PositionMenu = createMenuRadioGroup<Position>();
+
+export const Typed: Story = {
+  render: () => {
+    const [position, setPosition] = useState<Position>('bottom');
+
+    return (
+      <Menu>
+        <MenuTrigger
+          render={
+            <Button appearance='gray' size='md'>
+              Panel Position
+            </Button>
+          }
+        />
+        <MenuContent className='w-208'>
+          <MenuGroup>
+            <MenuLabel>Panel Position</MenuLabel>
+            <PositionMenu.MenuRadioGroup
+              value={position}
+              onValueChange={setPosition}
+            >
+              <PositionMenu.MenuRadioItem value='top'>
+                Top
+              </PositionMenu.MenuRadioItem>
+              <PositionMenu.MenuRadioItem value='bottom'>
+                Bottom
+              </PositionMenu.MenuRadioItem>
+              <PositionMenu.MenuRadioItem value='left'>
+                Left
+              </PositionMenu.MenuRadioItem>
+              <PositionMenu.MenuRadioItem value='right'>
+                Right
+              </PositionMenu.MenuRadioItem>
+            </PositionMenu.MenuRadioGroup>
+          </MenuGroup>
         </MenuContent>
       </Menu>
     );

--- a/libs/ui-react/src/lib/Components/Menu/Menu.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.stories.tsx
@@ -392,7 +392,7 @@ export const CompleteExample: Story = {
 type Position = 'top' | 'bottom' | 'left' | 'right';
 const PositionMenu = createMenuRadioGroup<Position>();
 
-export const Typed: Story = {
+export const TypesafeFactory: Story = {
   render: () => {
     const [position, setPosition] = useState<Position>('bottom');
 

--- a/libs/ui-react/src/lib/Components/Menu/Menu.test.tsx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.test.tsx
@@ -8,6 +8,7 @@ import {
   MenuCheckboxItem,
   MenuRadioGroup,
   MenuRadioItem,
+  createMenuRadioGroup,
 } from './Menu';
 
 const openMenu = (trigger: HTMLElement) => {
@@ -150,5 +151,34 @@ describe('Menu', () => {
     });
 
     expect(screen.getByText('Disabled Item')).toHaveAttribute('data-disabled');
+  });
+
+  describe('createMenuRadioGroup', () => {
+    it('returns typed radio components that render and select', async () => {
+      const { MenuRadioGroup: TypedGroup, MenuRadioItem: TypedItem } =
+        createMenuRadioGroup<'option1' | 'option2'>();
+      const onValueChange = vi.fn();
+
+      render(
+        <Menu>
+          <MenuTrigger render={<button type='button'>Open Menu</button>} />
+          <MenuContent>
+            <TypedGroup value='option1' onValueChange={onValueChange}>
+              <TypedItem value='option1'>Option 1</TypedItem>
+              <TypedItem value='option2'>Option 2</TypedItem>
+            </TypedGroup>
+          </MenuContent>
+        </Menu>,
+      );
+
+      openMenu(screen.getByRole('button', { name: 'Open Menu' }));
+      await waitFor(() => {
+        expect(screen.getByText('Option 2')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Option 2'));
+
+      expect(onValueChange).toHaveBeenCalledWith('option2');
+    });
   });
 });

--- a/libs/ui-react/src/lib/Components/Menu/Menu.tsx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.tsx
@@ -5,6 +5,7 @@ import {
   useDisabledContext,
 } from '@ledgerhq/lumen-utils-shared';
 import { cva } from 'class-variance-authority';
+import type { ReactElement } from 'react';
 import { Check, ChevronRight } from '../../Symbols';
 import { Divider } from '../Divider';
 import type {
@@ -14,6 +15,7 @@ import type {
   MenuItemProps,
   MenuCheckboxItemProps,
   MenuRadioItemProps,
+  MenuRadioValue,
   MenuLabelProps,
   MenuSeparatorProps,
   MenuSubTriggerProps,
@@ -99,11 +101,14 @@ function MenuSub({ ...props }: MenuSubProps) {
   return <MenuPrimitive.SubmenuRoot {...props} />;
 }
 
-function MenuRadioGroup({ onValueChange, ...props }: MenuRadioGroupProps) {
+function MenuRadioGroup<T extends MenuRadioValue = MenuRadioValue>({
+  onValueChange,
+  ...props
+}: MenuRadioGroupProps<T>) {
   return (
     <MenuPrimitive.RadioGroup
       data-slot='menu-radio-group'
-      onValueChange={(value) => onValueChange?.(String(value))}
+      onValueChange={(value) => onValueChange?.(String(value) as T)}
       {...props}
     />
   );
@@ -241,13 +246,13 @@ const MenuCheckboxItem = ({
   );
 };
 
-const MenuRadioItem = ({
+const MenuRadioItem = <T extends MenuRadioValue = MenuRadioValue>({
   ref,
   className,
   children,
   disabled: disabledProp,
   ...props
-}: MenuRadioItemProps) => {
+}: MenuRadioItemProps<T>) => {
   const disabled = useDisabledContext({
     consumerName: 'MenuRadioItem',
     mergeWith: { disabled: disabledProp },
@@ -301,3 +306,10 @@ export {
   MenuSubTrigger,
   MenuRadioGroup,
 };
+
+export function createMenuRadioGroup<T extends MenuRadioValue = never>(): {
+  MenuRadioGroup: (props: MenuRadioGroupProps<T>) => ReactElement;
+  MenuRadioItem: (props: MenuRadioItemProps<T>) => ReactElement;
+} {
+  return { MenuRadioGroup, MenuRadioItem };
+}

--- a/libs/ui-react/src/lib/Components/Menu/types.ts
+++ b/libs/ui-react/src/lib/Components/Menu/types.ts
@@ -7,6 +7,8 @@ import type {
 
 type MenuRootChangeEventDetails = MenuNamespace.Root.ChangeEventDetails;
 
+export type MenuRadioValue = string;
+
 /**
  * Props for the Menu root component.
  *
@@ -185,13 +187,13 @@ export type MenuCheckboxItemProps = {
  * An item that can be controlled and rendered like a radio button.
  * Must be used within a `MenuRadioGroup`.
  */
-export type MenuRadioItemProps = {
+export type MenuRadioItemProps<T extends MenuRadioValue = MenuRadioValue> = {
   /**
    * The unique value of the item.
    *
    * @required
    */
-  value: string;
+  value: T;
 } & MenuItemProps;
 
 /**
@@ -231,19 +233,19 @@ export type MenuGroupProps = ComponentPropsWithoutRef<'div'>;
  *
  * Used to group multiple radio items together.
  */
-export type MenuRadioGroupProps = {
+export type MenuRadioGroupProps<T extends MenuRadioValue = MenuRadioValue> = {
   /**
    * The controlled value of the radio item to check.
    * Should be used in conjunction with `onValueChange`.
    */
-  value?: string;
+  value?: T;
 
   /**
    * Event handler called when the value changes.
    *
    * @param value - The value of the radio item that was selected
    */
-  onValueChange?: (value: string) => void;
+  onValueChange?: (value: T) => void;
 } & ComponentPropsWithoutRef<'div'>;
 
 /**

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.mdx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.mdx
@@ -92,8 +92,6 @@ export default function Example() {
 
 `createSegmentedControl<T>()` ties both components to one literal union. Call it once at module scope; the returned pair are typed against your `T`.
 
-<Canvas of={SegmentedControlStories.Typed} />
-
 ```tsx
 import { createSegmentedControl } from '@ledgerhq/lumen-ui-react';
 

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.mdx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.mdx
@@ -86,6 +86,37 @@ export default function Example() {
 }
 ```
 
+## Type-safe variant
+
+`SegmentedControl` and `SegmentedControlButton` communicate via context, so TypeScript cannot connect the root's `selectedValue` to each button's `value` on its own. A typo in `value` compiles, and the pill silently never moves to that segment.
+
+`createSegmentedControl<T>()` ties both components to one literal union. Call it once at module scope; the returned pair are typed against your `T`.
+
+<Canvas of={SegmentedControlStories.Typed} />
+
+```tsx
+import { createSegmentedControl } from '@ledgerhq/lumen-ui-react';
+
+type View = 'preview' | 'raw' | 'blame';
+
+const { SegmentedControl, SegmentedControlButton } = createSegmentedControl<View>();
+
+function Example() {
+  const [view, setView] = React.useState<View>('preview');
+
+  return (
+    <SegmentedControl selectedValue={view} onSelectedChange={setView}>
+      <SegmentedControlButton value='preview'>Preview</SegmentedControlButton>
+      <SegmentedControlButton value='raw'>Raw</SegmentedControlButton>
+      <SegmentedControlButton value='blame'>Blame</SegmentedControlButton>
+      {/* <SegmentedControlButton value='wrong' /> ts(2322) */}
+    </SegmentedControl>
+  );
+}
+```
+
+Zero runtime cost, as `createSegmentedControl` is a type-only wrapper.
+
 ## With trailing content
 
 Pass any node via `trailingContent` to render it to the right of the label. Use it for badges like `DotCount` to surface counts per segment.

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.mdx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.mdx
@@ -113,8 +113,6 @@ function Example() {
 }
 ```
 
-Zero runtime cost, as `createSegmentedControl` is a type-only wrapper.
-
 ## With trailing content
 
 Pass any node via `trailingContent` to render it to the right of the label. Use it for badges like `DotCount` to surface counts per segment.

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.mdx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.mdx
@@ -107,7 +107,6 @@ function Example() {
       <SegmentedControlButton value='preview'>Preview</SegmentedControlButton>
       <SegmentedControlButton value='raw'>Raw</SegmentedControlButton>
       <SegmentedControlButton value='blame'>Blame</SegmentedControlButton>
-      {/* <SegmentedControlButton value='wrong' /> ts(2322) */}
     </SegmentedControl>
   );
 }

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
@@ -2,7 +2,11 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { Coins, TransferHorizontal, Nft } from '../../Symbols';
 import { DotCount } from '../DotCount';
-import { SegmentedControl, SegmentedControlButton } from './SegmentedControl';
+import {
+  createSegmentedControl,
+  SegmentedControl,
+  SegmentedControlButton,
+} from './SegmentedControl';
 
 const meta = {
   title: 'Navigation/SegmentedControl',
@@ -161,6 +165,34 @@ export const WithTrailingContent: Story = {
         </SegmentedControlButton>
         <SegmentedControlButton value='trade'>Trade</SegmentedControlButton>
       </SegmentedControl>
+    );
+  },
+};
+
+type View = 'preview' | 'raw' | 'blame';
+const TypedSegmentedControl = createSegmentedControl<View>();
+
+export const Typed: Story = {
+  args: {} as React.ComponentProps<typeof SegmentedControl>,
+  render: (args) => {
+    const [view, setView] = useState<View>('preview');
+
+    return (
+      <TypedSegmentedControl.SegmentedControl
+        {...args}
+        selectedValue={view}
+        onSelectedChange={setView}
+      >
+        <TypedSegmentedControl.SegmentedControlButton value='preview'>
+          Preview
+        </TypedSegmentedControl.SegmentedControlButton>
+        <TypedSegmentedControl.SegmentedControlButton value='raw'>
+          Raw
+        </TypedSegmentedControl.SegmentedControlButton>
+        <TypedSegmentedControl.SegmentedControlButton value='blame'>
+          Blame
+        </TypedSegmentedControl.SegmentedControlButton>
+      </TypedSegmentedControl.SegmentedControl>
     );
   },
 };

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
@@ -172,7 +172,7 @@ export const WithTrailingContent: Story = {
 type View = 'preview' | 'raw' | 'blame';
 const TypedSegmentedControl = createSegmentedControl<View>();
 
-export const Typed: Story = {
+export const TypesafeFactory: Story = {
   args: {} as React.ComponentProps<typeof SegmentedControl>,
   render: (args) => {
     const [view, setView] = useState<View>('preview');

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.test.tsx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.test.tsx
@@ -3,7 +3,11 @@ import { describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
 
 import { DotCount } from '../DotCount';
-import { SegmentedControl, SegmentedControlButton } from './SegmentedControl';
+import {
+  SegmentedControl,
+  SegmentedControlButton,
+  createSegmentedControl,
+} from './SegmentedControl';
 
 describe('SegmentedControl', () => {
   it('renders segments with labels', () => {
@@ -61,5 +65,30 @@ describe('SegmentedControl', () => {
     );
 
     expect(screen.getByLabelText('3 tokens')).toBeTruthy();
+  });
+
+  describe('createSegmentedControl', () => {
+    it('returns typed components that render and select like the originals', () => {
+      const {
+        SegmentedControl: TypedControl,
+        SegmentedControlButton: TypedButton,
+      } = createSegmentedControl<'send' | 'receive'>();
+      const onSelectedChange = vi.fn();
+
+      render(
+        <TypedControl
+          selectedValue='send'
+          onSelectedChange={onSelectedChange}
+          aria-label='Transaction type'
+        >
+          <TypedButton value='send'>Send</TypedButton>
+          <TypedButton value='receive'>Receive</TypedButton>
+        </TypedControl>,
+      );
+
+      fireEvent.click(screen.getByText('Receive'));
+
+      expect(onSelectedChange).toHaveBeenCalledWith('receive');
+    });
   });
 });

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.tsx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.tsx
@@ -1,5 +1,6 @@
 import { cn, useDisabledContext } from '@ledgerhq/lumen-utils-shared';
 import { cva } from 'class-variance-authority';
+import type { ReactElement } from 'react';
 import { useRef } from 'react';
 import {
   SegmentedControlContextProvider,
@@ -8,6 +9,7 @@ import {
 import type {
   SegmentedControlButtonProps,
   SegmentedControlProps,
+  SegmentedControlValue,
 } from './types';
 import {
   usePillElementLayoutEffect,
@@ -64,7 +66,9 @@ const segmentedControlStyles = {
   ),
 };
 
-export function SegmentedControlButton({
+export function SegmentedControlButton<
+  T extends SegmentedControlValue = SegmentedControlValue,
+>({
   value,
   children,
   icon: Icon,
@@ -72,7 +76,7 @@ export function SegmentedControlButton({
   onClick,
   className,
   ...props
-}: SegmentedControlButtonProps) {
+}: SegmentedControlButtonProps<T>) {
   const { selectedValue, onSelectedChange, disabled, tabLayout } =
     useSegmentedControlContext();
   const selected = selectedValue === value;
@@ -106,7 +110,9 @@ export function SegmentedControlButton({
   );
 }
 
-export function SegmentedControl({
+export function SegmentedControl<
+  T extends SegmentedControlValue = SegmentedControlValue,
+>({
   selectedValue,
   onSelectedChange,
   children,
@@ -115,7 +121,7 @@ export function SegmentedControl({
   appearance = 'background',
   tabLayout = 'fixed',
   ...props
-}: SegmentedControlProps) {
+}: SegmentedControlProps<T>) {
   const disabled = useDisabledContext({
     consumerName: 'SegmentedControl',
     mergeWith: { disabled: disabledProp },
@@ -134,7 +140,12 @@ export function SegmentedControl({
 
   return (
     <SegmentedControlContextProvider
-      value={{ selectedValue, onSelectedChange, disabled, tabLayout }}
+      value={{
+        selectedValue,
+        onSelectedChange: onSelectedChange as (value: string) => void,
+        disabled,
+        tabLayout,
+      }}
     >
       <div
         {...props}
@@ -162,4 +173,15 @@ export function SegmentedControl({
       </div>
     </SegmentedControlContextProvider>
   );
+}
+
+export function createSegmentedControl<
+  T extends SegmentedControlValue = never,
+>(): {
+  SegmentedControl: (props: SegmentedControlProps<T>) => ReactElement;
+  SegmentedControlButton: (
+    props: SegmentedControlButtonProps<T>,
+  ) => ReactElement;
+} {
+  return { SegmentedControl, SegmentedControlButton };
 }

--- a/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.tsx
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/SegmentedControl.tsx
@@ -142,7 +142,7 @@ export function SegmentedControl<
     <SegmentedControlContextProvider
       value={{
         selectedValue,
-        onSelectedChange: onSelectedChange as (value: string) => void,
+        onSelectedChange: (value) => onSelectedChange(value as T),
         disabled,
         tabLayout,
       }}

--- a/libs/ui-react/src/lib/Components/SegmentedControl/types.ts
+++ b/libs/ui-react/src/lib/Components/SegmentedControl/types.ts
@@ -1,15 +1,19 @@
 import type { ComponentType, ReactNode, ComponentPropsWithoutRef } from 'react';
 import type { IconSize } from '../Icon/types';
 
-export type SegmentedControlProps = {
+export type SegmentedControlValue = string;
+
+export type SegmentedControlProps<
+  T extends SegmentedControlValue = SegmentedControlValue,
+> = {
   /**
    * The value of the currently selected segment (drives the sliding pill).
    */
-  selectedValue: string;
+  selectedValue: T;
   /**
    * Callback when the selected segment value changes.
    */
-  onSelectedChange: (value: string) => void;
+  onSelectedChange: (value: T) => void;
   /**
    * When true, the entire control is disabled (no interaction, selected uses muted styling).
    */
@@ -37,11 +41,13 @@ type IconComponent = ComponentType<{
   className?: string;
 }>;
 
-export type SegmentedControlButtonProps = {
+export type SegmentedControlButtonProps<
+  T extends SegmentedControlValue = SegmentedControlValue,
+> = {
   /**
    * Value for this segment (must be unique among siblings).
    */
-  value: string;
+  value: T;
   /**
    * Button label.
    */

--- a/libs/ui-react/src/lib/Components/Select/Select.mdx
+++ b/libs/ui-react/src/lib/Components/Select/Select.mdx
@@ -149,6 +149,8 @@ The `@base-ui/react` dependency provides accessible, unstyled select functionali
 
 > **Content width:** `SelectContent` has a minimum width equal to the trigger width (`min-w-[trigger-width]`). The dropdown will grow wider if items need more space but will never be narrower than the trigger.
 
+> **Recommended:** prefer the [type-safe variant](#type-safe-variant) below. It ties `value`, `items[].value`, `SelectItem.value`, and `SelectTrigger.render({ selectedValue })` to the same literal union, and propagates your `TMeta` shape into `renderItem(item)` without casts.
+
 ```tsx
 import {
   Select,
@@ -184,6 +186,57 @@ function MyComponent() {
   );
 }
 ```
+
+## Type-safe variant
+
+`Select` and its subcomponents communicate via context, so TypeScript cannot connect `value` / `items[].value` / `SelectItem.value` on its own. A typo in any of them compiles. `createSelect<T, TMeta>()` ties them together via one literal union (`T`) and an optional meta shape (`TMeta`) that flows into `renderItem(item)`.
+
+<Canvas of={SelectStories.Typed} />
+
+```tsx
+import { createSelect } from '@ledgerhq/lumen-ui-react';
+import type { SelectItemData } from '@ledgerhq/lumen-ui-react';
+
+type Network = 'eth' | 'sol' | 'btc';
+
+const NetworkSelect = createSelect<Network>();
+
+const NETWORKS: SelectItemData<Network>[] = [
+  { value: 'eth', label: 'Ethereum' },
+  { value: 'sol', label: 'Solana' },
+  { value: 'btc', label: 'Bitcoin' },
+];
+
+function Example() {
+  const [network, setNetwork] = React.useState<Network | null>('eth');
+
+  return (
+    <NetworkSelect.Select items={NETWORKS} value={network} onValueChange={setNetwork}>
+      <NetworkSelect.SelectTrigger label='Network' />
+      <NetworkSelect.SelectContent>
+        <NetworkSelect.SelectList
+          renderItem={(item) => (
+            <NetworkSelect.SelectItem key={item.value} value={item.value}>
+              <NetworkSelect.SelectItemText>{item.label}</NetworkSelect.SelectItemText>
+            </NetworkSelect.SelectItem>
+          )}
+        />
+      </NetworkSelect.SelectContent>
+    </NetworkSelect.Select>
+  );
+}
+```
+
+To carry extra fields on each item (icons, tickers, IDs…), pass a `TMeta`:
+
+```tsx
+type CryptoMeta = { ticker: string };
+const NetworkSelect = createSelect<Network, CryptoMeta>();
+
+// items[].meta is now typed as CryptoMeta, and so is renderItem(item).meta
+```
+
+Zero runtime cost, as `createSelect` is a type-only wrapper.
 
 ### With Descriptions
 

--- a/libs/ui-react/src/lib/Components/Select/Select.mdx
+++ b/libs/ui-react/src/lib/Components/Select/Select.mdx
@@ -191,8 +191,6 @@ function MyComponent() {
 
 `Select` and its subcomponents communicate via context, so TypeScript cannot connect `value` / `items[].value` / `SelectItem.value` on its own. A typo in any of them compiles. `createSelect<T, TMeta>()` ties them together via one literal union (`T`) and an optional meta shape (`TMeta`) that flows into `renderItem(item)`.
 
-<Canvas of={SelectStories.Typed} />
-
 ```tsx
 import { createSelect } from '@ledgerhq/lumen-ui-react';
 import type { SelectItemData } from '@ledgerhq/lumen-ui-react';

--- a/libs/ui-react/src/lib/Components/Select/Select.mdx
+++ b/libs/ui-react/src/lib/Components/Select/Select.mdx
@@ -234,8 +234,6 @@ const NetworkSelect = createSelect<Network, CryptoMeta>();
 // items[].meta is now typed as CryptoMeta, and so is renderItem(item).meta
 ```
 
-Zero runtime cost, as `createSelect` is a type-only wrapper.
-
 ### With Descriptions
 
 You can add descriptions or additional content to select items by including extra elements alongside `SelectItemText`:

--- a/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
@@ -6,6 +6,7 @@ import { Settings } from '../../Symbols';
 import { Button } from '../Button';
 import { MediaButton } from '../MediaButton';
 import {
+  createSelect,
   Select,
   SelectTrigger,
   SelectContent,
@@ -871,6 +872,44 @@ export const ControlledSearch: Story = {
             />
           </SelectContent>
         </Select>
+      </div>
+    );
+  },
+};
+
+type Network = 'eth' | 'sol' | 'btc';
+const NetworkSelect = createSelect<Network>();
+
+const NETWORKS: SelectItemData<Network>[] = [
+  { value: 'eth', label: 'Ethereum' },
+  { value: 'sol', label: 'Solana' },
+  { value: 'btc', label: 'Bitcoin' },
+];
+
+export const Typed: StoryObj<typeof Select> = {
+  render: () => {
+    const [network, setNetwork] = useState<Network | null>('eth');
+
+    return (
+      <div className='w-320'>
+        <NetworkSelect.Select
+          items={NETWORKS}
+          value={network}
+          onValueChange={setNetwork}
+        >
+          <NetworkSelect.SelectTrigger label='Network' />
+          <NetworkSelect.SelectContent>
+            <NetworkSelect.SelectList
+              renderItem={(item) => (
+                <NetworkSelect.SelectItem key={item.value} value={item.value}>
+                  <NetworkSelect.SelectItemText>
+                    {item.label}
+                  </NetworkSelect.SelectItemText>
+                </NetworkSelect.SelectItem>
+              )}
+            />
+          </NetworkSelect.SelectContent>
+        </NetworkSelect.Select>
       </div>
     );
   },

--- a/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
@@ -886,7 +886,7 @@ const NETWORKS: SelectItemData<Network>[] = [
   { value: 'btc', label: 'Bitcoin' },
 ];
 
-export const Typed: StoryObj<typeof Select> = {
+export const TypesafeFactory: StoryObj<typeof Select> = {
   render: () => {
     const [network, setNetwork] = useState<Network | null>('eth');
 

--- a/libs/ui-react/src/lib/Components/Select/Select.test.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.test.tsx
@@ -11,7 +11,9 @@ import {
   SelectList,
   SelectSearch,
   SelectTrigger,
+  createSelect,
 } from './Select';
+import type { SelectItemData } from './types';
 
 const options = [
   { value: 'opt1', label: 'Option 1' },
@@ -596,5 +598,45 @@ describe('Disabled items', () => {
     fireEvent.click(screen.getByText('Option 3'));
 
     expect(handleChange).toHaveBeenCalledWith('opt3');
+  });
+
+  describe('createSelect', () => {
+    it('returns typed components that render and select', () => {
+      type Opt = 'opt1' | 'opt2' | 'opt3';
+      const typedOptions: SelectItemData<Opt>[] = [
+        { value: 'opt1', label: 'Option 1' },
+        { value: 'opt2', label: 'Option 2' },
+        { value: 'opt3', label: 'Option 3' },
+      ];
+      const {
+        Select: TypedSelect,
+        SelectTrigger: TypedTrigger,
+        SelectContent: TypedContent,
+        SelectList: TypedList,
+        SelectItem: TypedItem,
+        SelectItemText: TypedItemText,
+      } = createSelect<Opt>();
+      const handleChange = vi.fn();
+
+      render(
+        <TypedSelect items={typedOptions} onValueChange={handleChange}>
+          <TypedTrigger label='Choose an option' />
+          <TypedContent>
+            <TypedList
+              renderItem={(item) => (
+                <TypedItem key={item.value} value={item.value}>
+                  <TypedItemText>{item.label}</TypedItemText>
+                </TypedItem>
+              )}
+            />
+          </TypedContent>
+        </TypedSelect>,
+      );
+
+      fireEvent.click(screen.getByRole('combobox'));
+      fireEvent.click(screen.getByText('Option 3'));
+
+      expect(handleChange).toHaveBeenCalledWith('opt3');
+    });
   });
 });

--- a/libs/ui-react/src/lib/Components/Select/Select.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.tsx
@@ -1,6 +1,7 @@
 import { Combobox } from '@base-ui/react/combobox';
 import { cn, useDisabledContext } from '@ledgerhq/lumen-utils-shared';
 import { cva } from 'class-variance-authority';
+import type { ReactElement } from 'react';
 import { useLayoutEffect } from 'react';
 import { useControllableState } from '../../../utils/useControllableState';
 import { ChevronDown, Check } from '../../Symbols';
@@ -22,11 +23,15 @@ import type {
   SelectItemDescriptionProps,
   SelectSeparatorProps,
   SelectEmptyStateProps,
+  SelectValue,
 } from './types';
 import { useSelectItems } from './useSelectItems';
 import { resolveValue } from './utils';
 
-function Select<TMeta extends MetaShape = MetaShape>({
+function Select<
+  T extends SelectValue = SelectValue,
+  TMeta extends MetaShape = MetaShape,
+>({
   value,
   defaultValue,
   onValueChange,
@@ -43,7 +48,7 @@ function Select<TMeta extends MetaShape = MetaShape>({
   name,
   required,
   children,
-}: Readonly<SelectProps<TMeta>>) {
+}: Readonly<SelectProps<T, TMeta>>) {
   const disabled = useDisabledContext({
     consumerName: 'Select',
     mergeWith: { disabled: disabledProp },
@@ -54,7 +59,7 @@ function Select<TMeta extends MetaShape = MetaShape>({
       prop: value,
       defaultProp: defaultValue ?? null,
       onChange: (next) => {
-        onValueChange?.(next);
+        onValueChange?.(next as T | null);
       },
     },
   );
@@ -67,7 +72,7 @@ function Select<TMeta extends MetaShape = MetaShape>({
     searchMounted,
     registerSearch,
     handleSearchValueChange,
-  } = useSelectItems({
+  } = useSelectItems<T, TMeta>({
     items,
     filter,
     filteredItems,
@@ -162,7 +167,11 @@ const SelectInputTrigger = ({
   );
 };
 
-const SelectTrigger = ({ render, disabled, ...props }: SelectTriggerProps) => {
+const SelectTrigger = <T extends SelectValue = SelectValue>({
+  render,
+  disabled,
+  ...props
+}: SelectTriggerProps<T>) => {
   const { selectedValue } = useSelectContext({
     consumerName: 'SelectTrigger',
     contextRequired: true,
@@ -175,7 +184,10 @@ const SelectTrigger = ({ render, disabled, ...props }: SelectTriggerProps) => {
         disabled={disabled}
         ref={props.ref}
         data-slot='select-trigger'
-        render={render({ selectedValue, selectedContent })}
+        render={render({
+          selectedValue: selectedValue as T | null,
+          selectedContent,
+        })}
       />
     );
   }
@@ -244,12 +256,15 @@ const SelectContent = ({
   </Combobox.Portal>
 );
 
-const SelectList = <TMeta extends MetaShape = MetaShape>({
+const SelectList = <
+  T extends SelectValue = SelectValue,
+  TMeta extends MetaShape = MetaShape,
+>({
   ref,
   className,
   renderItem,
   ...props
-}: SelectListProps<TMeta>) => {
+}: SelectListProps<T, TMeta>) => {
   const { isGrouped } = useSelectContext({
     consumerName: 'SelectList',
     contextRequired: true,
@@ -266,7 +281,7 @@ const SelectList = <TMeta extends MetaShape = MetaShape>({
       {...props}
     >
       {isGrouped
-        ? (group: SelectItemGroup<TMeta>, groupIndex: number) => (
+        ? (group: SelectItemGroup<T, TMeta>, groupIndex: number) => (
             <Combobox.Group
               key={group.label}
               items={group.items}
@@ -301,12 +316,12 @@ const itemStyles = cn(
   'data-disabled:cursor-not-allowed data-disabled:text-disabled',
 );
 
-const SelectItem = ({
+const SelectItem = <T extends SelectValue = SelectValue>({
   ref,
   className,
   children,
   ...props
-}: SelectItemProps) => (
+}: SelectItemProps<T>) => (
   <Combobox.Item
     ref={ref}
     data-slot='select-item'
@@ -445,3 +460,34 @@ export {
   SelectSeparator,
   SelectEmptyState,
 };
+
+export function createSelect<
+  T extends SelectValue = never,
+  TMeta extends MetaShape = MetaShape,
+>(): {
+  Select: (props: Readonly<SelectProps<T, TMeta>>) => ReactElement;
+  SelectTrigger: (props: SelectTriggerProps<T>) => ReactElement;
+  SelectContent: (props: SelectContentProps) => ReactElement;
+  SelectSearch: (props: SelectSearchProps) => ReactElement;
+  SelectList: (props: SelectListProps<T, TMeta>) => ReactElement;
+  SelectItemText: (props: SelectItemTextProps) => ReactElement;
+  SelectItemContent: (props: SelectItemContentProps) => ReactElement;
+  SelectItemDescription: (props: SelectItemDescriptionProps) => ReactElement;
+  SelectItem: (props: SelectItemProps<T>) => ReactElement;
+  SelectSeparator: (props: SelectSeparatorProps) => ReactElement;
+  SelectEmptyState: (props: SelectEmptyStateProps) => ReactElement;
+} {
+  return {
+    Select,
+    SelectTrigger,
+    SelectContent,
+    SelectSearch,
+    SelectList,
+    SelectItemText,
+    SelectItemContent,
+    SelectItemDescription,
+    SelectItem,
+    SelectSeparator,
+    SelectEmptyState,
+  };
+}

--- a/libs/ui-react/src/lib/Components/Select/index.ts
+++ b/libs/ui-react/src/lib/Components/Select/index.ts
@@ -1,6 +1,7 @@
 export * from './Select';
 export type {
   MetaShape,
+  SelectValue,
   SelectItemData,
   SelectProps,
   SelectTriggerProps,

--- a/libs/ui-react/src/lib/Components/Select/types.ts
+++ b/libs/ui-react/src/lib/Components/Select/types.ts
@@ -8,9 +8,14 @@ import type { SearchInputProps } from '../SearchInput/types';
 
 export type MetaShape = Record<string, unknown>;
 
-export type SelectItemData<TMeta extends MetaShape = MetaShape> = {
+export type SelectValue = string;
+
+export type SelectItemData<
+  T extends SelectValue = SelectValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
   /** Unique string identifier for this item, used for selection tracking. */
-  value: string;
+  value: T;
   /** Display text used in the trigger. Also the field matched against by the default search filter. */
   label: string;
   /** When true, the item cannot be selected or focused. */
@@ -35,25 +40,31 @@ export type SelectItemData<TMeta extends MetaShape = MetaShape> = {
 };
 
 /** @internal A named group of select items, used to represent a resolved group with its header label and child items. */
-export type SelectItemGroup<TMeta extends MetaShape = MetaShape> = {
+export type SelectItemGroup<
+  T extends SelectValue = SelectValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
   /** The displayed group name, matching the `group` field on each child item. */
   label: string;
   /** The items belonging to this group. */
-  items: SelectItemData<TMeta>[];
+  items: SelectItemData<T, TMeta>[];
 };
 
-export type SelectTriggerRenderProps = {
+export type SelectTriggerRenderProps<T extends SelectValue = SelectValue> = {
   /**
    * The currently selected value, or null if nothing is selected.
    */
-  selectedValue: string | null;
+  selectedValue: T | null;
   /**
    * A ReactNode that renders the selected item's content via `Combobox.Value`.
    */
   selectedContent: ReactNode;
 };
 
-export type SelectProps<TMeta extends MetaShape = MetaShape> = {
+export type SelectProps<
+  T extends SelectValue = SelectValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
   /**
    * The children of the select.
    */
@@ -69,7 +80,7 @@ export type SelectProps<TMeta extends MetaShape = MetaShape> = {
    * them by that value, rendering group headers, separators, and per-group
    * collection iteration internally.
    */
-  items: SelectItemData<TMeta>[];
+  items: SelectItemData<T, TMeta>[];
   /**
    * Filter function used to match items against a search query.
    * When `SelectSearch` is rendered inside the content, a default case-insensitive
@@ -80,13 +91,13 @@ export type SelectProps<TMeta extends MetaShape = MetaShape> = {
    * items within each group. Empty groups are automatically hidden.
    * @default undefined
    */
-  filter?: null | ((item: SelectItemData<TMeta>, query: string) => boolean);
+  filter?: null | ((item: SelectItemData<T, TMeta>, query: string) => boolean);
   /**
    * Pre-filtered items to display in the list. When provided, the component uses
    * these items directly instead of filtering `items` internally. Use alongside
    * `onSearchValueChange` for async/remote search where the server handles filtering.
    */
-  filteredItems?: SelectItemData<TMeta>[];
+  filteredItems?: SelectItemData<T, TMeta>[];
   /**
    * The controlled search input value.
    * Should be used in conjunction with `onSearchValueChange`.
@@ -116,7 +127,7 @@ export type SelectProps<TMeta extends MetaShape = MetaShape> = {
   /**
    * The value of the select when initially rendered (uncontrolled).
    */
-  defaultValue?: string;
+  defaultValue?: T;
   /**
    * Event handler called when the open state of the popup changes.
    */
@@ -125,12 +136,12 @@ export type SelectProps<TMeta extends MetaShape = MetaShape> = {
    * The controlled value of the select.
    * Should be used in conjunction with `onValueChange`.
    */
-  value?: string | null;
+  value?: T | null;
   /**
    * Event handler called when the selected value changes.
    * Receives `null` when the selection is cleared (e.g. combobox clear behavior).
    */
-  onValueChange?: (value: string | null) => void;
+  onValueChange?: (value: T | null) => void;
   /**
    * The name of the select for form submission.
    */
@@ -146,7 +157,7 @@ export type SelectProps<TMeta extends MetaShape = MetaShape> = {
   required?: boolean;
 };
 
-export type SelectTriggerProps = {
+export type SelectTriggerProps<T extends SelectValue = SelectValue> = {
   /**
    * Render function that replaces the default input-style trigger.
    * When provided, the trigger delegates rendering to this function.
@@ -155,7 +166,7 @@ export type SelectTriggerProps = {
    * @example render={({ selectedValue, selectedContent }) => <MediaButton>{selectedValue ? selectedContent : 'Label'}</MediaButton>}
    * @example render={({ selectedValue, selectedContent }) => <MyTrigger />}
    */
-  render?: (props: SelectTriggerRenderProps) => ReactElement;
+  render?: (props: SelectTriggerRenderProps<T>) => ReactElement;
   /**
    * Extra class names to apply to the trigger element.
    */
@@ -206,7 +217,10 @@ export type SelectContentProps = {
   initialFocus?: boolean | RefObject<HTMLElement | null>;
 } & ComponentPropsWithRef<'div'>;
 
-export type SelectListProps<TMeta extends MetaShape = MetaShape> = {
+export type SelectListProps<
+  T extends SelectValue = SelectValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
   /**
    * A render function that receives each item and its index, returning a ReactNode.
    *
@@ -215,7 +229,7 @@ export type SelectListProps<TMeta extends MetaShape = MetaShape> = {
    * is handled automatically by `SelectList`.
    * @example renderItem={(item) => <SelectItem value={item.value}>{item.label}</SelectItem>}
    */
-  renderItem: (item: SelectItemData<TMeta>, index: number) => ReactNode;
+  renderItem: (item: SelectItemData<T, TMeta>, index: number) => ReactNode;
   /**
    * Extra class names to apply to the list element.
    */
@@ -244,11 +258,11 @@ export type SelectItemTextProps = {
   className?: string;
 } & ComponentPropsWithRef<'span'>;
 
-export type SelectItemProps = {
+export type SelectItemProps<T extends SelectValue = SelectValue> = {
   /**
    * The unique string value associated with this item.
    */
-  value: string;
+  value: T;
   /**
    * The children of the select item. Supports custom content
    * (icons, tags, descriptions, etc.) alongside `SelectItemText`.

--- a/libs/ui-react/src/lib/Components/Select/useSelectItems/useSelectItems.ts
+++ b/libs/ui-react/src/lib/Components/Select/useSelectItems/useSelectItems.ts
@@ -1,21 +1,34 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useControllableState } from '../../../../utils/useControllableState';
-import type { MetaShape, SelectItemData, SelectItemGroup } from '../types';
+import type {
+  MetaShape,
+  SelectItemData,
+  SelectItemGroup,
+  SelectValue,
+} from '../types';
 import { defaultLabelFilter, groupItemsByKey } from '../utils';
 
-type UseSelectItemsParams<TMeta extends MetaShape = MetaShape> = {
-  items: SelectItemData<TMeta>[];
-  filter?: null | ((item: SelectItemData<TMeta>, query: string) => boolean);
-  filteredItems?: SelectItemData<TMeta>[];
+type UseSelectItemsParams<
+  T extends SelectValue = SelectValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
+  items: SelectItemData<T, TMeta>[];
+  filter?: null | ((item: SelectItemData<T, TMeta>, query: string) => boolean);
+  filteredItems?: SelectItemData<T, TMeta>[];
   searchValue?: string;
   defaultSearchValue?: string;
   onSearchValueChange?: (value: string) => void;
 };
 
-type UseSelectItemsReturn<TMeta extends MetaShape = MetaShape> = {
+type UseSelectItemsReturn<
+  T extends SelectValue = SelectValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
   isGrouped: boolean;
-  groupedItems: SelectItemGroup<TMeta>[] | null;
-  filteredItemsForRoot: SelectItemData<TMeta>[] | SelectItemGroup<TMeta>[];
+  groupedItems: SelectItemGroup<T, TMeta>[] | null;
+  filteredItemsForRoot:
+    | SelectItemData<T, TMeta>[]
+    | SelectItemGroup<T, TMeta>[];
   resolvedSearchValue: string;
   searchMounted: boolean;
   registerSearch: () => () => void;
@@ -32,14 +45,17 @@ type UseSelectItemsReturn<TMeta extends MetaShape = MetaShape> = {
  *   the internal filter entirely.
  * - Supports controlled and uncontrolled `searchValue` via `useControllableState`.
  */
-export function useSelectItems<TMeta extends MetaShape = MetaShape>({
+export function useSelectItems<
+  T extends SelectValue = SelectValue,
+  TMeta extends MetaShape = MetaShape,
+>({
   items,
   filter,
   filteredItems: filteredItemsProp,
   searchValue: searchValueProp,
   defaultSearchValue,
   onSearchValueChange: onSearchValueChangeProp,
-}: UseSelectItemsParams<TMeta>): UseSelectItemsReturn<TMeta> {
+}: UseSelectItemsParams<T, TMeta>): UseSelectItemsReturn<T, TMeta> {
   const [searchMounted, setSearchMounted] = useState(false);
   const [searchValue, setSearchValue] = useControllableState<string>({
     prop: searchValueProp,
@@ -76,8 +92,8 @@ export function useSelectItems<TMeta extends MetaShape = MetaShape>({
   );
 
   const internalFilteredItems = useMemo(():
-    | SelectItemData<TMeta>[]
-    | SelectItemGroup<TMeta>[] => {
+    | SelectItemData<T, TMeta>[]
+    | SelectItemGroup<T, TMeta>[] => {
     if (!filterFn || !searchValue.trim()) return groupedItems ?? items;
 
     if (groupedItems) {
@@ -93,8 +109,8 @@ export function useSelectItems<TMeta extends MetaShape = MetaShape>({
   }, [groupedItems, items, searchValue, filterFn]);
 
   const externalGroupedItems = useMemo(():
-    | SelectItemData<TMeta>[]
-    | SelectItemGroup<TMeta>[]
+    | SelectItemData<T, TMeta>[]
+    | SelectItemGroup<T, TMeta>[]
     | null => {
     if (!filteredItemsProp) return null;
     return isGrouped ? groupItemsByKey(filteredItemsProp) : filteredItemsProp;

--- a/libs/ui-react/src/lib/Components/Select/utils/groupItems.ts
+++ b/libs/ui-react/src/lib/Components/Select/utils/groupItems.ts
@@ -1,4 +1,9 @@
-import type { MetaShape, SelectItemData, SelectItemGroup } from '../types';
+import type {
+  MetaShape,
+  SelectItemData,
+  SelectItemGroup,
+  SelectValue,
+} from '../types';
 
 /**
  * base-ui's Combobox calls onValueChange with either a string (click on
@@ -23,11 +28,12 @@ export const resolveValue = (value: unknown): string | null => {
  * the insertion order of the first occurrence of each group key.
  * Items without a `group` value are collected under an empty-string key.
  */
-export function groupItemsByKey<TMeta extends MetaShape = MetaShape>(
-  items: SelectItemData<TMeta>[],
-): SelectItemGroup<TMeta>[] {
+export function groupItemsByKey<
+  T extends SelectValue = SelectValue,
+  TMeta extends MetaShape = MetaShape,
+>(items: SelectItemData<T, TMeta>[]): SelectItemGroup<T, TMeta>[] {
   const order: string[] = [];
-  const map: Record<string, SelectItemData<TMeta>[]> = {};
+  const map: Record<string, SelectItemData<T, TMeta>[]> = {};
   for (const item of items) {
     const key = item.group ?? '';
     if (!map[key]) {

--- a/libs/ui-react/src/lib/Components/SideBar/SideBar.mdx
+++ b/libs/ui-react/src/lib/Components/SideBar/SideBar.mdx
@@ -120,8 +120,6 @@ function MyComponent() {
 
 `createSideBar<T>()` ties them to one literal union. `SideBarLeading`, `SideBarTrailing`, and `SideBarCollapseToggle` carry no value union, so the factory returns them as-is for ergonomic destructuring.
 
-<Canvas of={SideBarStories.Typed} />
-
 ```tsx
 import { createSideBar } from '@ledgerhq/lumen-ui-react';
 import { Home, HomeFill, Wallet, Settings } from '@ledgerhq/lumen-ui-react/symbols';

--- a/libs/ui-react/src/lib/Components/SideBar/SideBar.mdx
+++ b/libs/ui-react/src/lib/Components/SideBar/SideBar.mdx
@@ -83,6 +83,8 @@ npm install @ledgerhq/lumen-ui-react
 
 ## Basic Usage
 
+> **Recommended:** prefer the [type-safe variant](#type-safe-variant) below. It shares one literal union across `active` and every `SideBarItem.value`.
+
 ```tsx
 import {
   SideBar,
@@ -112,6 +114,42 @@ function MyComponent() {
 }
 ```
 
+## Type-safe variant
+
+`SideBar` and `SideBarItem` communicate via context, so TypeScript cannot connect the root's `active` to each item's `value` on its own. A typo compiles, and the wrong item (or none) is highlighted.
+
+`createSideBar<T>()` ties them to one literal union. `SideBarLeading`, `SideBarTrailing`, and `SideBarCollapseToggle` carry no value union, so the factory returns them as-is for ergonomic destructuring.
+
+<Canvas of={SideBarStories.Typed} />
+
+```tsx
+import { createSideBar } from '@ledgerhq/lumen-ui-react';
+import { Home, HomeFill, Wallet, Settings } from '@ledgerhq/lumen-ui-react/symbols';
+
+type Route = 'home' | 'wallet' | 'settings';
+
+const Nav = createSideBar<Route>();
+
+function Example() {
+  const [route, setRoute] = React.useState<Route>('home');
+
+  return (
+    <Nav.SideBar active={route} onActiveChange={setRoute}>
+      <Nav.SideBarLeading>
+        <Nav.SideBarItem value='home' icon={Home} activeIcon={HomeFill} label='Home' />
+        <Nav.SideBarItem value='wallet' icon={Wallet} activeIcon={Wallet} label='Wallet' />
+        {/* <Nav.SideBarItem value='wrong' .../> ts(2322) */}
+      </Nav.SideBarLeading>
+      <Nav.SideBarTrailing>
+        <Nav.SideBarItem value='settings' icon={Settings} activeIcon={Settings} label='Settings' />
+        <Nav.SideBarCollapseToggle />
+      </Nav.SideBarTrailing>
+    </Nav.SideBar>
+  );
+}
+```
+
+Zero runtime cost, as `createSideBar` is a type-only wrapper.
 
 ### Uncontrolled Mode
 

--- a/libs/ui-react/src/lib/Components/SideBar/SideBar.mdx
+++ b/libs/ui-react/src/lib/Components/SideBar/SideBar.mdx
@@ -147,8 +147,6 @@ function Example() {
 }
 ```
 
-Zero runtime cost, as `createSideBar` is a type-only wrapper.
-
 ### Uncontrolled Mode
 
 For simpler use cases, you can use `defaultActive` and `defaultCollapsed` instead of controlling the state.

--- a/libs/ui-react/src/lib/Components/SideBar/SideBar.mdx
+++ b/libs/ui-react/src/lib/Components/SideBar/SideBar.mdx
@@ -136,7 +136,6 @@ function Example() {
       <Nav.SideBarLeading>
         <Nav.SideBarItem value='home' icon={Home} activeIcon={HomeFill} label='Home' />
         <Nav.SideBarItem value='wallet' icon={Wallet} activeIcon={Wallet} label='Wallet' />
-        {/* <Nav.SideBarItem value='wrong' .../> ts(2322) */}
       </Nav.SideBarLeading>
       <Nav.SideBarTrailing>
         <Nav.SideBarItem value='settings' icon={Settings} activeIcon={Settings} label='Settings' />

--- a/libs/ui-react/src/lib/Components/SideBar/SideBar.stories.tsx
+++ b/libs/ui-react/src/lib/Components/SideBar/SideBar.stories.tsx
@@ -22,6 +22,7 @@ import {
 import { Button } from '../Button/Button';
 import { Tag } from '../Tag/Tag';
 import {
+  createSideBar,
   SideBar,
   SideBarLeading,
   SideBarTrailing,
@@ -424,4 +425,43 @@ export const ManyItems: Story = {
       </SideBar>
     </div>
   ),
+};
+
+type Route = 'home' | 'wallet' | 'settings';
+const Nav = createSideBar<Route>();
+
+export const Typed: Story = {
+  render: () => {
+    const [route, setRoute] = useState<Route>('home');
+
+    return (
+      <div style={{ height: '500px' }}>
+        <Nav.SideBar active={route} onActiveChange={setRoute}>
+          <Nav.SideBarLeading>
+            <Nav.SideBarItem
+              value='home'
+              icon={Home}
+              activeIcon={HomeFill}
+              label='Home'
+            />
+            <Nav.SideBarItem
+              value='wallet'
+              icon={Wallet}
+              activeIcon={Wallet}
+              label='Wallet'
+            />
+          </Nav.SideBarLeading>
+          <Nav.SideBarTrailing>
+            <Nav.SideBarItem
+              value='settings'
+              icon={Settings}
+              activeIcon={Settings}
+              label='Settings'
+            />
+            <Nav.SideBarCollapseToggle />
+          </Nav.SideBarTrailing>
+        </Nav.SideBar>
+      </div>
+    );
+  },
 };

--- a/libs/ui-react/src/lib/Components/SideBar/SideBar.stories.tsx
+++ b/libs/ui-react/src/lib/Components/SideBar/SideBar.stories.tsx
@@ -430,7 +430,7 @@ export const ManyItems: Story = {
 type Route = 'home' | 'wallet' | 'settings';
 const Nav = createSideBar<Route>();
 
-export const Typed: Story = {
+export const TypesafeFactory: Story = {
   render: () => {
     const [route, setRoute] = useState<Route>('home');
 

--- a/libs/ui-react/src/lib/Components/SideBar/SideBar.test.tsx
+++ b/libs/ui-react/src/lib/Components/SideBar/SideBar.test.tsx
@@ -15,6 +15,7 @@ import {
   SideBarTrailing,
   SideBarItem,
   SideBarCollapseToggle,
+  createSideBar,
 } from './SideBar';
 
 describe('SideBar Component', () => {
@@ -659,6 +660,42 @@ describe('SideBar Component', () => {
 
       expect(homeButton).toHaveClass('bg-base-transparent');
       expect(walletButton).toHaveClass('bg-muted-transparent');
+    });
+  });
+
+  describe('createSideBar', () => {
+    it('returns typed components that render and respond to clicks', () => {
+      const {
+        SideBar: TypedSideBar,
+        SideBarLeading: TypedLeading,
+        SideBarTrailing: TypedTrailing,
+        SideBarItem: TypedItem,
+        SideBarCollapseToggle: TypedToggle,
+      } = createSideBar<'home' | 'settings'>();
+      const handleActiveChange = vi.fn();
+
+      render(
+        <TypedSideBar onActiveChange={handleActiveChange}>
+          <TypedLeading>
+            <TypedItem value='home' icon={Home} activeIcon={HomeFill} label='Home' />
+          </TypedLeading>
+          <TypedTrailing>
+            <TypedItem
+              value='settings'
+              icon={SettingsAlt}
+              activeIcon={SettingsAlt2}
+              label='Settings'
+            />
+            <TypedToggle />
+          </TypedTrailing>
+        </TypedSideBar>,
+      );
+
+      expect(screen.getByText('Home')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Settings').closest('button')!);
+
+      expect(handleActiveChange).toHaveBeenCalledWith('settings');
     });
   });
 });

--- a/libs/ui-react/src/lib/Components/SideBar/SideBar.test.tsx
+++ b/libs/ui-react/src/lib/Components/SideBar/SideBar.test.tsx
@@ -677,7 +677,12 @@ describe('SideBar Component', () => {
       render(
         <TypedSideBar onActiveChange={handleActiveChange}>
           <TypedLeading>
-            <TypedItem value='home' icon={Home} activeIcon={HomeFill} label='Home' />
+            <TypedItem
+              value='home'
+              icon={Home}
+              activeIcon={HomeFill}
+              label='Home'
+            />
           </TypedLeading>
           <TypedTrailing>
             <TypedItem

--- a/libs/ui-react/src/lib/Components/SideBar/SideBar.tsx
+++ b/libs/ui-react/src/lib/Components/SideBar/SideBar.tsx
@@ -4,6 +4,7 @@ import {
   useDisabledContext,
 } from '@ledgerhq/lumen-utils-shared';
 import { cva } from 'class-variance-authority';
+import type { ReactElement } from 'react';
 import { useCallback } from 'react';
 import { useCommonTranslation } from '../../../i18n';
 import { useControllableState } from '../../../utils/useControllableState';
@@ -16,6 +17,7 @@ import type {
   SideBarTrailingProps,
   SideBarItemProps,
   SideBarCollapseToggleProps,
+  SideBarValue,
 } from './types';
 
 const [SideBarProvider, useSideBarContext] =
@@ -87,7 +89,7 @@ const sideBarVariants = {
  *   </SideBarTrailing>
  * </SideBar>
  */
-export const SideBar = ({
+export const SideBar = <T extends SideBarValue = SideBarValue>({
   ref,
   collapsed: controlledCollapsed,
   defaultCollapsed = false,
@@ -98,7 +100,7 @@ export const SideBar = ({
   children,
   className,
   ...props
-}: SideBarProps) => {
+}: SideBarProps<T>) => {
   const { t } = useCommonTranslation();
   const [collapsed, setCollapsed] = useControllableState({
     prop: controlledCollapsed,
@@ -106,10 +108,10 @@ export const SideBar = ({
     onChange: onCollapsedChange,
   });
 
-  const [active, setActive] = useControllableState({
+  const [active, setActive] = useControllableState<string>({
     prop: controlledActive,
     defaultProp: defaultActive ?? '',
-    onChange: onActiveChange,
+    onChange: onActiveChange as ((value: string) => void) | undefined,
   });
 
   return (
@@ -193,7 +195,7 @@ export const SideBarTrailing = ({
  *   tooltipContent="Wallet"
  * />
  */
-export const SideBarItem = ({
+export const SideBarItem = <T extends SideBarValue = SideBarValue>({
   ref,
   value,
   icon: Icon,
@@ -204,7 +206,7 @@ export const SideBarItem = ({
   className,
   onClick,
   ...props
-}: SideBarItemProps) => {
+}: SideBarItemProps<T>) => {
   const disabled = useDisabledContext({
     consumerName: 'SideBarItem',
     mergeWith: { disabled: disabledProp },
@@ -318,3 +320,19 @@ export const SideBarCollapseToggle = ({
     </Tooltip>
   );
 };
+
+export function createSideBar<T extends SideBarValue = never>(): {
+  SideBar: (props: SideBarProps<T>) => ReactElement;
+  SideBarLeading: (props: SideBarLeadingProps) => ReactElement;
+  SideBarTrailing: (props: SideBarTrailingProps) => ReactElement;
+  SideBarItem: (props: SideBarItemProps<T>) => ReactElement;
+  SideBarCollapseToggle: (props: SideBarCollapseToggleProps) => ReactElement;
+} {
+  return {
+    SideBar,
+    SideBarLeading,
+    SideBarTrailing,
+    SideBarItem,
+    SideBarCollapseToggle,
+  };
+}

--- a/libs/ui-react/src/lib/Components/SideBar/SideBar.tsx
+++ b/libs/ui-react/src/lib/Components/SideBar/SideBar.tsx
@@ -111,7 +111,9 @@ export const SideBar = <T extends SideBarValue = SideBarValue>({
   const [active, setActive] = useControllableState<string>({
     prop: controlledActive,
     defaultProp: defaultActive ?? '',
-    onChange: onActiveChange as ((value: string) => void) | undefined,
+    onChange: onActiveChange
+      ? (value) => onActiveChange(value as T)
+      : undefined,
   });
 
   return (

--- a/libs/ui-react/src/lib/Components/SideBar/index.ts
+++ b/libs/ui-react/src/lib/Components/SideBar/index.ts
@@ -1,8 +1,2 @@
-export {
-  SideBar,
-  SideBarLeading,
-  SideBarTrailing,
-  SideBarItem,
-  SideBarCollapseToggle,
-} from './SideBar';
-export * from './types';
+export * from './SideBar';
+export type * from './types';

--- a/libs/ui-react/src/lib/Components/SideBar/types.ts
+++ b/libs/ui-react/src/lib/Components/SideBar/types.ts
@@ -6,6 +6,8 @@ import type {
 } from 'react';
 import type { IconSize } from '../Icon/types';
 
+export type SideBarValue = string;
+
 /**
  * Context value for passing state to SideBar sub-components
  */
@@ -31,7 +33,7 @@ export type SideBarContextValue = {
 /**
  * Props for the SideBar root component
  */
-export type SideBarProps = {
+export type SideBarProps<T extends SideBarValue = SideBarValue> = {
   /**
    * Controlled collapsed state. When provided, the component becomes controlled.
    */
@@ -49,15 +51,15 @@ export type SideBarProps = {
    * The value of the currently active item.
    * When provided, the component becomes controlled for selection.
    */
-  active?: string;
+  active?: T;
   /**
    * Default active item value for uncontrolled mode.
    */
-  defaultActive?: string;
+  defaultActive?: T;
   /**
    * Callback fired when the active item changes.
    */
-  onActiveChange?: (value: string) => void;
+  onActiveChange?: (value: T) => void;
   /**
    * The children of the sidebar (SideBarLeading, SideBarTrailing).
    */
@@ -99,11 +101,11 @@ export type SideBarTrailingProps = {
 /**
  * Props for the SideBarItem component
  */
-export type SideBarItemProps = {
+export type SideBarItemProps<T extends SideBarValue = SideBarValue> = {
   /**
    * Unique identifier for this item. Used to determine which item is active.
    */
-  value: string;
+  value: T;
   /**
    * The icon component to display when inactive.
    */

--- a/libs/ui-rnative/src/lib/Components/OptionList/OptionList.mdx
+++ b/libs/ui-rnative/src/lib/Components/OptionList/OptionList.mdx
@@ -97,6 +97,8 @@ Install and set up the library with our [Setup Guide →](?path=/docs/getting-st
 
 ## Basic usage
 
+> **Recommended:** prefer the [type-safe variant](#type-safe-variant) below. It ties `value`, `items[].value`, `OptionListItem.value`, and the `renderItem(item).meta` shape to one literal union plus an optional `TMeta`, dropping the `as Meta` casts in `renderItem`.
+
 ```tsx
 import {
   OptionList,
@@ -129,6 +131,53 @@ function MyList() {
   );
 }
 ```
+
+## Type-safe variant
+
+`OptionList` and its subcomponents communicate via context, so TypeScript cannot connect `value` / `items[].value` / `OptionListItem.value` on its own. A typo compiles. `createOptionList<T, TMeta>()` ties them together via one literal union (`T`) and an optional meta shape (`TMeta`) that flows into `renderItem(item)`, removing the `as` cast on `item.meta`.
+
+<Canvas of={OptionListStories.Typed} />
+
+```tsx
+import { createOptionList } from '@ledgerhq/lumen-ui-rnative';
+import type { OptionListItemData } from '@ledgerhq/lumen-ui-rnative';
+
+type Network = 'eth' | 'sol' | 'btc';
+type NetworkMeta = { ticker: string; ledgerId: string };
+
+const NetworkList = createOptionList<Network, NetworkMeta>();
+
+const NETWORKS: OptionListItemData<Network, NetworkMeta>[] = [
+  { value: 'eth', label: 'Ethereum', meta: { ticker: 'ETH', ledgerId: 'ethereum' } },
+  { value: 'sol', label: 'Solana', meta: { ticker: 'SOL', ledgerId: 'solana' } },
+  { value: 'btc', label: 'Bitcoin', meta: { ticker: 'BTC', ledgerId: 'bitcoin' } },
+];
+
+function Example() {
+  const [value, setValue] = React.useState<Network | null>('eth');
+
+  return (
+    <NetworkList.OptionList items={NETWORKS} value={value} onValueChange={setValue}>
+      <NetworkList.OptionListContent
+        renderItem={({ value, label, meta }) =>
+          meta ? (
+            <NetworkList.OptionListItem value={value}>
+              <NetworkList.OptionListItemContent>
+                <NetworkList.OptionListItemText>{label}</NetworkList.OptionListItemText>
+                <NetworkList.OptionListItemDescription>
+                  {meta.ticker}
+                </NetworkList.OptionListItemDescription>
+              </NetworkList.OptionListItemContent>
+            </NetworkList.OptionListItem>
+          ) : null
+        }
+      />
+    </NetworkList.OptionList>
+  );
+}
+```
+
+Zero runtime cost, as `createOptionList` is a type-only wrapper.
 
 ## Inside a BottomSheet
 

--- a/libs/ui-rnative/src/lib/Components/OptionList/OptionList.mdx
+++ b/libs/ui-rnative/src/lib/Components/OptionList/OptionList.mdx
@@ -136,8 +136,6 @@ function MyList() {
 
 `OptionList` and its subcomponents communicate via context, so TypeScript cannot connect `value` / `items[].value` / `OptionListItem.value` on its own. A typo compiles. `createOptionList<T, TMeta>()` ties them together via one literal union (`T`) and an optional meta shape (`TMeta`) that flows into `renderItem(item)`, removing the `as` cast on `item.meta`.
 
-<Canvas of={OptionListStories.Typed} />
-
 ```tsx
 import { createOptionList } from '@ledgerhq/lumen-ui-rnative';
 import type { OptionListItemData } from '@ledgerhq/lumen-ui-rnative';

--- a/libs/ui-rnative/src/lib/Components/OptionList/OptionList.mdx
+++ b/libs/ui-rnative/src/lib/Components/OptionList/OptionList.mdx
@@ -175,8 +175,6 @@ function Example() {
 }
 ```
 
-Zero runtime cost, as `createOptionList` is a type-only wrapper.
-
 ## Inside a BottomSheet
 
 Use `OptionListTrigger` as the input-style trigger — it provides a floating label that animates up when a value is selected, and a chevron indicator. Pass children only when a value is selected so the label stays centered when empty.

--- a/libs/ui-rnative/src/lib/Components/OptionList/OptionList.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/OptionList/OptionList.stories.tsx
@@ -14,6 +14,7 @@ import { Spot } from '../Spot';
 import { Tag } from '../Tag/Tag';
 import { Box, Text } from '../Utility';
 import {
+  createOptionList,
   OptionList,
   OptionListContent,
   OptionListEmptyState,
@@ -1006,4 +1007,66 @@ export const WithDefaultValue: Story = {
       </OptionList>
     </Box>
   ),
+};
+
+type TypedNetwork = 'eth' | 'sol' | 'btc';
+type TypedNetworkMeta = { ticker: string; ledgerId: string };
+const NetworkList = createOptionList<TypedNetwork, TypedNetworkMeta>();
+
+const TYPED_NETWORKS: OptionListItemData<TypedNetwork, TypedNetworkMeta>[] = [
+  {
+    value: 'eth',
+    label: 'Ethereum',
+    meta: { ticker: 'ETH', ledgerId: 'ethereum' },
+  },
+  {
+    value: 'sol',
+    label: 'Solana',
+    meta: { ticker: 'SOL', ledgerId: 'solana' },
+  },
+  {
+    value: 'btc',
+    label: 'Bitcoin',
+    meta: { ticker: 'BTC', ledgerId: 'bitcoin' },
+  },
+];
+
+export const Typed: Story = {
+  render: () => {
+    const [value, setValue] = useState<TypedNetwork | null>('eth');
+
+    return (
+      <Box lx={{ width: 's320' }}>
+        <NetworkList.OptionList
+          items={TYPED_NETWORKS}
+          value={value}
+          onValueChange={setValue}
+        >
+          <NetworkList.OptionListContent
+            renderItem={({ value, label, meta }) =>
+              meta ? (
+                <NetworkList.OptionListItem value={value}>
+                  <NetworkList.OptionListItemLeading>
+                    <CryptoIcon
+                      ledgerId={meta.ledgerId}
+                      ticker={meta.ticker}
+                      size={32}
+                    />
+                  </NetworkList.OptionListItemLeading>
+                  <NetworkList.OptionListItemContent>
+                    <NetworkList.OptionListItemText>
+                      {label}
+                    </NetworkList.OptionListItemText>
+                    <NetworkList.OptionListItemDescription>
+                      {meta.ticker}
+                    </NetworkList.OptionListItemDescription>
+                  </NetworkList.OptionListItemContent>
+                </NetworkList.OptionListItem>
+              ) : null
+            }
+          />
+        </NetworkList.OptionList>
+      </Box>
+    );
+  },
 };

--- a/libs/ui-rnative/src/lib/Components/OptionList/OptionList.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/OptionList/OptionList.stories.tsx
@@ -1031,7 +1031,7 @@ const TYPED_NETWORKS: OptionListItemData<TypedNetwork, TypedNetworkMeta>[] = [
   },
 ];
 
-export const Typed: Story = {
+export const TypesafeFactory: Story = {
   render: () => {
     const [value, setValue] = useState<TypedNetwork | null>('eth');
 

--- a/libs/ui-rnative/src/lib/Components/OptionList/OptionList.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/OptionList/OptionList.test.tsx
@@ -15,6 +15,7 @@ import {
   OptionListEmptyState,
   OptionListSearch,
   OptionListTrigger,
+  createOptionList,
 } from './OptionList';
 import type { OptionListItemData } from './types';
 
@@ -550,6 +551,45 @@ describe('OptionList', () => {
 
       expect(getByRole('button')).toBeTruthy();
       expect(queryByText('Selected value')).toBeTruthy();
+    });
+  });
+
+  describe('createOptionList', () => {
+    it('returns typed components that render and select', () => {
+      type Value = 'a' | 'b' | 'c';
+      const typedItems: OptionListItemData<Value>[] = [
+        { value: 'a', label: 'Alpha' },
+        { value: 'b', label: 'Beta' },
+        { value: 'c', label: 'Gamma' },
+      ];
+      const {
+        OptionList: TypedList,
+        OptionListContent: TypedContent,
+        OptionListItem: TypedItem,
+        OptionListItemContent: TypedItemContent,
+        OptionListItemText: TypedItemText,
+      } = createOptionList<Value>();
+      const onValueChange = jest.fn();
+
+      const { getByText } = render(
+        <TestWrapper>
+          <TypedList items={typedItems} onValueChange={onValueChange}>
+            <TypedContent
+              renderItem={(item) => (
+                <TypedItem value={item.value}>
+                  <TypedItemContent>
+                    <TypedItemText>{item.label}</TypedItemText>
+                  </TypedItemContent>
+                </TypedItem>
+              )}
+            />
+          </TypedList>
+        </TestWrapper>,
+      );
+
+      fireEvent.press(getByText('Beta'));
+
+      expect(onValueChange).toHaveBeenCalledWith('b');
     });
   });
 });

--- a/libs/ui-rnative/src/lib/Components/OptionList/OptionList.tsx
+++ b/libs/ui-rnative/src/lib/Components/OptionList/OptionList.tsx
@@ -3,7 +3,7 @@ import {
   useDisabledContext,
   DisabledProvider,
 } from '@ledgerhq/lumen-utils-shared';
-import { Fragment, type ReactNode } from 'react';
+import { Fragment, type ReactElement, type ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useStyleSheet } from '../../../styles';
 import { Check, ChevronDown } from '../../Symbols';
@@ -27,13 +27,17 @@ import type {
   OptionListSearchProps,
   OptionListTriggerProps,
   OptionListLabelProps,
+  OptionListValue,
 } from './types';
 import { useOptionListItems } from './useOptionList/useOptionListItems';
 
 const [OptionListProvider, useOptionListContext] =
   createSafeContext<OptionListContextValue>('OptionList');
 
-export const OptionList = <TMeta extends MetaShape = MetaShape>({
+export const OptionList = <
+  T extends OptionListValue = OptionListValue,
+  TMeta extends MetaShape = MetaShape,
+>({
   items,
   value,
   defaultValue,
@@ -45,7 +49,7 @@ export const OptionList = <TMeta extends MetaShape = MetaShape>({
   defaultSearchValue,
   onSearchValueChange,
   children,
-}: OptionListProps<TMeta>) => {
+}: OptionListProps<T, TMeta>) => {
   const disabled = useDisabledContext({
     consumerName: 'OptionList',
     mergeWith: { disabled: disabledProp },
@@ -55,7 +59,7 @@ export const OptionList = <TMeta extends MetaShape = MetaShape>({
     {
       prop: value,
       defaultProp: defaultValue ?? null,
-      onChange: onValueChange,
+      onChange: (next: string | null) => onValueChange?.(next as T | null),
     },
   );
 
@@ -65,7 +69,7 @@ export const OptionList = <TMeta extends MetaShape = MetaShape>({
     flatItems,
     resolvedSearchValue,
     handleSearchValueChange,
-  } = useOptionListItems<TMeta>({
+  } = useOptionListItems<T, TMeta>({
     items,
     filter,
     filteredItems,
@@ -93,20 +97,26 @@ export const OptionList = <TMeta extends MetaShape = MetaShape>({
   );
 };
 
-export const OptionListContent = <TMeta extends MetaShape = MetaShape>({
+export const OptionListContent = <
+  T extends OptionListValue = OptionListValue,
+  TMeta extends MetaShape = MetaShape,
+>({
   renderItem,
   lx,
   style,
   ref,
   ...props
-}: OptionListContentProps<TMeta>) => {
+}: OptionListContentProps<T, TMeta>) => {
   const { selectedValue, isGrouped, groups, flatItems } = useOptionListContext({
     consumerName: 'OptionListContent',
     contextRequired: true,
   });
 
   const renderItemWithState = (item: OptionListItemData) =>
-    renderItem(item as OptionListItemData<TMeta>, selectedValue === item.value);
+    renderItem(
+      item as OptionListItemData<T, TMeta>,
+      selectedValue === item.value,
+    );
 
   if (isGrouped) {
     return (
@@ -161,7 +171,7 @@ const useItemStyles = ({
   );
 };
 
-export const OptionListItem = ({
+export const OptionListItem = <T extends OptionListValue = OptionListValue>({
   value,
   disabled: disabledProp = false,
   children,
@@ -169,7 +179,7 @@ export const OptionListItem = ({
   style,
   ref,
   ...props
-}: OptionListItemProps) => {
+}: OptionListItemProps<T>) => {
   const { selectedValue, onValueChange } = useOptionListContext({
     consumerName: 'OptionListItem',
     contextRequired: true,
@@ -576,3 +586,40 @@ export const OptionListTrigger = ({
     </Pressable>
   );
 };
+
+export function createOptionList<
+  T extends OptionListValue = never,
+  TMeta extends MetaShape = MetaShape,
+>(): {
+  OptionList: (props: OptionListProps<T, TMeta>) => ReactElement;
+  OptionListContent: (props: OptionListContentProps<T, TMeta>) => ReactElement;
+  OptionListItem: (props: OptionListItemProps<T>) => ReactElement;
+  OptionListItemText: (props: OptionListItemTextProps) => ReactElement;
+  OptionListItemDescription: (
+    props: OptionListItemDescriptionProps,
+  ) => ReactElement;
+  OptionListItemContent: (props: OptionListItemContentProps) => ReactElement;
+  OptionListItemContentRow: (
+    props: OptionListItemContentRowProps,
+  ) => ReactElement;
+  OptionListItemLeading: (props: OptionListItemLeadingProps) => ReactElement;
+  OptionListSearch: (props: OptionListSearchProps) => ReactElement;
+  OptionListEmptyState: (
+    props: OptionListEmptyStateProps,
+  ) => ReactElement | null;
+  OptionListTrigger: (props: OptionListTriggerProps) => ReactElement;
+} {
+  return {
+    OptionList,
+    OptionListContent,
+    OptionListItem,
+    OptionListItemText,
+    OptionListItemDescription,
+    OptionListItemContent,
+    OptionListItemContentRow,
+    OptionListItemLeading,
+    OptionListSearch,
+    OptionListEmptyState,
+    OptionListTrigger,
+  };
+}

--- a/libs/ui-rnative/src/lib/Components/OptionList/types.ts
+++ b/libs/ui-rnative/src/lib/Components/OptionList/types.ts
@@ -8,9 +8,14 @@ import type { SearchInputProps } from '../SearchInput';
 
 export type MetaShape = Record<string, unknown>;
 
-export type OptionListItemData<TMeta extends MetaShape = MetaShape> = {
+export type OptionListValue = string;
+
+export type OptionListItemData<
+  T extends OptionListValue = OptionListValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
   /** Unique string identifier for this item, used for selection tracking. */
-  value: string;
+  value: T;
   /** Display text. */
   label: string;
   /** Secondary text displayed below the label inside the item. */
@@ -43,29 +48,35 @@ export type OptionListContextValue = {
 };
 
 /** Internal type -- consumers never construct this directly. */
-export type OptionListItemGroup<TMeta extends MetaShape = MetaShape> = {
+export type OptionListItemGroup<
+  T extends OptionListValue = OptionListValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
   label: string;
-  items: OptionListItemData<TMeta>[];
+  items: OptionListItemData<T, TMeta>[];
 };
 
-export type OptionListProps<TMeta extends MetaShape = MetaShape> = {
+export type OptionListProps<
+  T extends OptionListValue = OptionListValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
   /**
    * Flat array of items.
    * Use the `group` field on each item for automatic grouping.
    */
-  items: OptionListItemData<TMeta>[];
+  items: OptionListItemData<T, TMeta>[];
   /**
    * The controlled selected value.
    */
-  value?: string | null;
+  value?: T | null;
   /**
    * The default selected value (uncontrolled)
    */
-  defaultValue?: string | null;
+  defaultValue?: T | null;
   /**
    * Called when the selected value changes.
    */
-  onValueChange?: (value: string | null) => void;
+  onValueChange?: (value: T | null) => void;
   /**
    * When true, prevents interaction with the entire list.
    */
@@ -74,12 +85,14 @@ export type OptionListProps<TMeta extends MetaShape = MetaShape> = {
    * Custom item/query matcher.
    * Defaults to case-insensitive label match; `null` disables filtering.
    */
-  filter?: null | ((item: OptionListItemData<TMeta>, query: string) => boolean);
+  filter?:
+    | null
+    | ((item: OptionListItemData<T, TMeta>, query: string) => boolean);
   /**
    * Pre-filtered items for async/remote search.
    * Bypasses internal filtering.
    */
-  filteredItems?: OptionListItemData<TMeta>[];
+  filteredItems?: OptionListItemData<T, TMeta>[];
   /**
    * Controlled search input value.
    */
@@ -95,14 +108,20 @@ export type OptionListProps<TMeta extends MetaShape = MetaShape> = {
   children: ReactNode;
 };
 
-export type OptionListContentProps<TMeta extends MetaShape = MetaShape> = {
+export type OptionListContentProps<
+  T extends OptionListValue = OptionListValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
   /** Render function called for each item. Receives the item data and selection/disabled state. */
-  renderItem: (item: OptionListItemData<TMeta>, selected: boolean) => ReactNode;
+  renderItem: (
+    item: OptionListItemData<T, TMeta>,
+    selected: boolean,
+  ) => ReactNode;
 } & Omit<StyledViewProps, 'children'>;
 
-export type OptionListItemProps = {
+export type OptionListItemProps<T extends OptionListValue = OptionListValue> = {
   /** The value associated with this item, used for selection matching. */
-  value: string;
+  value: T;
   /** Whether the item is disabled. */
   disabled?: boolean;
   children: ReactNode;

--- a/libs/ui-rnative/src/lib/Components/OptionList/useOptionList/useOptionListItems.ts
+++ b/libs/ui-rnative/src/lib/Components/OptionList/useOptionList/useOptionListItems.ts
@@ -4,13 +4,17 @@ import type {
   MetaShape,
   OptionListItemData,
   OptionListItemGroup,
+  OptionListValue,
 } from '../types';
 
-const groupByField = <TMeta extends MetaShape = MetaShape>(
-  items: OptionListItemData<TMeta>[],
-): OptionListItemGroup<TMeta>[] => {
+const groupByField = <
+  T extends OptionListValue = OptionListValue,
+  TMeta extends MetaShape = MetaShape,
+>(
+  items: OptionListItemData<T, TMeta>[],
+): OptionListItemGroup<T, TMeta>[] => {
   const order: string[] = [];
-  const map: Record<string, OptionListItemData<TMeta>[]> = {};
+  const map: Record<string, OptionListItemData<T, TMeta>[]> = {};
   for (const item of items) {
     const key = item.group ?? '';
     if (!map[key]) {
@@ -30,31 +34,42 @@ export const defaultLabelFilter = (
   query: string,
 ): boolean => item.label.toLowerCase().includes(query.toLowerCase());
 
-type UseOptionListItemsParams<TMeta extends MetaShape = MetaShape> = {
-  items: OptionListItemData<TMeta>[];
-  filter?: null | ((item: OptionListItemData<TMeta>, query: string) => boolean);
-  filteredItems?: OptionListItemData<TMeta>[];
+type UseOptionListItemsParams<
+  T extends OptionListValue = OptionListValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
+  items: OptionListItemData<T, TMeta>[];
+  filter?:
+    | null
+    | ((item: OptionListItemData<T, TMeta>, query: string) => boolean);
+  filteredItems?: OptionListItemData<T, TMeta>[];
   searchValue?: string;
   defaultSearchValue?: string;
   onSearchValueChange?: (value: string) => void;
 };
 
-type UseOptionListItemsResult<TMeta extends MetaShape = MetaShape> = {
+type UseOptionListItemsResult<
+  T extends OptionListValue = OptionListValue,
+  TMeta extends MetaShape = MetaShape,
+> = {
   isGrouped: boolean;
-  groups: OptionListItemGroup<TMeta>[];
-  flatItems: OptionListItemData<TMeta>[];
+  groups: OptionListItemGroup<T, TMeta>[];
+  flatItems: OptionListItemData<T, TMeta>[];
   resolvedSearchValue: string;
   handleSearchValueChange: (val: string) => void;
 };
 
-export const useOptionListItems = <TMeta extends MetaShape = MetaShape>({
+export const useOptionListItems = <
+  T extends OptionListValue = OptionListValue,
+  TMeta extends MetaShape = MetaShape,
+>({
   items,
   filter,
   filteredItems,
   searchValue: searchValueProp,
   defaultSearchValue,
   onSearchValueChange,
-}: UseOptionListItemsParams<TMeta>): UseOptionListItemsResult<TMeta> => {
+}: UseOptionListItemsParams<T, TMeta>): UseOptionListItemsResult<T, TMeta> => {
   const [searchValue, handleSearchValueChange] = useControllableState<string>({
     prop: searchValueProp,
     defaultProp: defaultSearchValue ?? '',

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.mdx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.mdx
@@ -95,8 +95,6 @@ export default function Example() {
 
 `createSegmentedControl<T>()` ties both components to one literal union. Call it once at module scope; the returned pair are typed against your `T`.
 
-<Canvas of={SegmentedControlStories.Typed} />
-
 ```tsx
 import { createSegmentedControl } from '@ledgerhq/lumen-ui-rnative';
 

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.mdx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.mdx
@@ -67,6 +67,8 @@ Use the library as part of `@ledgerhq/lumen-ui-rnative`. See the [Setup Guide â†
 
 Control selected value in state at the top level and pass it to SegmentedControl. Buttons use value to identify themselves; selected state is derived from context.
 
+> **Recommended:** prefer the [type-safe variant](#type-safe-variant) below. It shares a single literal union across the root and every button.
+
 ```tsx
 import { SegmentedControl, SegmentedControlButton } from '@ledgerhq/lumen-ui-rnative';
 
@@ -86,6 +88,37 @@ export default function Example() {
   );
 }
 ```
+
+## Type-safe variant
+
+`SegmentedControl` and `SegmentedControlButton` communicate via context, so TypeScript cannot connect the root's `selectedValue` to each button's `value` on its own. A typo compiles, and the pill silently never moves to that segment.
+
+`createSegmentedControl<T>()` ties both components to one literal union. Call it once at module scope; the returned pair are typed against your `T`.
+
+<Canvas of={SegmentedControlStories.Typed} />
+
+```tsx
+import { createSegmentedControl } from '@ledgerhq/lumen-ui-rnative';
+
+type View = 'preview' | 'raw' | 'blame';
+
+const { SegmentedControl, SegmentedControlButton } = createSegmentedControl<View>();
+
+function Example() {
+  const [view, setView] = React.useState<View>('preview');
+
+  return (
+    <SegmentedControl selectedValue={view} onSelectedChange={setView}>
+      <SegmentedControlButton value='preview'>Preview</SegmentedControlButton>
+      <SegmentedControlButton value='raw'>Raw</SegmentedControlButton>
+      <SegmentedControlButton value='blame'>Blame</SegmentedControlButton>
+      {/* <SegmentedControlButton value='wrong' /> ts(2322) */}
+    </SegmentedControl>
+  );
+}
+```
+
+Zero runtime cost, as `createSegmentedControl` is a type-only wrapper.
 
 ## With trailing content
 

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.mdx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.mdx
@@ -116,8 +116,6 @@ function Example() {
 }
 ```
 
-Zero runtime cost, as `createSegmentedControl` is a type-only wrapper.
-
 ## With trailing content
 
 Pass any node via `trailingContent` to render it to the right of the label. Use it for badges like `DotCount` to surface counts per segment.

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.mdx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.mdx
@@ -110,7 +110,6 @@ function Example() {
       <SegmentedControlButton value='preview'>Preview</SegmentedControlButton>
       <SegmentedControlButton value='raw'>Raw</SegmentedControlButton>
       <SegmentedControlButton value='blame'>Blame</SegmentedControlButton>
-      {/* <SegmentedControlButton value='wrong' /> ts(2322) */}
     </SegmentedControl>
   );
 }

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
@@ -3,7 +3,11 @@ import { useState } from 'react';
 import { Coins, Nft, TransferHorizontal } from '../../Symbols';
 import { DotCount } from '../DotCount';
 import { Box } from '../Utility';
-import { SegmentedControl, SegmentedControlButton } from './SegmentedControl';
+import {
+  createSegmentedControl,
+  SegmentedControl,
+  SegmentedControlButton,
+} from './SegmentedControl';
 
 const meta = {
   title: 'Navigation/SegmentedControl',
@@ -167,6 +171,35 @@ export const WithTrailingContent: Story = {
         </SegmentedControlButton>
         <SegmentedControlButton value='trade'>Trade</SegmentedControlButton>
       </SegmentedControl>
+    );
+  },
+};
+
+type View = 'preview' | 'raw' | 'blame';
+const TypedSegmentedControl = createSegmentedControl<View>();
+
+export const Typed: Story = {
+  args: {} as React.ComponentProps<typeof SegmentedControl>,
+  render: (args) => {
+    const [view, setView] = useState<View>('preview');
+
+    return (
+      <TypedSegmentedControl.SegmentedControl
+        {...args}
+        selectedValue={view}
+        onSelectedChange={setView}
+        accessibilityLabel='File view'
+      >
+        <TypedSegmentedControl.SegmentedControlButton value='preview'>
+          Preview
+        </TypedSegmentedControl.SegmentedControlButton>
+        <TypedSegmentedControl.SegmentedControlButton value='raw'>
+          Raw
+        </TypedSegmentedControl.SegmentedControlButton>
+        <TypedSegmentedControl.SegmentedControlButton value='blame'>
+          Blame
+        </TypedSegmentedControl.SegmentedControlButton>
+      </TypedSegmentedControl.SegmentedControl>
     );
   },
 };

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.stories.tsx
@@ -178,7 +178,7 @@ export const WithTrailingContent: Story = {
 type View = 'preview' | 'raw' | 'blame';
 const TypedSegmentedControl = createSegmentedControl<View>();
 
-export const Typed: Story = {
+export const TypesafeFactory: Story = {
   args: {} as React.ComponentProps<typeof SegmentedControl>,
   render: (args) => {
     const [view, setView] = useState<View>('preview');

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.test.tsx
@@ -3,7 +3,11 @@ import { ledgerLiveThemes } from '@ledgerhq/lumen-design-core';
 import { render, fireEvent } from '@testing-library/react-native';
 import { DotCount } from '../DotCount';
 import { ThemeProvider } from '../ThemeProvider/ThemeProvider';
-import { SegmentedControl, SegmentedControlButton } from './SegmentedControl';
+import {
+  SegmentedControl,
+  SegmentedControlButton,
+  createSegmentedControl,
+} from './SegmentedControl';
 
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
   <ThemeProvider themes={ledgerLiveThemes} colorScheme='dark' locale='en'>
@@ -170,6 +174,33 @@ describe('SegmentedControl', () => {
       fireEvent.press(getByText('Preview'));
 
       expect(onSelectedChange).toHaveBeenCalledWith('preview');
+    });
+  });
+
+  describe('createSegmentedControl', () => {
+    it('returns typed components that render and select like the originals', () => {
+      const {
+        SegmentedControl: TypedControl,
+        SegmentedControlButton: TypedButton,
+      } = createSegmentedControl<'send' | 'receive'>();
+      const onSelectedChange = jest.fn();
+
+      const { getByText } = render(
+        <TestWrapper>
+          <TypedControl
+            selectedValue='send'
+            onSelectedChange={onSelectedChange}
+            accessibilityLabel='Transaction type'
+          >
+            <TypedButton value='send'>Send</TypedButton>
+            <TypedButton value='receive'>Receive</TypedButton>
+          </TypedControl>
+        </TestWrapper>,
+      );
+
+      fireEvent.press(getByText('Receive'));
+
+      expect(onSelectedChange).toHaveBeenCalledWith('receive');
     });
   });
 });

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.tsx
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/SegmentedControl.tsx
@@ -1,4 +1,5 @@
 import { useDisabledContext } from '@ledgerhq/lumen-utils-shared';
+import type { ReactElement } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useStyleSheet } from '../../../styles';
@@ -11,20 +12,23 @@ import {
 import type {
   SegmentedControlButtonProps,
   SegmentedControlProps,
+  SegmentedControlValue,
 } from './types';
 import {
   usePillLayout,
   useSegmentedControlSelectedIndex,
 } from './usePillLayout';
 
-export function SegmentedControlButton({
+export function SegmentedControlButton<
+  T extends SegmentedControlValue = SegmentedControlValue,
+>({
   value,
   children,
   icon: Icon,
   trailingContent,
   onPress,
   ...props
-}: SegmentedControlButtonProps) {
+}: SegmentedControlButtonProps<T>) {
   const {
     selectedValue,
     onSelectedChange,
@@ -126,7 +130,9 @@ function useButtonStyles({
   return { ...styles, typography, textColor };
 }
 
-export function SegmentedControl({
+export function SegmentedControl<
+  T extends SegmentedControlValue = SegmentedControlValue,
+>({
   selectedValue,
   onSelectedChange,
   accessibilityLabel,
@@ -135,7 +141,7 @@ export function SegmentedControl({
   appearance = 'background',
   tabLayout = 'fixed',
   ...props
-}: SegmentedControlProps) {
+}: SegmentedControlProps<T>) {
   const disabled = useDisabledContext({
     consumerName: 'SegmentedControl',
     mergeWith: { disabled: disabledProp },
@@ -160,7 +166,7 @@ export function SegmentedControl({
     <SegmentedControlContextProvider
       value={{
         selectedValue,
-        onSelectedChange,
+        onSelectedChange: onSelectedChange as (value: string) => void,
         disabled,
         tabLayout,
         registerButtonLayout,
@@ -219,4 +225,15 @@ function useRootStyles({
     }),
     [disabled, appearance, tabLayout],
   );
+}
+
+export function createSegmentedControl<
+  T extends SegmentedControlValue = never,
+>(): {
+  SegmentedControl: (props: SegmentedControlProps<T>) => ReactElement;
+  SegmentedControlButton: (
+    props: SegmentedControlButtonProps<T>,
+  ) => ReactElement;
+} {
+  return { SegmentedControl, SegmentedControlButton };
 }

--- a/libs/ui-rnative/src/lib/Components/SegmentedControl/types.ts
+++ b/libs/ui-rnative/src/lib/Components/SegmentedControl/types.ts
@@ -3,15 +3,19 @@ import type { LumenTextStyle, StyledPressableProps } from '../../../styles';
 import type { IconSize } from '../Icon';
 import type { BoxProps } from '../Utility';
 
-export type SegmentedControlProps = {
+export type SegmentedControlValue = string;
+
+export type SegmentedControlProps<
+  T extends SegmentedControlValue = SegmentedControlValue,
+> = {
   /**
    * The value of the currently selected segment (drives the sliding pill).
    */
-  selectedValue: string;
+  selectedValue: T;
   /**
    * Callback when the selected segment value changes.
    */
-  onSelectedChange: (value: string) => void;
+  onSelectedChange: (value: T) => void;
   /**
    * When true, the entire control is disabled (no interaction, selected uses muted styling).
    */
@@ -43,11 +47,13 @@ type IconComponent = ComponentType<{
   color?: LumenTextStyle['color'];
 }>;
 
-export type SegmentedControlButtonProps = {
+export type SegmentedControlButtonProps<
+  T extends SegmentedControlValue = SegmentedControlValue,
+> = {
   /**
    * Value for this segment (must be unique among siblings).
    */
-  value: string;
+  value: T;
   /**
    * Button label (e.g. "Preview", "Raw").
    */

--- a/libs/ui-rnative/src/lib/Components/TabBar/TabBar.mdx
+++ b/libs/ui-rnative/src/lib/Components/TabBar/TabBar.mdx
@@ -94,8 +94,6 @@ function MyComponent() {
 
 `createTabBar<T>()` ties both components to one literal union. Call it once at module scope; the returned pair are typed against your `T`.
 
-<Canvas of={TabBarStories.Typed} />
-
 ```tsx
 import { createTabBar } from '@ledgerhq/lumen-ui-rnative';
 import { Home, HomeFill, Settings } from '@ledgerhq/lumen-ui-rnative/symbols';

--- a/libs/ui-rnative/src/lib/Components/TabBar/TabBar.mdx
+++ b/libs/ui-rnative/src/lib/Components/TabBar/TabBar.mdx
@@ -69,6 +69,8 @@ Install and set up the library with our [Setup Guide →](?path=/docs/getting-st
 
 ### Basic Usage
 
+> **Recommended:** prefer the [type-safe variant](#type-safe-variant) below. It shares one literal union across `active` and every `TabBarItem.value`.
+
 ```tsx
 import { useState } from 'react';
 import { TabBar, TabBarItem } from '@ledgerhq/lumen-ui-rnative';
@@ -85,6 +87,38 @@ function MyComponent() {
   );
 }
 ```
+
+### Type-safe variant
+
+`TabBar` and `TabBarItem` communicate via context, so TypeScript cannot connect the root's `active` to each item's `value` on its own. A typo compiles, and the wrong tab (or none) is highlighted.
+
+`createTabBar<T>()` ties both components to one literal union. Call it once at module scope; the returned pair are typed against your `T`.
+
+<Canvas of={TabBarStories.Typed} />
+
+```tsx
+import { createTabBar } from '@ledgerhq/lumen-ui-rnative';
+import { Home, HomeFill, Settings } from '@ledgerhq/lumen-ui-rnative/symbols';
+
+type Route = 'home' | 'swap' | 'settings';
+
+const { TabBar, TabBarItem } = createTabBar<Route>();
+
+function Example() {
+  const [active, setActive] = React.useState<Route>('home');
+
+  return (
+    <TabBar active={active} onTabPress={setActive}>
+      <TabBarItem value='home' label='Home' icon={Home} activeIcon={HomeFill} />
+      <TabBarItem value='swap' label='Swap' icon={Settings} />
+      <TabBarItem value='settings' label='Settings' icon={Settings} />
+      {/* <TabBarItem value='wrong' /> ts(2322) */}
+    </TabBar>
+  );
+}
+```
+
+Zero runtime cost, as `createTabBar` is a type-only wrapper.
 
 ### With Active Icons
 

--- a/libs/ui-rnative/src/lib/Components/TabBar/TabBar.mdx
+++ b/libs/ui-rnative/src/lib/Components/TabBar/TabBar.mdx
@@ -116,8 +116,6 @@ function Example() {
 }
 ```
 
-Zero runtime cost, as `createTabBar` is a type-only wrapper.
-
 ### With Active Icons
 
 Provide different icons for active and inactive states:

--- a/libs/ui-rnative/src/lib/Components/TabBar/TabBar.mdx
+++ b/libs/ui-rnative/src/lib/Components/TabBar/TabBar.mdx
@@ -110,7 +110,6 @@ function Example() {
       <TabBarItem value='home' label='Home' icon={Home} activeIcon={HomeFill} />
       <TabBarItem value='swap' label='Swap' icon={Settings} />
       <TabBarItem value='settings' label='Settings' icon={Settings} />
-      {/* <TabBarItem value='wrong' /> ts(2322) */}
     </TabBar>
   );
 }

--- a/libs/ui-rnative/src/lib/Components/TabBar/TabBar.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/TabBar/TabBar.stories.tsx
@@ -15,7 +15,7 @@ import {
   CreditCard,
   CreditCardFill,
 } from '../../Symbols';
-import { TabBar, TabBarItem } from './TabBar';
+import { createTabBar, TabBar, TabBarItem } from './TabBar';
 
 const meta = {
   title: 'Navigation/TabBar',
@@ -115,6 +115,39 @@ export const MissingLabel: Story = {
         <TabBarItem value='tab2' label='Tab' icon={Placeholder} />
         <TabBarItem value='tab3' icon={Cart} />
       </TabBar>
+    );
+  },
+};
+
+type Route = 'home' | 'swap' | 'card' | 'help';
+const Nav = createTabBar<Route>();
+
+export const Typed: Story = {
+  args: {} as React.ComponentProps<typeof TabBar>,
+  render: () => {
+    const [active, setActive] = useState<Route>('home');
+    return (
+      <Nav.TabBar active={active} onTabPress={setActive} lx={{ width: 's320' }}>
+        <Nav.TabBarItem
+          value='home'
+          label='Home'
+          icon={Home}
+          activeIcon={HomeFill}
+        />
+        <Nav.TabBarItem value='swap' label='Swap' icon={CoinPercent} />
+        <Nav.TabBarItem
+          value='card'
+          label='Card'
+          icon={CreditCard}
+          activeIcon={CreditCardFill}
+        />
+        <Nav.TabBarItem
+          value='help'
+          label='Help'
+          icon={LifeRing}
+          activeIcon={LifeRingFill}
+        />
+      </Nav.TabBar>
     );
   },
 };

--- a/libs/ui-rnative/src/lib/Components/TabBar/TabBar.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/TabBar/TabBar.test.tsx
@@ -3,7 +3,7 @@ import { ledgerLiveThemes } from '@ledgerhq/lumen-design-core';
 import { render, fireEvent } from '@testing-library/react-native';
 import { HomeFill, Settings, BasketPutIn } from '../../Symbols';
 import { ThemeProvider } from '../ThemeProvider/ThemeProvider';
-import { TabBar, TabBarItem } from './TabBar';
+import { TabBar, TabBarItem, createTabBar } from './TabBar';
 
 const renderWithProvider = (component: React.ReactElement) => {
   return render(
@@ -53,5 +53,27 @@ describe('TabBar', () => {
     expect(getByText('Home')).toBeTruthy();
     expect(getByText('Shop')).toBeTruthy();
     expect(getByText('Settings')).toBeTruthy();
+  });
+
+  describe('createTabBar', () => {
+    it('returns typed components that render and respond to presses', () => {
+      const { TabBar: TypedTabBar, TabBarItem: TypedItem } = createTabBar<
+        'home' | 'settings'
+      >();
+      const onTabPress = jest.fn();
+
+      const { getByText } = renderWithProvider(
+        <TypedTabBar active='home' onTabPress={onTabPress}>
+          <TypedItem value='home' label='Home' icon={HomeFill} />
+          <TypedItem value='settings' label='Settings' icon={Settings} />
+        </TypedTabBar>,
+      );
+
+      expect(getByText('Home')).toBeTruthy();
+
+      fireEvent.press(getByText('Settings'));
+
+      expect(onTabPress).toHaveBeenCalledWith('settings');
+    });
   });
 });

--- a/libs/ui-rnative/src/lib/Components/TabBar/TabBar.tsx
+++ b/libs/ui-rnative/src/lib/Components/TabBar/TabBar.tsx
@@ -1,5 +1,5 @@
 import { BlurView } from '@sbaiahmed1/react-native-blur';
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { Children, isValidElement, useEffect, useMemo, useRef } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import { StyleSheet, Text, View } from 'react-native';
@@ -18,7 +18,7 @@ import { Placeholder } from '../../Symbols';
 import { RuntimeConstants } from '../../utils';
 import { Box, Pressable } from '../Utility';
 import { TabBarContextProvider, useTabBarContext } from './TabBarContext';
-import type { TabBarItemProps, TabBarProps } from './types';
+import type { TabBarItemProps, TabBarProps, TabBarValue } from './types';
 
 export const TAB_BAR_HEIGHT = 60;
 const PILL_INSET = 4;
@@ -242,12 +242,12 @@ export function TabBarItem({
  *   <TabBarItem value="settings" label="Settings" icon={Settings} />
  * </TabBar>
  */
-export function TabBar({
+export function TabBar<T extends TabBarValue = TabBarValue>({
   active,
   onTabPress,
   children,
   ...props
-}: TabBarProps) {
+}: TabBarProps<T>) {
   const styles = useStyles();
   const { theme, colorScheme } = useTheme();
 
@@ -256,12 +256,13 @@ export function TabBar({
     children,
   });
 
-  function handleTabPress(value: string) {
-    onTabPress?.(value);
-  }
-
   return (
-    <TabBarContextProvider value={{ active, onTabPress: handleTabPress }}>
+    <TabBarContextProvider
+      value={{
+        active,
+        onTabPress: onTabPress as (value: string) => void,
+      }}
+    >
       <Box
         style={styles.container}
         onLayout={onLayout}
@@ -349,3 +350,10 @@ const useStyles = () =>
     }),
     [],
   );
+
+export function createTabBar<T extends TabBarValue = never>(): {
+  TabBar: (props: TabBarProps<T>) => ReactElement;
+  TabBarItem: (props: TabBarItemProps<T>) => ReactElement;
+} {
+  return { TabBar, TabBarItem };
+}

--- a/libs/ui-rnative/src/lib/Components/TabBar/TabBar.tsx
+++ b/libs/ui-rnative/src/lib/Components/TabBar/TabBar.tsx
@@ -260,7 +260,7 @@ export function TabBar<T extends TabBarValue = TabBarValue>({
     <TabBarContextProvider
       value={{
         active,
-        onTabPress: onTabPress as (value: string) => void,
+        onTabPress: (value) => onTabPress(value as T),
       }}
     >
       <Box

--- a/libs/ui-rnative/src/lib/Components/TabBar/index.ts
+++ b/libs/ui-rnative/src/lib/Components/TabBar/index.ts
@@ -1,2 +1,2 @@
-export { TabBar, TabBarItem, TAB_BAR_HEIGHT } from './TabBar';
-export type { TabBarProps, TabBarItemProps } from './types';
+export * from './TabBar';
+export * from './types';

--- a/libs/ui-rnative/src/lib/Components/TabBar/types.ts
+++ b/libs/ui-rnative/src/lib/Components/TabBar/types.ts
@@ -7,11 +7,28 @@ type IconComponent = ComponentType<{
   size?: IconSize;
 }>;
 
-export type TabBarItemProps = {
+export type TabBarValue = string;
+
+export type TabBarProps<T extends TabBarValue = TabBarValue> = {
+  /**
+   * The value of the currently active tab.
+   */
+  active: T;
+  /**
+   * The callback function called when a tab is pressed.
+   */
+  onTabPress: (active: T) => void;
+  /**
+   * The tab items to display.
+   */
+  children: ReactNode;
+} & Omit<BoxProps, 'children'>;
+
+export type TabBarItemProps<T extends TabBarValue = TabBarValue> = {
   /**
    * The unique identifier for the tab item.
    */
-  value: string;
+  value: T;
   /**
    * The display label for the tab item.
    * If not provided, the icon will be centered.
@@ -27,18 +44,3 @@ export type TabBarItemProps = {
    */
   activeIcon?: IconComponent;
 } & Omit<StyledViewProps, 'children'>;
-
-export type TabBarProps = {
-  /**
-   * The value of the currently active tab.
-   */
-  active: string;
-  /**
-   * The callback function called when a tab is pressed.
-   */
-  onTabPress: (active: string) => void;
-  /**
-   * The tab items to display.
-   */
-  children: ReactNode;
-} & Omit<BoxProps, 'children'>;


### PR DESCRIPTION
Closes [DLS-811](https://ledgerhq.atlassian.net/browse/DLS-811).

Based on the suggestions found in this article:
https://tkdodo.eu/blog/building-type-safe-compound-components#component-factory-pattern

## Considerations

Tagged as BREAKING_CHANGE because (from the version plan):

> The generics on `Select` components now take the value union `T` as the first parameter, followed by `TMeta` (previously `TMeta` was the only parameter).

Same for `OptionList`. This is a type-level breaking change only, so IMO this has very small surface. Still, just to bring extra attention to it, I've tagged it as a breaking change.

[DLS-811]: https://ledgerhq.atlassian.net/browse/DLS-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ