### PR TITLE
feat(TileButton): Introduce 'appearance' prop with gray and red variants

### DIFF
--- a/.nx/version-plans/version-plan-1783493181738.md
+++ b/.nx/version-plans/version-plan-1783493181738.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+feat(TileButton): Introduce `appearance` prop with `gray` and `red` variants.

--- a/.nx/version-plans/version-plan-1783493197985.md
+++ b/.nx/version-plans/version-plan-1783493197985.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+feat(TileButton): Introduce `appearance` prop with `gray` and `red` variants.

--- a/libs/ui-react/src/lib/Components/TileButton/TileButton.figma.tsx
+++ b/libs/ui-react/src/lib/Components/TileButton/TileButton.figma.tsx
@@ -16,6 +16,10 @@ figma.connect(
       disabled: figma.enum('state', {
         disabled: true,
       }),
+      appearance: figma.enum('appearance', {
+        gray: 'gray',
+        red: 'red',
+      }),
       children: figma.string('label'),
       icon: Placeholder,
     },
@@ -24,7 +28,11 @@ figma.connect(
         icon: any;
       },
     ) => (
-      <TileButton disabled={props.disabled} icon={props.icon}>
+      <TileButton
+        disabled={props.disabled}
+        appearance={props.appearance}
+        icon={props.icon}
+      >
         {props.children}
       </TileButton>
     ),

--- a/libs/ui-react/src/lib/Components/TileButton/TileButton.mdx
+++ b/libs/ui-react/src/lib/Components/TileButton/TileButton.mdx
@@ -2,8 +2,8 @@ import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as TileButtonStories from './TileButton.stories';
 import { TileButton } from './TileButton';
 import {
-    CustomTabs,
-    Tab,
+  CustomTabs,
+  Tab,
   SetupNote,
 } from '../../../../.storybook/components';
 import { Settings, Plus } from '../../Symbols';
@@ -35,9 +35,18 @@ TileButton is a compact interactive component that displays an icon above a labe
 <Canvas of={TileButtonStories.Base} />
 <Controls of={TileButtonStories.Base} />
 
+### Appearance
+
+TileButton comes in two appearances:
+
+- **gray** (default): neutral surface background with base text and icon color
+- **red**: same surface background but with red text and icon, for destructive or error actions
+
+<Canvas of={TileButtonStories.AppearanceShowcase} />
+
 ### States
 
-TileButton supports default, hover, pressed, and disabled states:
+TileButton supports default, hover, pressed, and disabled states. The disabled state renders identically regardless of appearance:
 
 <Canvas of={TileButtonStories.DisabledShowcase} />
 

--- a/libs/ui-react/src/lib/Components/TileButton/TileButton.stories.tsx
+++ b/libs/ui-react/src/lib/Components/TileButton/TileButton.stories.tsx
@@ -33,6 +33,10 @@ const meta: Meta<typeof TileButton> = {
       mapping: iconOptions,
       control: { type: 'select' },
     },
+    appearance: {
+      options: ['gray', 'red'],
+      control: { type: 'select' },
+    },
     onClick: {
       action: 'clicked',
     },
@@ -56,13 +60,30 @@ export const Base: Story = {
   },
 };
 
+export const AppearanceShowcase: Story = {
+  render: () => (
+    <div className='flex flex-col gap-16'>
+      <div className='flex gap-16'>
+        <TileButton icon={Settings}>Gray</TileButton>
+        <TileButton icon={Settings} appearance='red'>
+          Red
+        </TileButton>
+      </div>
+    </div>
+  ),
+};
+
 export const DisabledShowcase: Story = {
   render: () => (
     <div className='flex gap-16'>
-      <TileButton icon={Settings}>Enabled</TileButton>
-      <TileButton icon={Settings} disabled>
-        Disabled
-      </TileButton>
+      <div className='flex gap-16'>
+        <TileButton icon={Settings} disabled>
+          Gray disabled
+        </TileButton>
+        <TileButton icon={Settings} appearance='red' disabled>
+          Red disabled
+        </TileButton>
+      </div>
     </div>
   ),
 };

--- a/libs/ui-react/src/lib/Components/TileButton/TileButton.test.tsx
+++ b/libs/ui-react/src/lib/Components/TileButton/TileButton.test.tsx
@@ -80,6 +80,38 @@ describe('TileButton Component', () => {
     });
   });
 
+  describe('Appearance', () => {
+    it('should apply gray appearance classes by default', () => {
+      render(<TileButton icon={Settings}>Settings</TileButton>);
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('text-base');
+    });
+
+    it('should apply red appearance classes when appearance is red', () => {
+      render(
+        <TileButton icon={Settings} appearance='red'>
+          Settings
+        </TileButton>,
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('text-error');
+    });
+
+    it('should override red appearance with disabled styles when disabled', () => {
+      render(
+        <TileButton icon={Settings} appearance='red' disabled>
+          Settings
+        </TileButton>,
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('text-disabled');
+      expect(button).not.toHaveClass('text-error');
+    });
+  });
+
   describe('Custom Styling', () => {
     it('should apply custom className', () => {
       const customClass = 'custom-test-class';

--- a/libs/ui-react/src/lib/Components/TileButton/TileButton.tsx
+++ b/libs/ui-react/src/lib/Components/TileButton/TileButton.tsx
@@ -7,13 +7,17 @@ import type { TileButtonProps } from './types';
 const tileButtonVariants = cva(
   [
     'flex flex-col items-center gap-8 rounded-md p-12',
-    'bg-surface body-2-semi-bold text-base transition-colors',
+    'bg-surface body-2-semi-bold transition-colors',
     'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus',
   ],
   {
     variants: {
+      appearance: {
+        gray: 'text-base',
+        red: 'text-error',
+      },
       disabled: {
-        true: 'bg-disabled text-disabled cursor-not-allowed',
+        true: 'cursor-not-allowed bg-disabled text-disabled',
         false:
           'hover:bg-surface-hover active:bg-surface-pressed cursor-pointer',
       },
@@ -22,6 +26,7 @@ const tileButtonVariants = cva(
       },
     },
     defaultVariants: {
+      appearance: 'gray',
       disabled: false,
       isFull: false,
     },
@@ -30,12 +35,16 @@ const tileButtonVariants = cva(
 
 const iconVariants = cva('shrink-0', {
   variants: {
+    appearance: {
+      gray: 'text-base',
+      red: 'text-error',
+    },
     disabled: {
       true: 'text-disabled',
-      false: 'text-base',
     },
   },
   defaultVariants: {
+    appearance: 'gray',
     disabled: false,
   },
 });
@@ -69,6 +78,7 @@ export const TileButton = ({
   onClick,
   disabled: disabledProp = false,
   isFull = false,
+  appearance = 'gray',
   className,
   asChild = false,
   'aria-label': ariaLabel,
@@ -95,14 +105,17 @@ export const TileButton = ({
     <Comp
       ref={ref}
       type={asChild ? undefined : 'button'}
-      className={cn(tileButtonVariants({ disabled, isFull }), className)}
+      className={cn(
+        tileButtonVariants({ disabled, isFull, appearance }),
+        className,
+      )}
       onClick={handleClick}
       disabled={disabled}
       data-disabled={disabled || undefined}
       aria-label={ariaLabel}
       {...props}
     >
-      <Icon size={20} className={iconVariants({ disabled })} />
+      <Icon size={20} className={iconVariants({ disabled, appearance })} />
       {asChild ? (
         <Slottable>{children}</Slottable>
       ) : (

--- a/libs/ui-react/src/lib/Components/TileButton/types.ts
+++ b/libs/ui-react/src/lib/Components/TileButton/types.ts
@@ -31,6 +31,11 @@ export type TileButtonProps = {
    */
   isFull?: boolean;
   /**
+   * The visual appearance of the button.
+   * @default 'gray'
+   */
+  appearance?: 'gray' | 'red';
+  /**
    * Additional CSS classes for layout adjustments.
    */
   className?: string;

--- a/libs/ui-rnative/src/lib/Components/TileButton/TileButton.figma.tsx
+++ b/libs/ui-rnative/src/lib/Components/TileButton/TileButton.figma.tsx
@@ -15,6 +15,10 @@ figma.connect(
       disabled: figma.enum('state', {
         disabled: true,
       }),
+      appearance: figma.enum('appearance', {
+        gray: 'gray',
+        red: 'red',
+      }),
       children: figma.string('label'),
       icon: Placeholder,
     },
@@ -25,6 +29,7 @@ figma.connect(
     ) => (
       <TileButton
         disabled={props.disabled}
+        appearance={props.appearance}
         icon={props.icon}
         onPress={() => {}}
       >

--- a/libs/ui-rnative/src/lib/Components/TileButton/TileButton.mdx
+++ b/libs/ui-rnative/src/lib/Components/TileButton/TileButton.mdx
@@ -30,9 +30,18 @@ TileButton is a compact interactive component that displays an icon above a labe
 <Canvas of={TileButtonStories.Base} />
 <Controls of={TileButtonStories.Base} />
 
+### Appearance
+
+TileButton comes in two appearances:
+
+- **gray** (default): neutral surface background with base text and icon color
+- **red**: same surface background but with red text and icon, for destructive or error actions
+
+<Canvas of={TileButtonStories.AppearanceShowcase} />
+
 ### States
 
-TileButton supports default, pressed, and disabled states:
+TileButton supports default, pressed, and disabled states. The disabled state renders identically regardless of appearance:
 
 <Canvas of={TileButtonStories.DisabledShowcase} />
 
@@ -104,6 +113,16 @@ function ActionGrid() {
     </View>
   );
 }
+```
+
+## Appearance
+
+Use the `appearance` prop to switch to the red (destructive) variant:
+
+```tsx
+<TileButton icon={Trash} appearance='red' onPress={() => {}}>
+  Delete
+</TileButton>
 ```
 
 ## Full Width

--- a/libs/ui-rnative/src/lib/Components/TileButton/TileButton.mdx
+++ b/libs/ui-rnative/src/lib/Components/TileButton/TileButton.mdx
@@ -115,16 +115,6 @@ function ActionGrid() {
 }
 ```
 
-## Appearance
-
-Use the `appearance` prop to switch to the red (destructive) variant:
-
-```tsx
-<TileButton icon={Trash} appearance='red' onPress={() => {}}>
-  Delete
-</TileButton>
-```
-
 ## Full Width
 
 Use the `isFull` prop to make the button take the full width of its container:

--- a/libs/ui-rnative/src/lib/Components/TileButton/TileButton.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/TileButton/TileButton.stories.tsx
@@ -62,19 +62,6 @@ export const AppearanceShowcase: Story = {
           Red
         </TileButton>
       </View>
-      <View style={{ flexDirection: 'row', gap: 16 }}>
-        <TileButton icon={Settings} onPress={args.onPress} disabled>
-          Gray disabled
-        </TileButton>
-        <TileButton
-          icon={Settings}
-          appearance='red'
-          onPress={args.onPress}
-          disabled
-        >
-          Red disabled
-        </TileButton>
-      </View>
     </View>
   ),
 };
@@ -82,11 +69,16 @@ export const AppearanceShowcase: Story = {
 export const DisabledShowcase: Story = {
   render: (args) => (
     <View style={{ flexDirection: 'row', gap: 16 }}>
-      <TileButton icon={Settings} onPress={args.onPress}>
-        Enabled
-      </TileButton>
       <TileButton icon={Settings} onPress={args.onPress} disabled>
-        Disabled
+        Gray disabled
+      </TileButton>
+      <TileButton
+        icon={Settings}
+        appearance='red'
+        onPress={args.onPress}
+        disabled
+      >
+        Red disabled
       </TileButton>
     </View>
   ),

--- a/libs/ui-rnative/src/lib/Components/TileButton/TileButton.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/TileButton/TileButton.stories.tsx
@@ -23,6 +23,10 @@ const meta: Meta<typeof TileButton> = {
       mapping: iconOptions,
       control: { type: 'select' },
     },
+    appearance: {
+      options: ['gray', 'red'],
+      control: { type: 'select' },
+    },
     onPress: {
       action: 'pressed',
     },
@@ -45,6 +49,34 @@ export const Base: Story = {
       },
     },
   },
+};
+
+export const AppearanceShowcase: Story = {
+  render: (args) => (
+    <View style={{ gap: 16 }}>
+      <View style={{ flexDirection: 'row', gap: 16 }}>
+        <TileButton icon={Settings} onPress={args.onPress}>
+          Gray
+        </TileButton>
+        <TileButton icon={Settings} appearance='red' onPress={args.onPress}>
+          Red
+        </TileButton>
+      </View>
+      <View style={{ flexDirection: 'row', gap: 16 }}>
+        <TileButton icon={Settings} onPress={args.onPress} disabled>
+          Gray disabled
+        </TileButton>
+        <TileButton
+          icon={Settings}
+          appearance='red'
+          onPress={args.onPress}
+          disabled
+        >
+          Red disabled
+        </TileButton>
+      </View>
+    </View>
+  ),
 };
 
 export const DisabledShowcase: Story = {

--- a/libs/ui-rnative/src/lib/Components/TileButton/TileButton.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/TileButton/TileButton.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { ledgerLiveThemes } from '@ledgerhq/lumen-design-core';
 import { render, screen, fireEvent } from '@testing-library/react-native';
-import type { ViewStyle } from 'react-native';
+import type { TextStyle, ViewStyle } from 'react-native';
 
 import { Settings } from '../../Symbols';
 import { ThemeProvider } from '../ThemeProvider/ThemeProvider';
@@ -98,6 +98,40 @@ describe('TileButton Component', () => {
       );
       const button = screen.getByTestId('tile-button');
       expect(button.props.style).toBeDefined();
+    });
+  });
+
+  describe('Appearances', () => {
+    const { dark: darkTheme } = ledgerLiveThemes;
+
+    it.each([
+      ['gray' as const, darkTheme.colors.text.base],
+      ['red' as const, darkTheme.colors.text.error],
+    ])(
+      'should apply correct text color for %s appearance',
+      (appearance, expectedColor) => {
+        renderWithProvider(
+          <TileButton icon={Settings} appearance={appearance}>
+            Label
+          </TileButton>,
+        );
+
+        const label = screen.getByText('Label');
+        const style = label.props.style as TextStyle;
+        expect(style.color).toBe(expectedColor);
+      },
+    );
+
+    it('should override red appearance with disabled color when disabled', () => {
+      renderWithProvider(
+        <TileButton icon={Settings} appearance='red' disabled>
+          Label
+        </TileButton>,
+      );
+
+      const label = screen.getByText('Label');
+      const style = label.props.style as TextStyle;
+      expect(style.color).toBe(darkTheme.colors.text.disabled);
     });
   });
 });

--- a/libs/ui-rnative/src/lib/Components/TileButton/TileButton.tsx
+++ b/libs/ui-rnative/src/lib/Components/TileButton/TileButton.tsx
@@ -26,40 +26,55 @@ const useStyles = ({
   disabled,
   pressed,
   isFull,
+  appearance,
 }: {
   disabled: boolean;
   pressed: boolean;
   isFull: boolean;
+  appearance: 'gray' | 'red';
 }) => {
   return useStyleSheet(
-    (t) => ({
-      container: StyleSheet.flatten([
-        {
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: t.spacings.s8,
-          padding: t.spacings.s12,
-          borderRadius: t.borderRadius.md,
-          backgroundColor: t.colors.bg.surface,
+    (t) => {
+      const foregroundColors: Record<'gray' | 'red', string> = {
+        gray: t.colors.text.base,
+        red: t.colors.text.error,
+      };
+      const foregroundColor = disabled
+        ? t.colors.text.disabled
+        : foregroundColors[appearance];
+
+      return {
+        container: StyleSheet.flatten([
+          {
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: t.spacings.s8,
+            padding: t.spacings.s12,
+            borderRadius: t.borderRadius.md,
+            backgroundColor: t.colors.bg.surface,
+          },
+          isFull && { width: t.sizes.full },
+          pressed &&
+            !disabled && {
+              backgroundColor: t.colors.bg.surfacePressed,
+            },
+          disabled && { backgroundColor: t.colors.bg.disabled },
+        ]),
+        label: StyleSheet.flatten([
+          t.typographies.body2SemiBold,
+          {
+            textAlign: 'center',
+            color: foregroundColor,
+          },
+        ]),
+        icon: {
+          flexShrink: 0,
+          color: foregroundColor,
         },
-        isFull && { width: t.sizes.full },
-        pressed && !disabled && { backgroundColor: t.colors.bg.surfacePressed },
-        disabled && { backgroundColor: t.colors.bg.disabled },
-      ]),
-      label: StyleSheet.flatten([
-        t.typographies.body2SemiBold,
-        {
-          textAlign: 'center',
-          color: disabled ? t.colors.text.disabled : t.colors.text.base,
-        },
-      ]),
-      icon: {
-        flexShrink: 0,
-        color: disabled ? t.colors.text.disabled : t.colors.text.base,
-      },
-    }),
-    [disabled, pressed, isFull],
+      };
+    },
+    [disabled, pressed, isFull, appearance],
   );
 };
 
@@ -84,6 +99,7 @@ export const TileButton = ({
   children,
   disabled: disabledProp = false,
   isFull = false,
+  appearance = 'gray',
   numberOfLines = 2,
   ...props
 }: TileButtonProps) => {
@@ -107,6 +123,7 @@ export const TileButton = ({
           disabled={disabled}
           pressed={pressed}
           isFull={isFull}
+          appearance={appearance}
           IconProp={IconProp}
           numberOfLines={numberOfLines}
         >
@@ -121,6 +138,7 @@ type TileButtonContentProps = PropsWithChildren<{
   disabled: boolean;
   pressed: boolean;
   isFull: boolean;
+  appearance: 'gray' | 'red';
   IconProp: TileButtonProps['icon'];
   numberOfLines?: number;
 }>;
@@ -129,11 +147,12 @@ const TileButtonContent: FC<TileButtonContentProps> = ({
   disabled,
   pressed,
   isFull,
+  appearance,
   IconProp,
   numberOfLines,
   children,
 }) => {
-  const styles = useStyles({ disabled, pressed, isFull });
+  const styles = useStyles({ disabled, pressed, isFull, appearance });
 
   return (
     <View style={styles.container} testID='tile-button-content'>

--- a/libs/ui-rnative/src/lib/Components/TileButton/types.ts
+++ b/libs/ui-rnative/src/lib/Components/TileButton/types.ts
@@ -24,6 +24,11 @@ export type TileButtonProps = {
    */
   isFull?: boolean;
   /**
+   * The visual appearance of the button.
+   * @default 'gray'
+   */
+  appearance?: 'gray' | 'red';
+  /**
    * Maximum number of lines for the label text.
    * Text will be truncated with ellipsis if it exceeds this limit.
    * @default 2


### PR DESCRIPTION
<img width="1109" height="674" alt="image" src="https://github.com/user-attachments/assets/0b05eb6d-927e-46c5-a81c-a85b63aa5beb" />
