### PR TITLE
[M]DLS-829-fix(Scrubber): prevent gesture handler from blocking vertical scroll

### DIFF
--- a/.nx/version-plans/version-plan-1782377682608.md
+++ b/.nx/version-plans/version-plan-1782377682608.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative-visualization': patch
+---
+
+fix(LineChart): prevent gesture handler from blocking vertical scroll

--- a/libs/ui-rnative-visualization/src/lib/Components/Scrubber/ScrubberProvider.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Scrubber/ScrubberProvider.tsx
@@ -153,7 +153,8 @@ export function ScrubberProvider({
       .onStart((e) => {
         'worklet';
         scheduleOnRN(handlePositionChange, e.x);
-      });
+      })
+      .onEnd(resetScrubber);
 
     const pan = Gesture.Pan()
       .activeOffsetX([-PAN_AXIS_THRESHOLD_PX, PAN_AXIS_THRESHOLD_PX])
@@ -162,7 +163,6 @@ export function ScrubberProvider({
         'worklet';
         scheduleOnRN(handlePositionChange, e.x);
       })
-      .onEnd(resetScrubber)
       .onFinalize(resetScrubber);
 
     return Gesture.Simultaneous(longPress, pan);

--- a/libs/ui-rnative-visualization/src/lib/Components/Scrubber/ScrubberProvider.tsx
+++ b/libs/ui-rnative-visualization/src/lib/Components/Scrubber/ScrubberProvider.tsx
@@ -2,7 +2,7 @@ import { triggerHapticFeedback } from '@ledgerhq/lumen-ui-rnative';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, { useSharedValue } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import { scheduleOnRN } from 'react-native-worklets';
 
 import { clamp } from '../../utils/numbers';
@@ -17,7 +17,11 @@ import {
   buildSortedMagnets,
 } from './utils';
 
-const LONG_PRESS_MIN_DURATION_MS = 50;
+const LONG_PRESS_MIN_DURATION_MS = 100;
+
+// Travel (px) past which a horizontal drag scrubs and a vertical drag fails
+// the pan (yielding to an ancestor scroll view). Also bounds the long press.
+const PAN_AXIS_THRESHOLD_PX = 10;
 
 /**
  * Provides scrubbing interaction for a chart.
@@ -27,10 +31,9 @@ const LONG_PRESS_MIN_DURATION_MS = 50;
  * gesture-capture `View` overlay). `CartesianChart` handles this positioning
  * automatically when `enableScrubbing` is true.
  *
- * Activation requires a 50 ms long press before panning begins. This prevents
- * accidental scrubbing when the user is scrolling a parent `ScrollView` or
- * `FlatList`. The `isScrubbing` shared value gates the pan via manual activation
- * so scroll and scrub gestures never compete.
+ * Scrubbing engages on horizontal panning (`activeOffsetX`) or a press-and-hold
+ * (`LongPress`); vertical movement fails the pan (`failOffsetY`) so an ancestor
+ * vertical scroll view keeps scrolling.
  */
 export function ScrubberProvider({
   children,
@@ -48,11 +51,9 @@ export function ScrubberProvider({
   const { getXScale, getXAxisConfig, dataLength } = useCartesianChartContext();
   const { getMagneticPoints, version } = useMagneticSnapshot();
 
-  // All values touched by the gesture's JS-thread callback live in a single
-  // ref. Reading via `latest.current` keeps the callbacks reference-stable
-  // across data, scale, and prop updates, which in turn keeps `composed` and
-  // the gesture surface JSX stable so re-rendering the provider on each
-  // index change never tears down the GestureDetector or the View tree.
+  // Gesture callbacks read everything through this ref so they stay
+  // reference-stable, keeping `composed` and the surface JSX from re-creating
+  // (which would tear down the GestureDetector) on each index change.
   const sortedMagnets = useMemo(() => {
     const magneticIndices = getMagneticPoints();
     return buildSortedMagnets({
@@ -140,29 +141,23 @@ export function ScrubberProvider({
     [setScrubberPositionAndNotify],
   );
 
-  const isScrubbing = useSharedValue(false);
-
   const resetScrubber = useCallback((): void => {
     'worklet';
-    isScrubbing.value = false;
     scheduleOnRN(handlePositionChange, null);
-  }, [isScrubbing, handlePositionChange]);
+  }, [handlePositionChange]);
 
   const composed = useMemo(() => {
     const longPress = Gesture.LongPress()
       .minDuration(LONG_PRESS_MIN_DURATION_MS)
+      .maxDistance(PAN_AXIS_THRESHOLD_PX)
       .onStart((e) => {
         'worklet';
-        isScrubbing.value = true;
         scheduleOnRN(handlePositionChange, e.x);
       });
 
     const pan = Gesture.Pan()
-      .manualActivation(true)
-      .onTouchesMove((_, manager) => {
-        'worklet';
-        if (isScrubbing.value) manager.activate();
-      })
+      .activeOffsetX([-PAN_AXIS_THRESHOLD_PX, PAN_AXIS_THRESHOLD_PX])
+      .failOffsetY([-PAN_AXIS_THRESHOLD_PX, PAN_AXIS_THRESHOLD_PX])
       .onUpdate((e) => {
         'worklet';
         scheduleOnRN(handlePositionChange, e.x);
@@ -171,12 +166,10 @@ export function ScrubberProvider({
       .onFinalize(resetScrubber);
 
     return Gesture.Simultaneous(longPress, pan);
-  }, [isScrubbing, handlePositionChange, resetScrubber]);
+  }, [handlePositionChange, resetScrubber]);
 
-  // Memoizing the surface lets React's element-identity bailout skip
-  // reconciling the View / GestureDetector / chart `children` subtree when
-  // only `scrubberPosition` changes. The Scrubber consumer still updates via
-  // context as expected.
+  // Memoized so a `scrubberPosition` change doesn't re-render the chart
+  // subtree; the Scrubber still updates through context.
   const surface = useMemo(
     () => (
       <View style={[{ width, height }, style]}>


### PR DESCRIPTION
## Overview

Problem: We previously were manually activating Scrubber with a simple boolean set to true upon longPress. This were blocking the drawing area spanning Gesture handler to a BEGAN state preventing the ScrollView container from receiving scroll gestures.

Solution: We now have a clear gesture contract with a proper exit condition.
- If a horizontal gesture is detected over the drawing area -> Scrubbing
- If a longPress of over 100ms is detected -> Scrubbing
- If a vertical scroll that spans over a 10px threshold is detected, we purposefully fail the scrubber gesture to let the container catch scroll.