### PR TITLE
chore: fix issues after enabling a11y on chromatic

### DIFF
--- a/.nx/version-plans/version-plan-1782146162995.md
+++ b/.nx/version-plans/version-plan-1782146162995.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+chore: fix issues after enabling a11y on chromatic

--- a/libs/ui-react/src/lib/Components/AddressInput/AddressInput.stories.tsx
+++ b/libs/ui-react/src/lib/Components/AddressInput/AddressInput.stories.tsx
@@ -118,6 +118,7 @@ export const Error: Story = {
     status: 'error',
     className: 'max-w-md',
     onQrCodeClick: () => console.log('QR code clicked!'),
+    'aria-label': 'Address or ENS',
   },
   parameters: {
     docs: {

--- a/libs/ui-react/src/lib/Components/AmountDisplay/AmountDisplay.tsx
+++ b/libs/ui-react/src/lib/Components/AmountDisplay/AmountDisplay.tsx
@@ -185,6 +185,7 @@ export function AmountDisplay({
         'relative inline-flex',
         className,
       )}
+      role='img'
       aria-label={ariaLabel}
       aria-busy={loading}
       {...props}

--- a/libs/ui-react/src/lib/Components/AmountInput/AmountInput.stories.tsx
+++ b/libs/ui-react/src/lib/Components/AmountInput/AmountInput.stories.tsx
@@ -44,6 +44,7 @@ export const WithValue: Story = {
     value: '1234.56',
     currencyText: '$',
     onChange: () => console.log('onChange triggered'),
+    'aria-label': 'Input amount',
   },
 };
 
@@ -61,6 +62,7 @@ export const Size: Story = {
             value='1234.56'
             currencyText='$'
             onChange={() => console.log('onChange triggered')}
+            aria-label='Input amount'
           />
         </div>
       ))}
@@ -82,6 +84,7 @@ export const Alignment: Story = {
             value='1234.56'
             currencyText='$'
             onChange={() => console.log('onChange triggered')}
+            aria-label='Input amount'
           />
         </div>
       ))}
@@ -96,6 +99,7 @@ export const Disabled: Story = {
     currencyPosition: 'right',
     disabled: true,
     onChange: () => console.log('onChange triggered'),
+    'aria-label': 'Input amount',
   },
 };
 
@@ -105,6 +109,7 @@ export const Error: Story = {
     currencyText: '$',
     'aria-invalid': true,
     onChange: () => console.log('onChange triggered'),
+    'aria-label': 'Input amount',
   },
 };
 
@@ -114,6 +119,7 @@ export const IntegerOnly: Story = {
     currencyText: '$',
     allowDecimals: false,
     onChange: () => console.log('onChange triggered'),
+    'aria-label': 'Input amount',
   },
   parameters: {
     docs: {
@@ -138,6 +144,7 @@ export const CustomMaxLength: Story = {
     value: '123',
     currencyText: '$',
     onChange: () => console.log('onChange triggered'),
+    'aria-label': 'Input amount',
   },
 };
 
@@ -172,6 +179,7 @@ export const LargeAmountDisplay: Story = {
             currencyText={currentCurrency}
             currencyPosition={isEth ? 'right' : 'left'}
             aria-invalid={hasError}
+            aria-label='Input amount'
           />
           <div className='mt-16 text-center body-2 text-muted'>
             {convertedValue}

--- a/libs/ui-react/src/lib/Components/Card/Card.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Card/Card.stories.tsx
@@ -55,7 +55,7 @@ export const Base: Story = {
     <Card {...args}>
       <CardHeader>
         <CardLeading>
-          <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+          <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} alt='Bitcoin' />
           <CardContent>
             <CardContentTitle>Bitcoin</CardContentTitle>
             <CardContentDescription>BTC</CardContentDescription>
@@ -87,7 +87,12 @@ export const StatesShowcase: Story = {
       <Card {...args} className='w-320'>
         <CardHeader>
           <CardLeading>
-            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+            <CryptoIcon
+              ledgerId='bitcoin'
+              ticker='BTC'
+              size={48}
+              alt='Bitcoin'
+            />
             <CardContent>
               <CardContentTitle>Interactive (default)</CardContentTitle>
               <CardContentDescription>
@@ -112,7 +117,12 @@ export const StatesShowcase: Story = {
       <Card {...args} className='w-320' outlined>
         <CardHeader>
           <CardLeading>
-            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+            <CryptoIcon
+              ledgerId='bitcoin'
+              ticker='BTC'
+              size={48}
+              alt='Bitcoin'
+            />
             <CardContent>
               <CardContentTitle>Outlined</CardContentTitle>
               <CardContentDescription>Selected state</CardContentDescription>
@@ -135,7 +145,12 @@ export const StatesShowcase: Story = {
       <Card {...args} className='w-320' type='info'>
         <CardHeader>
           <CardLeading>
-            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+            <CryptoIcon
+              ledgerId='bitcoin'
+              ticker='BTC'
+              size={48}
+              alt='Bitcoin'
+            />
             <CardContent>
               <CardContentTitle>Info</CardContentTitle>
               <CardContentDescription>Data display only</CardContentDescription>
@@ -158,7 +173,13 @@ export const StatesShowcase: Story = {
       <Card {...args} className='w-320' disabled>
         <CardHeader>
           <CardLeading>
-            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} disabled />
+            <CryptoIcon
+              ledgerId='bitcoin'
+              ticker='BTC'
+              size={48}
+              disabled
+              alt='Bitcoin'
+            />
             <CardContent>
               <CardContentTitle>Disabled</CardContentTitle>
               <CardContentDescription>Non-interactive</CardContentDescription>
@@ -276,7 +297,12 @@ export const ExpandableShowcase: Story = {
         >
           <CardHeader>
             <CardLeading>
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+              <CryptoIcon
+                ledgerId='bitcoin'
+                ticker='BTC'
+                size={48}
+                alt='Bitcoin'
+              />
               <CardContent>
                 <CardContentTitle>Expandable Card</CardContentTitle>
                 <CardContentDescription>Click to toggle</CardContentDescription>
@@ -319,7 +345,12 @@ export const LayoutShowcase: Story = {
       <Card {...args} className='w-fit'>
         <CardHeader>
           <CardLeading>
-            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+            <CryptoIcon
+              ledgerId='bitcoin'
+              ticker='BTC'
+              size={48}
+              alt='Bitcoin'
+            />
             <CardContent>
               <CardContentTitle>Fit content</CardContentTitle>
               <CardContentDescription>BTC</CardContentDescription>
@@ -334,7 +365,12 @@ export const LayoutShowcase: Story = {
       <Card {...args} className='w-320'>
         <CardHeader>
           <CardLeading>
-            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+            <CryptoIcon
+              ledgerId='bitcoin'
+              ticker='BTC'
+              size={48}
+              alt='Bitcoin'
+            />
             <CardContent>
               <CardContentRow>
                 <CardContentTitle>Defined width (320px)</CardContentTitle>
@@ -359,7 +395,12 @@ export const LayoutShowcase: Story = {
         <CardHeader>
           <CardLeading>
             <div className='shrink-0'>
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+              <CryptoIcon
+                ledgerId='bitcoin'
+                ticker='BTC'
+                size={48}
+                alt='Bitcoin'
+              />
             </div>
             <CardContent>
               <CardContentRow>
@@ -395,7 +436,12 @@ export const LayoutShowcase: Story = {
       <Card {...args} className='w-full'>
         <CardHeader>
           <CardLeading>
-            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+            <CryptoIcon
+              ledgerId='bitcoin'
+              ticker='BTC'
+              size={48}
+              alt='Bitcoin'
+            />
             <CardContent>
               <CardContentTitle>Full width (fills parent)</CardContentTitle>
               <CardContentDescription>BTC</CardContentDescription>
@@ -431,7 +477,12 @@ export const CompositionsShowcase: Story = {
         <Card {...args} className='w-320' type='info'>
           <CardHeader>
             <CardLeading>
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+              <CryptoIcon
+                ledgerId='bitcoin'
+                ticker='BTC'
+                size={48}
+                alt='Bitcoin'
+              />
               <CardContent>
                 <CardContentTitle>Account 1</CardContentTitle>
                 <CardContentDescription>Ethereum</CardContentDescription>
@@ -455,7 +506,12 @@ export const CompositionsShowcase: Story = {
         <Card {...args} className='w-320'>
           <CardHeader>
             <CardLeading>
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+              <CryptoIcon
+                ledgerId='bitcoin'
+                ticker='BTC'
+                size={48}
+                alt='Bitcoin'
+              />
               <CardContent>
                 <CardContentTitle>Bitcoin</CardContentTitle>
                 <CardContentDescription>BTC</CardContentDescription>
@@ -501,7 +557,12 @@ export const CompositionsShowcase: Story = {
         <Card {...args} className='w-320'>
           <CardHeader>
             <CardLeading>
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+              <CryptoIcon
+                ledgerId='bitcoin'
+                ticker='BTC'
+                size={48}
+                alt='Bitcoin'
+              />
               <CardContent>
                 <CardContentTitle>My Wallet</CardContentTitle>
                 <CardContentDescription>Ethereum</CardContentDescription>
@@ -521,7 +582,12 @@ export const CompositionsShowcase: Story = {
         <Card {...args} className='w-320'>
           <CardHeader>
             <CardLeading>
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+              <CryptoIcon
+                ledgerId='bitcoin'
+                ticker='BTC'
+                size={48}
+                alt='Bitcoin'
+              />
               <CardContent>
                 <CardContentRow>
                   <CardContentTitle>Bitcoin</CardContentTitle>
@@ -574,7 +640,12 @@ export const CompositionsShowcase: Story = {
         <Card {...args} className='w-320' type='info'>
           <CardHeader>
             <CardLeading>
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+              <CryptoIcon
+                ledgerId='bitcoin'
+                ticker='BTC'
+                size={48}
+                alt='Bitcoin'
+              />
               <CardContent>
                 <CardContentTitle>Staking</CardContentTitle>
                 <CardContentDescription>Earn rewards</CardContentDescription>
@@ -602,7 +673,12 @@ export const CompositionsShowcase: Story = {
         <Card {...args} className='w-320' type='info'>
           <CardHeader>
             <CardLeading>
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+              <CryptoIcon
+                ledgerId='bitcoin'
+                ticker='BTC'
+                size={48}
+                alt='Bitcoin'
+              />
               <CardContent>
                 <CardContentTitle>My Wallet</CardContentTitle>
                 <CardContentDescription>Ethereum</CardContentDescription>
@@ -630,7 +706,12 @@ export const CompositionsShowcase: Story = {
         >
           <CardHeader>
             <CardLeading>
-              <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+              <CryptoIcon
+                ledgerId='bitcoin'
+                ticker='BTC'
+                size={48}
+                alt='Bitcoin'
+              />
               <CardContent>
                 <CardContentTitle>Bitcoin</CardContentTitle>
                 <CardContentDescription>BTC</CardContentDescription>

--- a/libs/ui-react/src/lib/Components/Checkbox/Checkbox.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Checkbox/Checkbox.stories.tsx
@@ -30,7 +30,7 @@ type Story = StoryObj<typeof meta>;
 export const Base: Story = {
   render: (args) => (
     <div className='flex size-80 items-center justify-center'>
-      <Checkbox {...args} />
+      <Checkbox aria-label='Toggle' {...args} />
     </div>
   ),
 };
@@ -45,11 +45,11 @@ export const AllStates: Story = {
         <h3 className='heading-5'>Enabled</h3>
         <div className='space-y-8'>
           <div className='flex items-center space-x-8'>
-            <Checkbox checked={false} />
+            <Checkbox aria-label='Toggle' checked={false} />
             <span>Unchecked</span>
           </div>
           <div className='flex items-center space-x-8'>
-            <Checkbox checked />
+            <Checkbox aria-label='Toggle' checked />
             <span>Checked</span>
           </div>
         </div>
@@ -58,11 +58,11 @@ export const AllStates: Story = {
         <h3 className='heading-5'>Disabled</h3>
         <div className='space-y-8'>
           <div className='flex items-center space-x-8'>
-            <Checkbox disabled checked={false} />
+            <Checkbox aria-label='Toggle' disabled checked={false} />
             <span className='text-muted'>Unchecked</span>
           </div>
           <div className='flex items-center space-x-8'>
-            <Checkbox disabled checked />
+            <Checkbox aria-label='Toggle' disabled checked />
             <span className='text-muted'>Checked</span>
           </div>
         </div>
@@ -81,19 +81,30 @@ export const FormExample: Story = {
         <h3 className='body-1'>Subscribe to newsletters</h3>
         <div className='space-y-8'>
           <div className='flex items-center space-x-8'>
-            <Checkbox id='weekly' name='newsletter' value='weekly' />
+            <Checkbox
+              aria-label='Toggle'
+              id='weekly'
+              name='newsletter'
+              value='weekly'
+            />
             <label htmlFor='weekly' className='cursor-pointer body-3'>
               Weekly newsletter
             </label>
           </div>
           <div className='flex items-center space-x-8'>
-            <Checkbox id='monthly' name='newsletter' value='monthly' />
+            <Checkbox
+              aria-label='Toggle'
+              id='monthly'
+              name='newsletter'
+              value='monthly'
+            />
             <label htmlFor='monthly' className='cursor-pointer body-3'>
               Monthly newsletter
             </label>
           </div>
           <div className='flex items-center space-x-8'>
             <Checkbox
+              aria-label='Toggle'
               id='product-updates'
               name='newsletter'
               value='product-updates'
@@ -106,7 +117,7 @@ export const FormExample: Story = {
         </div>
       </div>
       <div className='flex items-center space-x-8'>
-        <Checkbox id='terms' name='terms' required />
+        <Checkbox aria-label='Toggle' id='terms' name='terms' required />
         <label htmlFor='terms' className='cursor-pointer body-3'>
           I agree to the{' '}
           <a href='#' onClick={(e) => e.preventDefault()} className='underline'>

--- a/libs/ui-react/src/lib/Components/DataTable/DataTable.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DataTable/DataTable.stories.tsx
@@ -506,7 +506,7 @@ export const WithGroupHeader: Story = {
           </>
         )}
       >
-        <DataTable className='max-h-480' />
+        <DataTable className='max-h-480' tabIndex={0} />
       </DataTableRoot>
     );
   },
@@ -626,7 +626,7 @@ export const WithoutStickyHeader: Story = {
 
     return (
       <DataTableRoot {...args} table={table}>
-        <DataTable className='max-h-400' />
+        <DataTable className='max-h-400' tabIndex={0} />
       </DataTableRoot>
     );
   },
@@ -752,7 +752,7 @@ export const WithGlobalFilter: Story = {
             </Button>
           </TableActionBarTrailing>
         </TableActionBar>
-        <DataTable className='max-h-400' />
+        <DataTable className='max-h-400' tabIndex={0} />
       </DataTableRoot>
     );
   },

--- a/libs/ui-react/src/lib/Components/DataTable/DataTable.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DataTable/DataTable.stories.tsx
@@ -538,7 +538,7 @@ export const WithCustomHeader: Story = {
             align: 'end',
             headerTrailingContent: (
               <Tooltip>
-                <TooltipTrigger asChild>
+                <TooltipTrigger aria-label='Open tooltip' asChild>
                   <TableInfoIcon />
                 </TooltipTrigger>
                 <TooltipContent>Total market capitalization</TooltipContent>
@@ -554,7 +554,7 @@ export const WithCustomHeader: Story = {
             align: 'end',
             headerTrailingContent: (
               <Tooltip>
-                <TooltipTrigger asChild>
+                <TooltipTrigger aria-label='Open tooltip' asChild>
                   <TableInfoIcon />
                 </TooltipTrigger>
                 <TooltipContent>

--- a/libs/ui-react/src/lib/Components/DescriptionItem/DescriptionItem.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DescriptionItem/DescriptionItem.stories.tsx
@@ -143,7 +143,7 @@ export const WithInfoIcon: Story = {
         <DescriptionItemLeading>
           <DescriptionItemLabel>Fees</DescriptionItemLabel>
           <Tooltip>
-            <TooltipTrigger>
+            <TooltipTrigger aria-label='Open tooltip'>
               <Information size={16} className='shrink-0 text-muted' />
             </TooltipTrigger>
             <TooltipContent>Network fee paid to miners</TooltipContent>
@@ -158,7 +158,7 @@ export const WithInfoIcon: Story = {
         <DescriptionItemLeading>
           <DescriptionItemLabel>Estimated time</DescriptionItemLabel>
           <Tooltip>
-            <TooltipTrigger>
+            <TooltipTrigger aria-label='Open tooltip'>
               <Information size={16} className='shrink-0 text-muted' />
             </TooltipTrigger>
             <TooltipContent>
@@ -236,7 +236,7 @@ export const WithSelect: Story = {
             value={network}
             onValueChange={setNetwork}
           >
-            <SelectTrigger label='Network' />
+            <SelectTrigger aria-label='Open tooltip' label='Network' />
             <SelectContent>
               <SelectList
                 renderItem={(item) => (

--- a/libs/ui-react/src/lib/Components/Design-tokens/animations/Animations.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Design-tokens/animations/Animations.stories.tsx
@@ -72,6 +72,7 @@ const AnimationDemo = ({
 
       <div className='relative'>
         <button
+          aria-label='Play animation'
           className='relative h-80 w-144 overflow-hidden rounded-sm border border-muted-subtle'
           onClick={handleTrigger}
         >

--- a/libs/ui-react/src/lib/Components/Design-tokens/styles/gradients.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Design-tokens/styles/gradients.stories.tsx
@@ -12,7 +12,7 @@ const GradientShowcase = () => (
   <div className='mb-32'>
     <div className='space-y-32'>
       <div>
-        <h4 className='mb-16 heading-5 text-base'>Directional Gradients</h4>
+        <h3 className='mb-16 heading-5 text-base'>Directional Gradients</h3>
         <div className='grid grid-cols-1 gap-16 sm:grid-cols-2'>
           {[
             { name: 'Top', class: 'bg-gradient-top' },
@@ -30,7 +30,7 @@ const GradientShowcase = () => (
       </div>
 
       <div>
-        <h4 className='mb-16 heading-5 text-base'>Status Gradients</h4>
+        <h3 className='mb-16 heading-5 text-base'>Status Gradients</h3>
         <div className='grid grid-cols-1 gap-16 sm:grid-cols-3'>
           {[
             { name: 'Error', class: 'bg-gradient-error' },
@@ -49,7 +49,7 @@ const GradientShowcase = () => (
       </div>
 
       <div>
-        <h4 className='mb-16 heading-5 text-base'>Asset Gradients</h4>
+        <h3 className='mb-16 heading-5 text-base'>Asset Gradients</h3>
         <div className='grid grid-cols-2 gap-16 sm:grid-cols-3 lg:grid-cols-6'>
           {[
             { name: 'Aion', class: 'bg-gradient-aion' },

--- a/libs/ui-react/src/lib/Components/Design-tokens/styles/scrollbar.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Design-tokens/styles/scrollbar.stories.tsx
@@ -21,6 +21,7 @@ const ScrollableBox = ({
 }) => (
   <div>
     <div
+      tabIndex={0}
       className={`h-224 overflow-y-auto rounded-lg border border-muted-subtle bg-canvas p-16 ${utilityClass}`}
     >
       {PLACEHOLDER_ITEMS.map((item) => (

--- a/libs/ui-react/src/lib/Components/DotIcon/DotIcon.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DotIcon/DotIcon.stories.tsx
@@ -49,16 +49,16 @@ export const PinShowcase: Story = {
   render: () => (
     <div className='flex items-center gap-32'>
       <DotIcon appearance='success' icon={ArrowDown} pin='bottom-end'>
-        <MediaImage src={parentSrc} shape='circle' />
+        <MediaImage src={parentSrc} shape='circle' aria-label='Arrow down' />
       </DotIcon>
       <DotIcon appearance='success' icon={ArrowDown} pin='top-end'>
-        <MediaImage src={parentSrc} shape='circle' />
+        <MediaImage src={parentSrc} shape='circle' aria-label='Arrow down' />
       </DotIcon>
       <DotIcon appearance='success' icon={ArrowDown} pin='bottom-start'>
-        <MediaImage src={parentSrc} shape='circle' />
+        <MediaImage src={parentSrc} shape='circle' aria-label='Arrow down' />
       </DotIcon>
       <DotIcon appearance='success' icon={ArrowDown} pin='top-start'>
-        <MediaImage src={parentSrc} shape='circle' />
+        <MediaImage src={parentSrc} shape='circle' aria-label='Arrow down' />
       </DotIcon>
     </div>
   ),
@@ -74,7 +74,12 @@ export const ShapeShowcase: Story = {
         shape='circle'
         pin='bottom-end'
       >
-        <MediaImage src={parentSrc} size={48} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={48}
+          shape='circle'
+          aria-label='Arrow down'
+        />
       </DotIcon>
       <DotIcon
         appearance='muted'
@@ -82,7 +87,12 @@ export const ShapeShowcase: Story = {
         shape='square'
         pin='bottom-end'
       >
-        <MediaImage src={parentSrc} size={48} shape='square' />
+        <MediaImage
+          src={parentSrc}
+          size={48}
+          shape='square'
+          aria-label='Arrow down'
+        />
       </DotIcon>
     </div>
   ),
@@ -98,7 +108,12 @@ export const AppearanceShowcase: Story = {
         size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
       >
-        <MediaImage src={parentSrc} size={48} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={48}
+          shape='circle'
+          aria-label='Arrow down'
+        />
       </DotIcon>
       <DotIcon
         appearance='muted'
@@ -106,7 +121,12 @@ export const AppearanceShowcase: Story = {
         size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
       >
-        <MediaImage src={parentSrc} size={48} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={48}
+          shape='circle'
+          aria-label='Arrow up'
+        />
       </DotIcon>
       <DotIcon
         appearance='error'
@@ -114,7 +134,12 @@ export const AppearanceShowcase: Story = {
         size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
       >
-        <MediaImage src={parentSrc} size={48} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={48}
+          shape='circle'
+          aria-label='Close'
+        />
       </DotIcon>
     </div>
   ),
@@ -131,7 +156,12 @@ export const DisabledShowcase: Story = {
         pin='bottom-end'
         disabled
       >
-        <MediaImage src={parentSrc} size={48} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={48}
+          shape='circle'
+          aria-label='Arrow down'
+        />
       </DotIcon>
       <DotIcon
         appearance='muted'
@@ -140,7 +170,12 @@ export const DisabledShowcase: Story = {
         pin='bottom-end'
         disabled
       >
-        <MediaImage src={parentSrc} size={48} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={48}
+          shape='circle'
+          aria-label='Arrow up'
+        />
       </DotIcon>
       <DotIcon
         appearance='error'
@@ -149,7 +184,12 @@ export const DisabledShowcase: Story = {
         pin='bottom-end'
         disabled
       >
-        <MediaImage src={parentSrc} size={48} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={48}
+          shape='circle'
+          aria-label='Close'
+        />
       </DotIcon>
     </div>
   ),
@@ -165,7 +205,12 @@ export const SizeShowcase: Story = {
         size={mediaImageDotIconSizeMap[40]}
         pin='bottom-end'
       >
-        <MediaImage src={parentSrc} size={40} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={40}
+          shape='circle'
+          aria-label='Link'
+        />
       </DotIcon>
       <DotIcon
         appearance='success'
@@ -173,7 +218,12 @@ export const SizeShowcase: Story = {
         size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
       >
-        <MediaImage src={parentSrc} size={48} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={48}
+          shape='circle'
+          aria-label='Star'
+        />
       </DotIcon>
       <DotIcon
         appearance='success'
@@ -181,7 +231,12 @@ export const SizeShowcase: Story = {
         size={mediaImageDotIconSizeMap[56]}
         pin='bottom-end'
       >
-        <MediaImage src={parentSrc} size={56} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={56}
+          shape='circle'
+          aria-label='Arrow down'
+        />
       </DotIcon>
       <DotIcon
         appearance='muted'
@@ -189,7 +244,12 @@ export const SizeShowcase: Story = {
         size={mediaImageDotIconSizeMap[64]}
         pin='bottom-end'
       >
-        <MediaImage src={parentSrc} size={64} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={64}
+          shape='circle'
+          aria-label='Spinner'
+        />
       </DotIcon>
       <DotIcon
         appearance='muted'
@@ -197,7 +257,12 @@ export const SizeShowcase: Story = {
         size={mediaImageDotIconSizeMap[72]}
         pin='bottom-end'
       >
-        <MediaImage src={parentSrc} size={72} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={72}
+          shape='circle'
+          aria-label='Spinner'
+        />
       </DotIcon>
     </div>
   ),

--- a/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.stories.tsx
+++ b/libs/ui-react/src/lib/Components/DotSymbol/DotSymbol.stories.tsx
@@ -47,16 +47,16 @@ export const PinShowcase: Story = {
     <div className='flex flex-col items-center gap-24'>
       <div className='flex items-center gap-32'>
         <DotSymbol src={dotSrc} pin='bottom-end'>
-          <MediaImage src={parentSrc} shape='circle' />
+          <MediaImage src={parentSrc} shape='circle' aria-label='Bitcoin' />
         </DotSymbol>
         <DotSymbol src={dotSrc} pin='top-end'>
-          <MediaImage src={parentSrc} shape='circle' />
+          <MediaImage src={parentSrc} shape='circle' aria-label='Bitcoin' />
         </DotSymbol>
         <DotSymbol src={dotSrc} pin='bottom-start'>
-          <MediaImage src={parentSrc} shape='circle' />
+          <MediaImage src={parentSrc} shape='circle' aria-label='Bitcoin' />
         </DotSymbol>
         <DotSymbol src={dotSrc} pin='top-start'>
-          <MediaImage src={parentSrc} shape='circle' />
+          <MediaImage src={parentSrc} shape='circle' aria-label='Bitcoin' />
         </DotSymbol>
       </div>
       <div className='flex items-center gap-32'>
@@ -83,19 +83,39 @@ export const ShapeShowcase: Story = {
     <div className='flex flex-col items-center gap-48 body-2'>
       <div className='inline-flex items-center gap-48'>
         <DotSymbol shape='square' src={dotSrc} pin='bottom-end'>
-          <MediaImage src={parentSrc} size={48} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={48}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol shape='square' src={dotSrc} pin='bottom-end'>
-          <MediaImage src={parentSrc} size={48} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={48}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
       </div>
 
       <div className='inline-flex items-center gap-48'>
         <DotSymbol src={dotSrc} pin='bottom-end'>
-          <MediaImage src={parentSrc} size={48} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={48}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol src={dotSrc} pin='bottom-end'>
-          <MediaImage src={parentSrc} size={48} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={48}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
       </div>
     </div>
@@ -107,10 +127,20 @@ export const DisabledShowcase: Story = {
   render: () => (
     <div className='flex items-center gap-32'>
       <DotSymbol src={dotSrc} pin='bottom-end' disabled>
-        <MediaImage src={parentSrc} size={48} shape='circle' />
+        <MediaImage
+          src={parentSrc}
+          size={48}
+          shape='circle'
+          aria-label='Bitcoin'
+        />
       </DotSymbol>
       <DotSymbol src={dotSrc} pin='bottom-end' shape='square' disabled>
-        <MediaImage src={parentSrc} size={48} shape='square' />
+        <MediaImage
+          src={parentSrc}
+          size={48}
+          shape='square'
+          aria-label='Bitcoin'
+        />
       </DotSymbol>
       <DotSymbol src={dotSrc} pin='bottom-end' disabled>
         <Spot appearance='icon' icon={CoinAlert} />
@@ -129,56 +159,96 @@ export const SizeShowcase: Story = {
           size={mediaImageDotSizeMap[20]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={20} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={20}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
           size={mediaImageDotSizeMap[24]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={24} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={24}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
           size={mediaImageDotSizeMap[32]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={32} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={32}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
           size={mediaImageDotSizeMap[40]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={40} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={40}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
           size={mediaImageDotSizeMap[48]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={48} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={48}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
           size={mediaImageDotSizeMap[56]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={56} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={56}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
           size={mediaImageDotSizeMap[64]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={64} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={64}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
           size={mediaImageDotSizeMap[72]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={72} shape='circle' />
+          <MediaImage
+            src={parentSrc}
+            size={72}
+            shape='circle'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
       </div>
       <div className='inline-flex items-end gap-24 body-2'>
@@ -188,7 +258,12 @@ export const SizeShowcase: Story = {
           size={mediaImageDotSizeMap[20]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={20} shape='square' />
+          <MediaImage
+            src={parentSrc}
+            size={20}
+            shape='square'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           shape='square'
@@ -196,7 +271,12 @@ export const SizeShowcase: Story = {
           size={mediaImageDotSizeMap[24]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={24} shape='square' />
+          <MediaImage
+            src={parentSrc}
+            size={24}
+            shape='square'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           shape='square'
@@ -204,7 +284,12 @@ export const SizeShowcase: Story = {
           size={mediaImageDotSizeMap[32]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={32} shape='square' />
+          <MediaImage
+            src={parentSrc}
+            size={32}
+            shape='square'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           shape='square'
@@ -212,7 +297,12 @@ export const SizeShowcase: Story = {
           size={mediaImageDotSizeMap[40]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={40} shape='square' />
+          <MediaImage
+            src={parentSrc}
+            size={40}
+            shape='square'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           shape='square'
@@ -220,7 +310,12 @@ export const SizeShowcase: Story = {
           size={mediaImageDotSizeMap[48]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={48} shape='square' />
+          <MediaImage
+            src={parentSrc}
+            size={48}
+            shape='square'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           shape='square'
@@ -228,7 +323,12 @@ export const SizeShowcase: Story = {
           size={mediaImageDotSizeMap[56]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={56} shape='square' />
+          <MediaImage
+            src={parentSrc}
+            size={56}
+            shape='square'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           shape='square'
@@ -236,7 +336,12 @@ export const SizeShowcase: Story = {
           size={mediaImageDotSizeMap[64]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={64} shape='square' />
+          <MediaImage
+            src={parentSrc}
+            size={64}
+            shape='square'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
         <DotSymbol
           shape='square'
@@ -244,7 +349,12 @@ export const SizeShowcase: Story = {
           size={mediaImageDotSizeMap[72]}
           pin='bottom-end'
         >
-          <MediaImage src={parentSrc} size={72} shape='square' />
+          <MediaImage
+            src={parentSrc}
+            size={72}
+            shape='square'
+            aria-label='Bitcoin'
+          />
         </DotSymbol>
       </div>
     </div>

--- a/libs/ui-react/src/lib/Components/ListItem/ListItem.stories.tsx
+++ b/libs/ui-react/src/lib/Components/ListItem/ListItem.stories.tsx
@@ -210,7 +210,7 @@ export const InteractiveShowcase: Story = {
               </ListItemContent>
             </ListItemLeading>
             <ListItemTrailing>
-              <Switch tabIndex={-1} selected={selected} />
+              <Switch aria-label='Toggle' tabIndex={-1} selected={selected} />
             </ListItemTrailing>
           </ListItem>
 
@@ -247,7 +247,11 @@ export const DisabledState: Story = {
           </ListItemContent>
         </ListItemLeading>
         <ListItemTrailing>
-          <Switch selected={false} disabled={args.disabled} />
+          <Switch
+            aria-label='Toggle'
+            selected={false}
+            disabled={args.disabled}
+          />
         </ListItemTrailing>
       </ListItem>
 

--- a/libs/ui-react/src/lib/Components/ListItem/ListItem.stories.tsx
+++ b/libs/ui-react/src/lib/Components/ListItem/ListItem.stories.tsx
@@ -95,7 +95,7 @@ export const DensityShowcase: Story = {
     <div className='flex max-w-320 flex-col gap-16'>
       <ListItem density='compact' onClick={() => {}}>
         <ListItemLeading>
-          <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />
+          <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} alt='Bitcoin' />
           <ListItemContent>
             <ListItemTitle>Compact with crypto icon</ListItemTitle>
           </ListItemContent>
@@ -119,7 +119,7 @@ export const DensityShowcase: Story = {
 
       <ListItem density='expanded' onClick={() => {}}>
         <ListItemLeading>
-          <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} />
+          <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={48} alt='Bitcoin' />
           <ListItemContent>
             <ListItemTitle>Expanded with crypto icon</ListItemTitle>
             <ListItemDescription>Additional information</ListItemDescription>

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.stories.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.stories.tsx
@@ -78,7 +78,12 @@ export const LeadingContentShapeShowcase: Story = {
         </MediaButton>
         <MediaButton
           leadingContent={
-            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} />
+            <CryptoIcon
+              ledgerId='bitcoin'
+              ticker='BTC'
+              size={32}
+              alt='Bitcoin'
+            />
           }
           leadingContentShape='rounded'
           appearance='gray'
@@ -98,7 +103,12 @@ export const LeadingContentShapeShowcase: Story = {
         </MediaButton>
         <MediaButton
           leadingContent={
-            <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />
+            <CryptoIcon
+              ledgerId='bitcoin'
+              ticker='BTC'
+              size={24}
+              alt='Bitcoin'
+            />
           }
           leadingContentShape='rounded'
           appearance='gray'
@@ -132,7 +142,12 @@ export const AllAppearancesWithLeadingShowcase: Story = {
             <MediaButton
               appearance={appearance}
               leadingContent={
-                <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} />
+                <CryptoIcon
+                  ledgerId='bitcoin'
+                  ticker='BTC'
+                  size={32}
+                  alt='Bitcoin'
+                />
               }
               leadingContentShape='rounded'
             >

--- a/libs/ui-react/src/lib/Components/MediaCard/MediaCard.stories.tsx
+++ b/libs/ui-react/src/lib/Components/MediaCard/MediaCard.stories.tsx
@@ -197,7 +197,7 @@ export const CompositionShowcase: Story = {
       </MediaCard>
 
       <MediaCard {...baseArgs}>
-        <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} />
+        <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={32} alt='Bitcoin' />
         <MediaCardTitle>With crypto icon</MediaCardTitle>
       </MediaCard>
     </div>

--- a/libs/ui-react/src/lib/Components/Menu/Menu.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.stories.tsx
@@ -76,6 +76,16 @@ export const Base: Story = {
 
 export const OpenByDefault: Story = {
   name: 'Open by Default',
+  parameters: {
+    a11y: {
+      config: {
+        rules: [
+          { id: 'aria-hidden-focus', enabled: false },
+          { id: 'aria-valid-attr-value', enabled: false },
+        ],
+      },
+    },
+  },
   render: () => (
     <Menu defaultOpen>
       <MenuTrigger

--- a/libs/ui-react/src/lib/Components/NavBar/NavBar.stories.tsx
+++ b/libs/ui-react/src/lib/Components/NavBar/NavBar.stories.tsx
@@ -243,7 +243,7 @@ export const WithCoinCapsule: Story = {
       <NavBarCoinCapsule
         ticker='BTC'
         leadingContent={
-          <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} />
+          <CryptoIcon ledgerId='bitcoin' ticker='BTC' size={24} alt='Bitcoin' />
         }
       />
       <NavBarTrailing>

--- a/libs/ui-react/src/lib/Components/SearchInput/SearchInput.stories.tsx
+++ b/libs/ui-react/src/lib/Components/SearchInput/SearchInput.stories.tsx
@@ -109,6 +109,7 @@ export const Error: Story = {
     helperText: 'Search term is invalid',
     status: 'error',
     className: 'max-w-md',
+    'aria-label': 'Search',
   },
   parameters: {
     docs: {

--- a/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
@@ -71,7 +71,7 @@ export const Base: Story = {
           onValueChange={setValue}
           disabled={args.disabled}
         >
-          <SelectTrigger label='Label' />
+          <SelectTrigger aria-label='Select option' label='Label' />
           <SelectContent>
             <SelectList
               renderItem={(item) => (
@@ -110,7 +110,7 @@ export const WithGroups: Story = {
     return (
       <div className='w-400'>
         <Select items={produceItems} value={value} onValueChange={setValue}>
-          <SelectTrigger label='Category' />
+          <SelectTrigger aria-label='Select option' label='Category' />
           <SelectContent>
             <SelectList
               renderItem={(item) => (
@@ -133,7 +133,7 @@ export const WithGroupsAndSearch: Story = {
     return (
       <div className='w-400'>
         <Select items={produceItems} value={value} onValueChange={setValue}>
-          <SelectTrigger label='Category' />
+          <SelectTrigger aria-label='Select category' label='Category' />
           <SelectContent>
             <SelectSearch placeholder='Search produce' />
             <SelectList
@@ -183,7 +183,7 @@ export const LongList: Story = {
     return (
       <div className='w-208'>
         <Select items={countryOptions} value={value} onValueChange={setValue}>
-          <SelectTrigger label='Country' />
+          <SelectTrigger aria-label='Select country' label='Country' />
           <SelectContent>
             <SelectList
               renderItem={(item) => (
@@ -206,7 +206,7 @@ export const WithSearch: Story = {
     return (
       <div className='w-400'>
         <Select items={countryOptions} value={value} onValueChange={setValue}>
-          <SelectTrigger label='Country' />
+          <SelectTrigger aria-label='Select country' label='Country' />
           <SelectContent>
             <SelectSearch placeholder='Search countries' />
             <SelectList
@@ -254,7 +254,7 @@ export const WithCustomFilter: Story = {
             );
           }}
         >
-          <SelectTrigger label='Token' />
+          <SelectTrigger aria-label='Select token' label='Token' />
           <SelectContent>
             <SelectSearch placeholder='Search by name or ticker' />
             <SelectList
@@ -291,7 +291,7 @@ export const Disabled: Story = {
     return (
       <div className='w-208'>
         <Select items={simpleOptions} disabled>
-          <SelectTrigger label='Disabled' />
+          <SelectTrigger aria-label='Select option' label='Disabled' />
           <SelectContent>
             <SelectList
               renderItem={(item) => (
@@ -312,7 +312,7 @@ export const WithDefaultValue: Story = {
     return (
       <div className='w-208'>
         <Select items={simpleOptions} defaultValue='option2'>
-          <SelectTrigger label='Label' />
+          <SelectTrigger aria-label='Select option' label='Label' />
           <SelectContent>
             <SelectList
               renderItem={(item) => (
@@ -339,7 +339,7 @@ export const WithDescription: Story = {
     return (
       <div className='w-208'>
         <Select items={descriptionOptions}>
-          <SelectTrigger label='Label' />
+          <SelectTrigger aria-label='Select option' label='Label' />
           <SelectContent>
             <SelectList
               renderItem={(item) => (
@@ -394,7 +394,7 @@ export const FormIntegration: Story = {
           name='category'
           required
         >
-          <SelectTrigger label='Category' />
+          <SelectTrigger aria-label='Select category' label='Category' />
           <SelectContent>
             <SelectList
               renderItem={(item) => (
@@ -413,7 +413,7 @@ export const FormIntegration: Story = {
           name='priority'
           required
         >
-          <SelectTrigger label='Priority' />
+          <SelectTrigger aria-label='Select priority' label='Priority' />
           <SelectContent>
             <SelectList
               renderItem={(item) => (
@@ -493,8 +493,9 @@ export const TriggerShowcase: Story = {
           onValueChange={setButtonValue}
         >
           <SelectTrigger
+            aria-label='Select account'
             render={({ selectedValue, selectedContent }) => (
-              <MediaButton>
+              <MediaButton aria-label='Select all accounts'>
                 {selectedValue ? selectedContent : 'All accounts'}
               </MediaButton>
             )}
@@ -512,8 +513,9 @@ export const TriggerShowcase: Story = {
 
         <Select items={accountOptions} disabled>
           <SelectTrigger
+            aria-label='Select option'
             render={({ selectedValue, selectedContent }) => (
-              <MediaButton>
+              <MediaButton aria-label='Select option'>
                 {selectedValue ? selectedContent : 'Disabled'}
               </MediaButton>
             )}
@@ -535,10 +537,12 @@ export const TriggerShowcase: Story = {
           onValueChange={setIconValue}
         >
           <SelectTrigger
+            aria-label='Select option'
             render={({ selectedValue, selectedContent }) => (
               <MediaButton
                 leadingContent={<Settings size={20} />}
                 leadingContentShape='flat'
+                aria-label='Select settings'
               >
                 {selectedValue ? selectedContent : 'Settings'}
               </MediaButton>
@@ -561,8 +565,10 @@ export const TriggerShowcase: Story = {
           onValueChange={setCryptoValue}
         >
           <SelectTrigger
+            aria-label='Select crypto'
             render={({ selectedValue, selectedContent }) => (
               <MediaButton
+                aria-label='Select network'
                 leadingContent={
                   selectedCrypto ? (
                     <CryptoIcon
@@ -602,8 +608,12 @@ export const TriggerShowcase: Story = {
           {appearances.map((appearance) => (
             <Select key={appearance} items={appearanceOptions}>
               <SelectTrigger
+                aria-label='Select appearance'
                 render={({ selectedValue, selectedContent }) => (
-                  <MediaButton appearance={appearance}>
+                  <MediaButton
+                    aria-label='Select appearance'
+                    appearance={appearance}
+                  >
                     {selectedValue ? selectedContent : appearance}
                   </MediaButton>
                 )}
@@ -627,8 +637,12 @@ export const TriggerShowcase: Story = {
           onValueChange={setCustomValue}
         >
           <SelectTrigger
+            aria-label='Select option'
             render={({ selectedValue, selectedContent }) => (
-              <button className='flex items-center gap-8 rounded-sm bg-muted px-16 py-12 body-2 text-base hover:bg-muted-hover'>
+              <button
+                aria-label='Select an option'
+                className='flex items-center gap-8 rounded-sm bg-muted px-16 py-12 body-2 text-base hover:bg-muted-hover'
+              >
                 {selectedValue ? (
                   selectedContent
                 ) : (
@@ -736,7 +750,7 @@ export const LeadingContentShowcase: Story = {
             value={smCoinValue}
             onValueChange={setSmCoinValue}
           >
-            <SelectTrigger label='Token' />
+            <SelectTrigger aria-label='Select token' label='Token' />
             <SelectContent>
               <SelectList
                 renderItem={(item) => (
@@ -761,7 +775,7 @@ export const LeadingContentShowcase: Story = {
             value={mdCoinValue}
             onValueChange={setMdCoinValue}
           >
-            <SelectTrigger label='Token' />
+            <SelectTrigger aria-label='Select token' label='Token' />
             <SelectContent>
               <SelectList
                 renderItem={(item) => (
@@ -791,7 +805,7 @@ export const LeadingContentShowcase: Story = {
             value={iconValue}
             onValueChange={setIconValue}
           >
-            <SelectTrigger label='Settings' />
+            <SelectTrigger aria-label='Select setting' label='Settings' />
             <SelectContent>
               <SelectList
                 renderItem={(item) => (
@@ -855,7 +869,7 @@ export const ControlledSearch: Story = {
           value={value}
           onValueChange={setValue}
         >
-          <SelectTrigger label='Assign reviewer' />
+          <SelectTrigger aria-label='Select reviewer' label='Assign reviewer' />
           <SelectContent>
             <SelectSearch placeholder='Search users...' />
             <SelectList

--- a/libs/ui-react/src/lib/Components/SideBar/SideBar.stories.tsx
+++ b/libs/ui-react/src/lib/Components/SideBar/SideBar.stories.tsx
@@ -138,7 +138,11 @@ export const CollapsedShowcase: Story = {
     <div className='flex h-480 gap-32'>
       <div>
         <div className='mb-8 body-3 text-muted'>Expanded</div>
-        <SideBar collapsed={false} active='home'>
+        <SideBar
+          collapsed={false}
+          active='home'
+          aria-label='Expanded navigation'
+        >
           <SideBarLeading>
             <SideBarItem
               value='home'

--- a/libs/ui-react/src/lib/Components/Subheader/Subheader.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Subheader/Subheader.stories.tsx
@@ -117,7 +117,7 @@ export const WithInfoIcon: Story = {
         <SubheaderRow>
           <SubheaderTitle>Section with Info</SubheaderTitle>
           <Tooltip>
-            <TooltipTrigger>
+            <TooltipTrigger aria-label='Open tooltip'>
               <SubheaderInfo />
             </TooltipTrigger>
             <TooltipContent>

--- a/libs/ui-react/src/lib/Components/Switch/Switch.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Switch/Switch.stories.tsx
@@ -27,15 +27,16 @@ export const Base: Story = {
       },
     },
   },
+  render: () => <Switch aria-label='Toggle example' />,
 };
 
 export const StatesShowcase: Story = {
   render: () => (
     <div className='flex items-center gap-32'>
-      <Switch selected={false} />
-      <Switch selected={true} />
-      <Switch disabled />
-      <Switch disabled selected={true} />
+      <Switch aria-label='Toggle' selected={false} />
+      <Switch aria-label='Toggle' selected={true} />
+      <Switch aria-label='Toggle' disabled />
+      <Switch aria-label='Toggle' disabled selected={true} />
     </div>
   ),
 };
@@ -43,8 +44,8 @@ export const StatesShowcase: Story = {
 export const SizesShowcase: Story = {
   render: () => (
     <div className='flex items-center gap-32'>
-      <Switch size='sm' />
-      <Switch size='md' />
+      <Switch aria-label='Toggle' size='sm' />
+      <Switch aria-label='Toggle' size='md' />
     </div>
   ),
 };

--- a/libs/ui-react/src/lib/Components/Table/Table.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Table/Table.stories.tsx
@@ -699,6 +699,7 @@ export const WithNetworkIconsAndActionBar: Story = {
                           ledgerId={cryptoIconLedgerIds[row.symbol]}
                           ticker={row.symbol}
                           size={40}
+                          alt={row.name}
                         />
                       }
                     />

--- a/libs/ui-react/src/lib/Components/Table/Table.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Table/Table.stories.tsx
@@ -426,7 +426,7 @@ export const WithCustomHeader: Story = {
                   children='Market cap long text that should be truncated'
                   trailingContent={
                     <Tooltip>
-                      <TooltipTrigger asChild>
+                      <TooltipTrigger aria-label='Open tooltip' asChild>
                         <TableInfoIcon />
                       </TooltipTrigger>
                       <TooltipContent>
@@ -439,7 +439,7 @@ export const WithCustomHeader: Story = {
                   align='end'
                   trailingContent={
                     <Tooltip>
-                      <TooltipTrigger asChild>
+                      <TooltipTrigger aria-label='Open tooltip' asChild>
                         <TableInfoIcon />
                       </TooltipTrigger>
                       <TooltipContent>
@@ -656,7 +656,9 @@ export const WithNetworkIconsAndActionBar: Story = {
             >
               <SelectTrigger
                 render={({ selectedContent }) => (
-                  <MediaButton>{selectedContent}</MediaButton>
+                  <MediaButton aria-label='Filter by category'>
+                    {selectedContent}
+                  </MediaButton>
                 )}
               />
               <SelectContent className='w-208'>

--- a/libs/ui-react/src/lib/Components/Table/Table.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Table/Table.stories.tsx
@@ -320,7 +320,7 @@ export const WithInfiniteLoading: Story = {
           loading={loading}
           onScrollBottom={loadMore}
         >
-          <Table>
+          <Table tabIndex={0}>
             <TableHeader>
               <TableHeaderRow>
                 <TableHeaderCell>Asset</TableHeaderCell>
@@ -359,7 +359,7 @@ export const WithoutStickyHeader: Story = {
   render: (args) => (
     <div className='w-3xl text-base'>
       <TableRoot {...args} className='h-320'>
-        <Table>
+        <Table tabIndex={0}>
           <TableHeader>
             <TableHeaderRow stickyHeader={false}>
               <TableHeaderCell className='w-224'>Asset</TableHeaderCell>

--- a/libs/ui-react/src/lib/Components/Tile/Tile.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Tile/Tile.stories.tsx
@@ -58,6 +58,14 @@ const meta: Meta<typeof Tile> = {
 export default meta;
 type Story = StoryObj<typeof Tile>;
 
+const tileSecondaryAction = (
+  <TileSecondaryAction
+    aria-label='More actions'
+    icon={MoreVertical}
+    onClick={() => console.log('secondary action clicked')}
+  />
+);
+
 export const Base: Story = {
   args: {
     appearance: 'no-background',
@@ -65,11 +73,7 @@ export const Base: Story = {
     centered: false,
   },
   render: (args) => (
-    <Tile {...args} className='w-112'>
-      <TileSecondaryAction
-        icon={MoreVertical}
-        onClick={() => console.log('secondary action clicked')}
-      />
+    <Tile {...args} className='w-112' secondaryAction={tileSecondaryAction}>
       <Spot appearance='icon' icon={Settings} />
       <TileContent>
         <TileTitle>Item with Spot and Description</TileTitle>
@@ -106,30 +110,14 @@ export const Base: Story = {
 export const VariantsShowcase: Story = {
   render: () => (
     <div className='flex flex-col gap-16'>
-      <Tile
-        className='max-w-160'
-        secondaryAction={
-          <TileSecondaryAction
-            icon={MoreVertical}
-            onClick={() => console.log('secondary action clicked')}
-          />
-        }
-      >
+      <Tile className='max-w-160' secondaryAction={tileSecondaryAction}>
         <Spot appearance='icon' icon={User} />
         <TileContent>
           <TileTitle>User</TileTitle>
           <TileDescription>With description</TileDescription>
         </TileContent>
       </Tile>
-      <Tile
-        className='max-w-160'
-        secondaryAction={
-          <TileSecondaryAction
-            icon={MoreVertical}
-            onClick={() => console.log('secondary action clicked')}
-          />
-        }
-      >
+      <Tile className='max-w-160' secondaryAction={tileSecondaryAction}>
         <Spot appearance='icon' icon={Plus} />
         <TileContent>
           <TileTitle>Without Description</TileTitle>
@@ -142,15 +130,7 @@ export const VariantsShowcase: Story = {
           <TileDescription>Additional information</TileDescription>
         </TileContent>
       </Tile>
-      <Tile
-        className='max-w-160'
-        secondaryAction={
-          <TileSecondaryAction
-            icon={MoreVertical}
-            onClick={() => console.log('secondary action clicked')}
-          />
-        }
-      >
+      <Tile className='max-w-160' secondaryAction={tileSecondaryAction}>
         <Spot appearance='icon' icon={Settings} />
         <TileContent>
           <TileTitle>With Trailing Content</TileTitle>
@@ -160,15 +140,7 @@ export const VariantsShowcase: Story = {
           </TileTrailingContent>
         </TileContent>
       </Tile>
-      <Tile
-        className='max-w-160'
-        secondaryAction={
-          <TileSecondaryAction
-            icon={MoreVertical}
-            onClick={() => console.log('secondary action clicked')}
-          />
-        }
-      >
+      <Tile className='max-w-160' secondaryAction={tileSecondaryAction}>
         <Spot appearance='icon' icon={Settings} />
         <TileContent>
           <TileTitle>With Trailing Content</TileTitle>
@@ -179,15 +151,7 @@ export const VariantsShowcase: Story = {
         </TileContent>
       </Tile>
 
-      <Tile
-        className='max-w-160'
-        secondaryAction={
-          <TileSecondaryAction
-            icon={MoreVertical}
-            onClick={() => console.log('secondary action clicked')}
-          />
-        }
-      >
+      <Tile className='max-w-160' secondaryAction={tileSecondaryAction}>
         <Spot appearance='icon' icon={Settings} />
         <TileContent>
           <TileTitle>With Trailing Content</TileTitle>
@@ -205,15 +169,7 @@ export const HorizontalList: Story = {
     <div className='flex flex-col gap-16'>
       <div className='flex w-480 bg-base'>
         {Array.from({ length: 3 }).map((_, i) => (
-          <Tile
-            key={`list-1-${i}`}
-            secondaryAction={
-              <TileSecondaryAction
-                icon={MoreVertical}
-                onClick={() => console.log('secondary action clicked')}
-              />
-            }
-          >
+          <Tile key={`list-1-${i}`} secondaryAction={tileSecondaryAction}>
             <Spot appearance='icon' icon={Apps} />
             <TileContent>
               <TileTitle>Item {i + 1}</TileTitle>
@@ -227,12 +183,7 @@ export const HorizontalList: Story = {
           <Tile
             key={`list-2-${i}`}
             className='w-128 shrink-0'
-            secondaryAction={
-              <TileSecondaryAction
-                icon={MoreVertical}
-                onClick={() => console.log('secondary action clicked')}
-              />
-            }
+            secondaryAction={tileSecondaryAction}
           >
             <Spot appearance='icon' icon={Apps} />
             <TileContent>


### PR DESCRIPTION
Closes [DLS-781](https://ledgerhq.atlassian.net/browse/DLS-781).

Because our current Chromatic plan does not allow checking a11y against specific branches, this needs to be merged to main for a final validation.

Nonetheless, these changes have been manually tested and a **reduction from 220 -> 28 a11y violations** is expected. These 28 are accounted below:

### Not fixed

* [The color contrast between text and its background meets WCAG AA contrast ratio.](https://dequeuniversity.com/rules/axe/4.10/color-contrast?application=axeAPI) (16 instances)
* [Do not nest interactive elements; it can confuse screen readers and keyboard focus.](https://dequeuniversity.com/rules/axe/4.10/nested-interactive?application=axeAPI) (12 instances)

[DLS-781]: https://ledgerhq.atlassian.net/browse/DLS-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ