### PR TITLE
chore: fix a11y button-name violation in Select stories

### DIFF
--- a/.nx/version-plans/version-plan-1782390322269.md
+++ b/.nx/version-plans/version-plan-1782390322269.md
@@ -1,0 +1,6 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+'@ledgerhq/lumen-ui-react': patch
+---
+
+chore: fix a11y button-name violation in Select stories

--- a/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Select/Select.stories.tsx
@@ -912,7 +912,10 @@ export const TypesafeFactory: StoryObj<typeof Select> = {
           value={network}
           onValueChange={setNetwork}
         >
-          <NetworkSelect.SelectTrigger label='Network' />
+          <NetworkSelect.SelectTrigger
+            aria-label='Select network'
+            label='Network'
+          />
           <NetworkSelect.SelectContent>
             <NetworkSelect.SelectList
               renderItem={(item) => (

--- a/libs/ui-rnative/src/lib/Components/TabBar/TabBar.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/TabBar/TabBar.stories.tsx
@@ -123,7 +123,7 @@ export const MissingLabel: Story = {
 type Route = 'home' | 'swap' | 'card' | 'help';
 const Nav = createTabBar<Route>();
 
-export const Typed: Story = {
+export const TypesafeFactory: Story = {
   args: {} as React.ComponentProps<typeof TabBar>,
   render: () => {
     const [active, setActive] = useState<Route>('home');


### PR DESCRIPTION
Leftover fixes for [DLS-781](https://ledgerhq.atlassian.net/browse/DLS-781) and [DLS-811](https://ledgerhq.atlassian.net/browse/DLS-811).

[DLS-781]: https://ledgerhq.atlassian.net/browse/DLS-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLS-811]: https://ledgerhq.atlassian.net/browse/DLS-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ