### PR TITLE
fix(ci): Run full coverage suite on main for Sonarcloud, fail loudly if missing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,7 +89,15 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - run: npx nx affected -t test --passWithNoTests --coverage
+      - name: Run unit tests
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            # Always run the full suite on main so the SonarCloud baseline
+            # never depends on which projects a given merge happened to touch.
+            npx nx run-many -t test --all --passWithNoTests --coverage
+          else
+            npx nx affected -t test --passWithNoTests --coverage
+          fi
 
       - name: Fix lcov paths to be relative to workspace root
         run: |
@@ -122,4 +130,5 @@ jobs:
     uses: ./.github/workflows/scan-sonar-called.yml
     with:
       should_download_coverage: true
+      require_coverage: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit

--- a/.github/workflows/scan-sonar-called.yml
+++ b/.github/workflows/scan-sonar-called.yml
@@ -10,6 +10,13 @@ on:
         required: false
         default: false
         type: boolean
+      require_coverage:
+        description: >-
+          Fail the job if no coverage report was found, instead of silently
+          scanning without coverage data.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   id-token: write
@@ -28,10 +35,22 @@ jobs:
       - name: Download unit test coverage
         if: ${{ inputs.should_download_coverage }}
         uses: actions/download-artifact@v4
-        continue-on-error: true
+        # When coverage is required, let a download failure (e.g. missing or
+        # corrupt artifact) fail the job here with its own clear error,
+        # rather than continuing and getting a confusing "no reports found"
+        # failure from the verification step below.
+        continue-on-error: ${{ !inputs.require_coverage }}
         with:
           name: coverage
           path: libs
+
+      - name: Verify coverage was collected
+        if: ${{ inputs.should_download_coverage && inputs.require_coverage }}
+        run: |
+          if ! find libs -name lcov.info -size +0c | grep -q .; then
+            echo "::error::No coverage reports found, refusing to submit 0% coverage to SonarCloud."
+            exit 1
+          fi
 
       - uses: SonarSource/sonarqube-scan-action@v7
         env:


### PR DESCRIPTION
## Problem

SonarCloud coverage on `main` dropped from 88% to 0% after merging #824, even though every CI check was green.

## Root cause

The `unit-testing` job runs `nx affected -t test --coverage`, which only tests projects touched by a given merge. PR #824 only changed files in `apps/app-sandbox-rnative` (a demo app with no tests), so `nx affected` correctly determined that none of the coverage-tracked libs (`ui-react`, `ui-rnative`, `design-core`, `utils-shared`, etc.) needed testing. That produced zero `lcov.info` files.

Downstream, the "Download unit test coverage" step in the Sonar workflow has `continue-on-error: true`, so the missing coverage artifact was silently ignored. SonarCloud then ran its full-repo analysis with no coverage report to attach, reporting `0 Covered Lines` against the usual ~4,832 lines to cover — hence 0%.

This isn't specific to #824: any future merge that doesn't touch `libs/*` (docs, Storybook, sandbox apps, e2e, etc.) will reproduce it.

## Fix

- **`pr.yml`**: on push to `main`, run the full test suite (`nx run-many -t test --all --coverage`) instead of `nx affected`, so `main`'s coverage baseline never depends on which projects a given merge happened to touch. PR branches keep using `nx affected` for speed.
- **`scan-sonar-called.yml`**: added a `require_coverage` input. When set (only for `main`), the job now fails loudly if no non-empty `lcov.info` was collected, instead of silently submitting 0% coverage to SonarCloud. This is a safety net in case the full-suite run above ever regresses.

## Validation

Ran the full suite locally on `main` (`nx run-many -t test --all --coverage --parallel=3`): **~67s wall-clock** (528 tests across 6 libs), a negligible addition to the `main` pipeline for the guarantee that coverage is always accurate.