### PR TITLE
fix(Button): default native buttons to type="button"

### DIFF
--- a/.nx/version-plans/version-plan-1786240008000-ui-react.md
+++ b/.nx/version-plans/version-plan-1786240008000-ui-react.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+fix(Button): default native buttons (`BaseButton`, `MediaButton`, `CardButton`) to `type="button"` so they no longer accidentally submit a surrounding `<form>`; callers can still opt into `type="submit"`/`"reset"`, and `asChild` renders are left untouched

--- a/libs/ui-react/src/lib/Components/Button/BaseButton.tsx
+++ b/libs/ui-react/src/lib/Components/Button/BaseButton.tsx
@@ -114,6 +114,11 @@ export const BaseButton = ({
       data-disabled={disabled || undefined}
       disabled={disabled}
       onClick={onClick}
+      // Default native buttons to type="button" so they do not accidentally
+      // submit a surrounding form. Placed before {...props} so a caller can
+      // still opt into type="submit"/"reset". Skipped for asChild, where the
+      // rendered element (e.g. an anchor) is not a native button.
+      {...(asChild ? {} : { type: 'button' as const })}
       {...props}
     >
       {loading && (

--- a/libs/ui-react/src/lib/Components/Button/BaseButton.tsx
+++ b/libs/ui-react/src/lib/Components/Button/BaseButton.tsx
@@ -114,10 +114,6 @@ export const BaseButton = ({
       data-disabled={disabled || undefined}
       disabled={disabled}
       onClick={onClick}
-      // Default native buttons to type="button" so they do not accidentally
-      // submit a surrounding form. Placed before {...props} so a caller can
-      // still opt into type="submit"/"reset". Skipped for asChild, where the
-      // rendered element (e.g. an anchor) is not a native button.
       {...(asChild ? {} : { type: 'button' as const })}
       {...props}
     >

--- a/libs/ui-react/src/lib/Components/Button/Button.mdx
+++ b/libs/ui-react/src/lib/Components/Button/Button.mdx
@@ -72,6 +72,17 @@ Buttons come in four different sizes:
 
 > **Important Note:** The `loading` and `disabled` states are **not coupled**. When `disabled` is set, all event handlers are deactivated. When only `loading` is set (without `disabled`), the button remains clickable. Combine both props if you need to prevent interactions during loading.
 
+### Form submission
+
+The Button defaults to `type="button"`, so placing it inside a `<form>` does **not** submit the form by accident. To use it as a submit or reset control, pass the native `type` explicitly:
+
+```tsx
+<form onSubmit={handleSubmit}>
+  <Button type='submit'>Save</Button>
+  <Button type='reset' appearance='gray'>Reset</Button>
+</form>
+```
+
 ## Responsive Layout
 
 Buttons dynamically adapt their width to the size of their content, while keeping the default paddings:

--- a/libs/ui-react/src/lib/Components/Button/Button.mdx
+++ b/libs/ui-react/src/lib/Components/Button/Button.mdx
@@ -74,7 +74,7 @@ Buttons come in four different sizes:
 
 ### Form submission
 
-The Button defaults to `type="button"`, so placing it inside a `<form>` does **not** submit the form by accident. To use it as a submit or reset control, pass the native `type` explicitly:
+On the native `<button>` render path, the Button defaults to `type="button"`, so placing it inside a `<form>` does **not** submit the form by accident. To use it as a submit or reset control, pass the native `type` explicitly:
 
 ```tsx
 <form onSubmit={handleSubmit}>
@@ -82,6 +82,8 @@ The Button defaults to `type="button"`, so placing it inside a `<form>` does **n
   <Button type='reset' appearance='gray'>Reset</Button>
 </form>
 ```
+
+When `asChild` is used, no `type` is injected, since the rendered element (e.g. an anchor) is not a native button.
 
 ## Responsive Layout
 

--- a/libs/ui-react/src/lib/Components/Button/Button.test.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.test.tsx
@@ -58,4 +58,14 @@ describe('Button Component', () => {
     const buttonElement = screen.getByRole('button');
     expect(buttonElement).toHaveClass('w-full');
   });
+
+  it('should default to type="button" so it does not submit a form', () => {
+    render(<Button>Default type</Button>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('should let the caller override the type', () => {
+    render(<Button type='submit'>Submit</Button>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+  });
 });

--- a/libs/ui-react/src/lib/Components/Button/Button.test.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.test.tsx
@@ -68,4 +68,13 @@ describe('Button Component', () => {
     render(<Button type='submit'>Submit</Button>);
     expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
   });
+
+  it('should not inject a type onto asChild (Slot) renders', () => {
+    render(
+      <Button asChild>
+        <a href='/home'>Link</a>
+      </Button>,
+    );
+    expect(screen.getByRole('link')).not.toHaveAttribute('type');
+  });
 });

--- a/libs/ui-react/src/lib/Components/Button/Button.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.tsx
@@ -21,8 +21,10 @@ const buttonVariants = cva('', {
  *
  * When in loading state, it displays a spinner. If an icon is provided without children, it renders as an icon-only button.
  *
- * Defaults to `type="button"` so it does not accidentally submit a surrounding
- * `<form>`. Pass `type="submit"` (or `type="reset"`) to opt into form behaviour.
+ * On the native `<button>` render path it defaults to `type="button"` so it does
+ * not accidentally submit a surrounding `<form>`. Pass `type="submit"` (or
+ * `type="reset"`) to opt into form behaviour. When `asChild` is used, no `type`
+ * is injected, since the rendered element (e.g. an anchor) is not a button.
  *
  * @see {@link https://ldls.vercel.app/?path=/docs/react-button--docs Guidelines}
  *

--- a/libs/ui-react/src/lib/Components/Button/Button.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.tsx
@@ -21,6 +21,9 @@ const buttonVariants = cva('', {
  *
  * When in loading state, it displays a spinner. If an icon is provided without children, it renders as an icon-only button.
  *
+ * Defaults to `type="button"` so it does not accidentally submit a surrounding
+ * `<form>`. Pass `type="submit"` (or `type="reset"`) to opt into form behaviour.
+ *
  * @see {@link https://ldls.vercel.app/?path=/docs/react-button--docs Guidelines}
  *
  * @warning The `className` prop should only be used for layout adjustments like margins or positioning.
@@ -46,6 +49,11 @@ const buttonVariants = cva('', {
  * <Button asChild appearance="base" size="md">
  *   <Link to="/dashboard">Go to Dashboard</Link>
  * </Button>
+ *
+ * // Submit button inside a form (opt into type="submit")
+ * <form onSubmit={handleSubmit}>
+ *   <Button type="submit">Save</Button>
+ * </form>
  *
  */
 export const Button = ({

--- a/libs/ui-react/src/lib/Components/Button/Button.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.tsx
@@ -21,11 +21,6 @@ const buttonVariants = cva('', {
  *
  * When in loading state, it displays a spinner. If an icon is provided without children, it renders as an icon-only button.
  *
- * On the native `<button>` render path it defaults to `type="button"` so it does
- * not accidentally submit a surrounding `<form>`. Pass `type="submit"` (or
- * `type="reset"`) to opt into form behaviour. When `asChild` is used, no `type`
- * is injected, since the rendered element (e.g. an anchor) is not a button.
- *
  * @see {@link https://ldls.vercel.app/?path=/docs/react-button--docs Guidelines}
  *
  * @warning The `className` prop should only be used for layout adjustments like margins or positioning.

--- a/libs/ui-react/src/lib/Components/Button/types.ts
+++ b/libs/ui-react/src/lib/Components/Button/types.ts
@@ -50,6 +50,14 @@ export type BaseButtonProps = {
    * Optional children to render inside the button.
    */
   children?: ReactNode;
+  /**
+   * The native button `type`. Defaults to `'button'` so the button does not
+   * accidentally submit a surrounding `<form>`. Set `'submit'` or `'reset'` to
+   * opt into form behaviour. Ignored when `asChild` is used, since the rendered
+   * element (e.g. an anchor) is not a native button.
+   * @default 'button'
+   */
+  type?: 'button' | 'submit' | 'reset';
 } & ComponentPropsWithRef<'button'>;
 
 export type ButtonProps = {

--- a/libs/ui-react/src/lib/Components/CardButton/CardButton.test.tsx
+++ b/libs/ui-react/src/lib/Components/CardButton/CardButton.test.tsx
@@ -108,4 +108,14 @@ describe('CardButton Component', () => {
     render(<CardButton title='Ref Test' ref={ref} />);
     expect(ref).toHaveBeenCalled();
   });
+
+  it('should default to type="button" so it does not submit a form', () => {
+    render(<CardButton title='Default type' />);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('should let the caller override the type', () => {
+    render(<CardButton title='Submit' type='submit' />);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+  });
 });

--- a/libs/ui-react/src/lib/Components/CardButton/CardButton.tsx
+++ b/libs/ui-react/src/lib/Components/CardButton/CardButton.tsx
@@ -73,6 +73,10 @@ export const CardButton = ({
         className,
       )}
       disabled={disabled}
+      // Default to type="button" so this button does not accidentally submit a
+      // surrounding form. Placed before {...props} so a caller can still opt
+      // into type="submit"/"reset".
+      type='button'
       {...props}
     >
       {IconComponent && <IconComponent size={24} />}

--- a/libs/ui-react/src/lib/Components/CardButton/CardButton.tsx
+++ b/libs/ui-react/src/lib/Components/CardButton/CardButton.tsx
@@ -73,9 +73,6 @@ export const CardButton = ({
         className,
       )}
       disabled={disabled}
-      // Default to type="button" so this button does not accidentally submit a
-      // surrounding form. Placed before {...props} so a caller can still opt
-      // into type="submit"/"reset".
       type='button'
       {...props}
     >

--- a/libs/ui-react/src/lib/Components/CardButton/types.ts
+++ b/libs/ui-react/src/lib/Components/CardButton/types.ts
@@ -25,4 +25,11 @@ export type CardButtonProps = {
    * @default false
    */
   hideChevron?: boolean;
+  /**
+   * The native button `type`. Defaults to `'button'` so the card button does
+   * not accidentally submit a surrounding `<form>`. Set `'submit'` or `'reset'`
+   * to opt into form behaviour.
+   * @default 'button'
+   */
+  type?: 'button' | 'submit' | 'reset';
 } & Omit<ComponentPropsWithRef<'button'>, 'children'>;

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.test.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.test.tsx
@@ -80,4 +80,14 @@ describe('MediaButton', () => {
     render(<MediaButton className='ml-16'>Label</MediaButton>);
     expect(screen.getByRole('button')).toHaveClass('ml-16');
   });
+
+  it('should default to type="button" so it does not submit a form', () => {
+    render(<MediaButton>Label</MediaButton>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('should let the caller override the type', () => {
+    render(<MediaButton type='submit'>Label</MediaButton>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+  });
 });

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
@@ -151,10 +151,6 @@ export const MediaButton = ({
         className,
       )}
       disabled={disabled}
-      // Default native buttons to type="button" so they do not accidentally
-      // submit a surrounding form. Placed before {...props} so a caller can
-      // still opt into type="submit"/"reset". Skipped for asChild, where the
-      // rendered element (e.g. an anchor) is not a native button.
       {...(asChild ? {} : { type: 'button' as const })}
       {...props}
     >

--- a/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
+++ b/libs/ui-react/src/lib/Components/MediaButton/MediaButton.tsx
@@ -151,6 +151,11 @@ export const MediaButton = ({
         className,
       )}
       disabled={disabled}
+      // Default native buttons to type="button" so they do not accidentally
+      // submit a surrounding form. Placed before {...props} so a caller can
+      // still opt into type="submit"/"reset". Skipped for asChild, where the
+      // rendered element (e.g. an anchor) is not a native button.
+      {...(asChild ? {} : { type: 'button' as const })}
       {...props}
     >
       {leadingContent && (

--- a/libs/ui-react/src/lib/Components/MediaButton/types.ts
+++ b/libs/ui-react/src/lib/Components/MediaButton/types.ts
@@ -35,5 +35,13 @@ export type MediaButtonProps = {
    * The label content of the media button.
    */
   children: ReactNode;
+  /**
+   * The native button `type`. Defaults to `'button'` so the media button does
+   * not accidentally submit a surrounding `<form>`. Set `'submit'` or `'reset'`
+   * to opt into form behaviour. Ignored when `asChild` is used, since the
+   * rendered element (e.g. an anchor) is not a native button.
+   * @default 'button'
+   */
+  type?: 'button' | 'submit' | 'reset';
 } & Pick<BaseButtonProps, 'disabled' | 'className' | 'asChild'> &
   ComponentPropsWithRef<'button'>;


### PR DESCRIPTION
Native `<button>` elements default to `type="submit"`, so a Lumen button placed inside a `<form>` could submit it by accident. This defaults the native-button components to `type="button"`, matching what `TileButton`/`AvatarButton` already did.

- `BaseButton`, `MediaButton`, and `CardButton` now set `type="button"` before the props spread, so callers can still opt into `type="submit"`/`"reset"`.
- `asChild`/Slot renders are left untouched — no `type` is injected onto non-button elements.
- Web only; the React Native buttons use `Pressable`, which has no `type` concept.
- Docs updated (`Button` JSDoc + a "Form submission" section in `Button.mdx`), plus tests covering the default and the caller override.
