### PR TITLE
fix(ui-react): add explicit fallback icon style to respond to theme

### DIFF
--- a/.nx/version-plans/version-plan-1782207836512.md
+++ b/.nx/version-plans/version-plan-1782207836512.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+fix(ui-react): add explicit fallback icon style to respond to theme

--- a/libs/ui-react/.storybook/preview-head.html
+++ b/libs/ui-react/.storybook/preview-head.html
@@ -4,6 +4,7 @@
   .sb-preparing-story,
   .sb-preparing-docs {
     background-color: #fff !important;
+    color: var(--text-base);
   }
 
   .dark body,

--- a/libs/ui-react/src/lib/Components/Avatar/Avatar.tsx
+++ b/libs/ui-react/src/lib/Components/Avatar/Avatar.tsx
@@ -100,6 +100,7 @@ export const Avatar = ({
     >
       {shouldFallback ? (
         <User
+          className='text-base'
           size={fallbackSizes[size]}
           aria-label='Fallback Icon'
           aria-hidden='true'


### PR DESCRIPTION
Closes [DLS-771](https://ledgerhq.atlassian.net/browse/DLS-771).

## Context

We handle theming on icons differently depending on the platform:

* On RN, the `Icon` component bakes in a default of `theme.colors.text.base` and forwards it to SVG `color` when no color is passed. IMO this is correct.

* On React however, the `Icon` component does not style anything. Only the SVG uses `currentColor`, which works via inheritance. In Storybook we never really set the `color` style at the `preview-head.html`, making it so there's no color for our component to inherit.

## Changes

They are two-fold:

* Added a `text-color` default to the web component following the same pattern we have on `MediaImage`. A defensive approach if the consumer uses it in another bare-context environment.

* Added `color: var(--text-base);` to Storybook body style so inheritance is set correctly for future components.

[DLS-771]: https://ledgerhq.atlassian.net/browse/DLS-771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ