### PR TITLE
feat(Menu): add red (destructive) appearance to MenuItem

### DIFF
--- a/.nx/version-plans/version-plan-1783509758528.md
+++ b/.nx/version-plans/version-plan-1783509758528.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+feat(Menu): add red (destructive) appearance to MenuItem

--- a/libs/ui-react/src/lib/Components/Menu/Menu.mdx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.mdx
@@ -67,6 +67,12 @@ Organize related items:
 
 <Canvas of={MenuStories.WithGroups} />
 
+### Item Appearance
+
+Use the `appearance` prop on `MenuItem` to signal intent. Defaults to `base`. Set `red` for destructive actions such as deleting or removing:
+
+<Canvas of={MenuStories.Appearance} />
+
 ### Disabled State
 
 Items can be disabled to prevent interaction:

--- a/libs/ui-react/src/lib/Components/Menu/Menu.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
+import { Duplicate, PenEdit, Trash } from '../../Symbols';
 import { MoreVertical } from '../../Symbols/Icons/MoreVertical';
 import { Button } from '../Button/Button';
 import { IconButton } from '../IconButton';
@@ -282,10 +283,19 @@ export const Appearance: Story = {
         }
       />
       <MenuContent className='w-208'>
-        <MenuItem>Edit</MenuItem>
-        <MenuItem>Duplicate</MenuItem>
+        <MenuItem>
+          <PenEdit />
+          Edit
+        </MenuItem>
+        <MenuItem>
+          <Duplicate />
+          Duplicate
+        </MenuItem>
         <MenuSeparator />
-        <MenuItem appearance='red'>Delete</MenuItem>
+        <MenuItem appearance='red'>
+          <Trash />
+          Delete
+        </MenuItem>
       </MenuContent>
     </Menu>
   ),

--- a/libs/ui-react/src/lib/Components/Menu/Menu.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.stories.tsx
@@ -270,6 +270,27 @@ export const Disabled: Story = {
   ),
 };
 
+export const Appearance: Story = {
+  name: 'Item Appearance',
+  render: () => (
+    <Menu>
+      <MenuTrigger
+        render={
+          <Button appearance='gray' size='md'>
+            Open Menu
+          </Button>
+        }
+      />
+      <MenuContent className='w-208'>
+        <MenuItem>Edit</MenuItem>
+        <MenuItem>Duplicate</MenuItem>
+        <MenuSeparator />
+        <MenuItem appearance='red'>Delete</MenuItem>
+      </MenuContent>
+    </Menu>
+  ),
+};
+
 export const PositionShowcase: Story = {
   render: () => (
     <div className='flex items-center gap-16'>

--- a/libs/ui-react/src/lib/Components/Menu/Menu.tsx
+++ b/libs/ui-react/src/lib/Components/Menu/Menu.tsx
@@ -57,20 +57,33 @@ const contentStyles = cva(
   },
 );
 
-const itemStyles = cn(
-  'relative flex cursor-default items-center gap-12 select-none',
-  'h-44 rounded-sm px-8 outline-hidden',
-  'body-2-semi-bold text-base',
-  'transition-colors',
-  'data-highlighted:bg-base-transparent-hover',
-  'active:bg-base-transparent-pressed',
-  'data-disabled:pointer-events-none data-disabled:text-disabled',
+const itemStyles = cva(
+  cn(
+    'relative flex cursor-default items-center gap-12 select-none',
+    'h-44 rounded-sm px-8 outline-hidden',
+    'body-2-semi-bold',
+    'transition-colors',
+    'data-highlighted:bg-base-transparent-hover',
+    'active:bg-base-transparent-pressed',
+    'data-disabled:pointer-events-none data-disabled:text-disabled',
+  ),
+  {
+    variants: {
+      appearance: {
+        base: 'text-base',
+        red: 'text-error',
+      },
+    },
+    defaultVariants: {
+      appearance: 'base',
+    },
+  },
 );
 
 const labelStyles = cn('px-8 py-4 body-3-semi-bold text-muted');
 
 const subTriggerStyles = cn(
-  itemStyles,
+  itemStyles(),
   'data-popup-open:bg-base-transparent-hover',
 );
 
@@ -177,6 +190,7 @@ const MenuContent = ({
 const MenuItem = ({
   ref,
   className,
+  appearance = 'base',
   disabled: disabledProp,
   onClick,
   label,
@@ -196,7 +210,7 @@ const MenuItem = ({
         label={label}
         disabled={disabled}
         closeOnClick={closeOnClick}
-        className={cn(itemStyles, className)}
+        className={cn(itemStyles({ appearance }), className)}
         onClick={onClick}
         {...props}
       />
@@ -231,7 +245,7 @@ const MenuCheckboxItem = ({
         defaultChecked={defaultChecked}
         disabled={disabled}
         closeOnClick={closeOnClick ?? false}
-        className={cn(itemStyles, className)}
+        className={cn(itemStyles(), className)}
         onCheckedChange={onCheckedChange}
         {...props}
       >
@@ -264,7 +278,7 @@ const MenuRadioItem = <T extends MenuRadioValue = MenuRadioValue>({
         ref={ref}
         data-slot='menu-radio-item'
         disabled={disabled}
-        className={cn(itemStyles, className)}
+        className={cn(itemStyles(), className)}
         {...props}
       >
         {children}

--- a/libs/ui-react/src/lib/Components/Menu/types.ts
+++ b/libs/ui-react/src/lib/Components/Menu/types.ts
@@ -124,6 +124,12 @@ export type MenuItemProps = {
    */
   className?: string;
 
+  /**
+   * The visual appearance of the item, used to signal intent.
+   * Use `red` for destructive actions such as deleting.
+   *
+   * @default 'base'
+   */
   appearance?: 'base' | 'red';
 
   /**

--- a/libs/ui-react/src/lib/Components/Menu/types.ts
+++ b/libs/ui-react/src/lib/Components/Menu/types.ts
@@ -124,6 +124,8 @@ export type MenuItemProps = {
    */
   className?: string;
 
+  appearance?: 'base' | 'red';
+
   /**
    * When `true`, prevents the user from interacting with the item.
    *

--- a/libs/ui-react/src/lib/Components/Menu/types.ts
+++ b/libs/ui-react/src/lib/Components/Menu/types.ts
@@ -126,7 +126,6 @@ export type MenuItemProps = {
 
   /**
    * The visual appearance of the item, used to signal intent.
-   * Use `red` for destructive actions such as deleting.
    *
    * @default 'base'
    */


### PR DESCRIPTION
Closes [DLS-884](https://ledgerhq.atlassian.net/browse/DLS-884).

## Demo

<img width="264" height="234" alt="image" src="https://github.com/user-attachments/assets/473e50b2-4adb-4b8d-848d-b6faca679048" />


[DLS-884]: https://ledgerhq.atlassian.net/browse/DLS-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ