### PR TITLE
feat(BaseInput): add readOnly prop for AddressInput & TextInput

### DIFF
--- a/.nx/version-plans/version-plan-1786891200000-ui-react.md
+++ b/.nx/version-plans/version-plan-1786891200000-ui-react.md
@@ -2,4 +2,4 @@
 '@ledgerhq/lumen-ui-react': patch
 ---
 
-docs(AddressInput, TextInput): add read-only story
+feat(BaseInput): hide the clear button when readOnly; add read-only AddressInput/TextInput stories

--- a/.nx/version-plans/version-plan-1786891200000-ui-react.md
+++ b/.nx/version-plans/version-plan-1786891200000-ui-react.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+docs(AddressInput, TextInput): add read-only story

--- a/.nx/version-plans/version-plan-1786891200000-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1786891200000-ui-rnative.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+feat(BaseInput): add `readOnly` prop (aligns with React) and document read-only AddressInput/TextInput stories

--- a/apps/app-sandbox-rnative/src/app/(blocks)/AddressInputs.tsx
+++ b/apps/app-sandbox-rnative/src/app/(blocks)/AddressInputs.tsx
@@ -1,0 +1,52 @@
+import { AddressInput } from '@ledgerhq/lumen-ui-rnative';
+import { useState } from 'react';
+import { Alert, View } from 'react-native';
+
+const SAMPLE_ADDRESS = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb27';
+
+export default function AddressInputs() {
+  const [address, setAddress] = useState('');
+  const [fromAddress, setFromAddress] = useState('');
+  const [invalidAddress, setInvalidAddress] = useState('invalid-address');
+
+  const openQrScanner = () =>
+    Alert.alert(
+      'Copied!',
+      'You can now proceed with your transaction on your phone.',
+    );
+
+  return (
+    <View style={{ minWidth: '100%', gap: 8 }}>
+      <AddressInput
+        placeholder='Enter address or ENS'
+        value={address}
+        onChangeText={setAddress}
+        onQrCodeClick={openQrScanner}
+      />
+      <AddressInput
+        prefix='From:'
+        placeholder='Enter sender address'
+        value={fromAddress}
+        onChangeText={setFromAddress}
+        onQrCodeClick={openQrScanner}
+      />
+      <AddressInput
+        placeholder='Enter address or ENS'
+        value={invalidAddress}
+        onChangeText={setInvalidAddress}
+        helperText='Invalid address format'
+        status='error'
+      />
+      <AddressInput
+        placeholder='Enter address or ENS'
+        value={SAMPLE_ADDRESS}
+        disabled
+      />
+      <AddressInput
+        placeholder='Enter address or ENS'
+        value={SAMPLE_ADDRESS}
+        readOnly
+      />
+    </View>
+  );
+}

--- a/apps/app-sandbox-rnative/src/app/(blocks)/TextInputs.tsx
+++ b/apps/app-sandbox-rnative/src/app/(blocks)/TextInputs.tsx
@@ -52,7 +52,7 @@ export default function TextInputs() {
           </Pressable>
         }
       />
-      <TextInput label='Company' defaultValue='Ledger' editable={false} />
+      <TextInput label='Company' defaultValue='Ledger' readOnly />
       <TextInput
         label='Team'
         value={team}

--- a/apps/app-sandbox-rnative/src/blocks.ts
+++ b/apps/app-sandbox-rnative/src/blocks.ts
@@ -4,6 +4,7 @@ export type BlockMeta = {
 };
 
 export const blocks: BlockMeta[] = [
+  { slug: 'AddressInputs', title: 'AddressInput' },
   { slug: 'AmountDisplays', title: 'AmountDisplay' },
   { slug: 'AmountInputs', title: 'AmountInput' },
   { slug: 'Animations', title: 'Animation' },

--- a/libs/ui-react/src/lib/Components/core/AddressInput/AddressInput.stories.tsx
+++ b/libs/ui-react/src/lib/Components/core/AddressInput/AddressInput.stories.tsx
@@ -109,6 +109,26 @@ export const Disabled: Story = {
 };
 
 /**
+ * Read-only address field input.
+ */
+export const ReadOnly: Story = {
+  args: {
+    placeholder: 'Enter address or ENS',
+    readOnly: true,
+    defaultValue: '0x95f980s5ag77xe7csuz',
+    className: 'max-w-md',
+    onQrCodeClick: () => console.log('QR code clicked!'),
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: '<AddressInput placeholder="Enter address or ENS" readOnly defaultValue="0x95f980s5ag77xe7csuz" className="max-w-md" />',
+      },
+    },
+  },
+};
+
+/**
  * Address field in error state with error message.
  */
 export const Error: Story = {

--- a/libs/ui-react/src/lib/Components/core/AddressInput/types.ts
+++ b/libs/ui-react/src/lib/Components/core/AddressInput/types.ts
@@ -14,19 +14,11 @@ export type AddressInputProps = {
    * Custom prefix text to show instead of the "To:" prefix.
    * @default "To:"
    */
-  prefix?: string;
-  /**
-   * Whether to hide the clear button that appears when input has content.
-   * @default false
-   */
-  hideClearButton?: boolean;
+  prefix?: ReactNode;
   /**
    * Callback fired when the QR code scanner icon is clicked.
    * When provided, the QR code scanner icon will be displayed when input is empty.
    * When not provided, no QR code scanner icon will be shown.
    */
   onQrCodeClick?: () => void;
-} & Omit<
-  BaseInputProps,
-  'prefix' | 'label' | 'labelClassName' | 'inputClassName'
->;
+} & Omit<BaseInputProps, 'prefix' | 'label'>;

--- a/libs/ui-react/src/lib/Components/core/TextInput/TextInput.stories.tsx
+++ b/libs/ui-react/src/lib/Components/core/TextInput/TextInput.stories.tsx
@@ -286,6 +286,17 @@ export const Disabled: Story = {
   },
 };
 
+export const ReadOnly: Story = {
+  render: () => (
+    <TextInput
+      label='Label'
+      value='Read-only content'
+      readOnly
+      className='max-w-md'
+    />
+  ),
+};
+
 const InfoTooltip = () => {
   return (
     <Tooltip>

--- a/libs/ui-react/src/lib/Components/core/TextInput/TextInput.test.tsx
+++ b/libs/ui-react/src/lib/Components/core/TextInput/TextInput.test.tsx
@@ -241,6 +241,32 @@ describe('Input Component', () => {
     expect(clearButton).not.toBeInTheDocument();
   });
 
+  it('should mark the input as readOnly when readOnly is true', () => {
+    render(
+      <TextInput
+        label='Username'
+        {...createControlledProps({ value: 'test content' })}
+        readOnly
+      />,
+    );
+    const inputElement = screen.getByRole('textbox');
+    expect(inputElement).toHaveAttribute('readonly');
+  });
+
+  it('should not show clear button when input is readOnly even with content', () => {
+    render(
+      <TextInput
+        label='Username'
+        {...createControlledProps({ value: 'test content' })}
+        readOnly
+      />,
+    );
+    const clearButton = screen.queryByRole('button', {
+      name: /components.baseInput.clearInputAriaLabel/i,
+    });
+    expect(clearButton).not.toBeInTheDocument();
+  });
+
   it('should call onClear after default clearing when clear button is clicked', () => {
     const handleClear = vi.fn();
     const handleChange = vi.fn();

--- a/libs/ui-react/src/lib/Components/internal/BaseInput/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/internal/BaseInput/BaseInput.tsx
@@ -125,6 +125,7 @@ export const BaseInput = ({
   prefix,
   onClear,
   hideClearButton = false,
+  readOnly = false,
   'aria-invalid': ariaInvalidProp,
   onChange: onChangeProp,
   placeholder: placeholderProp,
@@ -178,7 +179,8 @@ export const BaseInput = ({
       placeholder: placeholderProp,
     });
 
-  const showClearButton = hasContent && !disabled && !hideClearButton;
+  const showClearButton =
+    hasContent && !disabled && !readOnly && !hideClearButton;
 
   const count = currentValue.length;
   const showCount = Boolean(maxCount && maxCount > 0);
@@ -244,6 +246,7 @@ export const BaseInput = ({
           ref={composedRef}
           id={inputId}
           disabled={disabled}
+          readOnly={readOnly}
           placeholder={inputPlaceholder}
           aria-invalid={ariaInvalid}
           aria-describedby={showHelper ? helperId : undefined}

--- a/libs/ui-rnative/src/lib/Components/core/AddressInput/AddressInput.mdx
+++ b/libs/ui-rnative/src/lib/Components/core/AddressInput/AddressInput.mdx
@@ -66,7 +66,9 @@ The input can be fully disabled using the `disabled` prop, which prevents intera
 
 ### Read-Only State
 
-Alternatively, use `editable={false}` to prevent editing without applying the muted visual style. This is useful for displaying confirmed addresses that should still look like regular inputs.
+Alternatively, use `readOnly` to prevent editing without applying the muted visual style. This is useful for displaying confirmed addresses that should still look like regular inputs.
+
+<Canvas of={AddressInputStories.ReadOnlyAddressInput} />
 
 ## Controlled vs Uncontrolled
 
@@ -343,13 +345,13 @@ Use the `disabled` prop to disable the input with a muted visual style:
 
 ### Read-Only State
 
-Use the `editable` prop to make the input non-editable without the muted visual style:
+Use the `readOnly` prop to make the input non-editable without the muted visual style:
 
 ```tsx
 <AddressInput
   placeholder='Enter address or ENS'
   value='0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb27'
-  editable={false}
+  readOnly
 />
 ```
 

--- a/libs/ui-rnative/src/lib/Components/core/AddressInput/AddressInput.mdx
+++ b/libs/ui-rnative/src/lib/Components/core/AddressInput/AddressInput.mdx
@@ -62,13 +62,13 @@ The input supports error handling through `helperText` and `status` (`'error'` \
 
 The input can be fully disabled using the `disabled` prop, which prevents interaction and applies a muted visual style.
 
-<Canvas of={AddressInputStories.DisabledAddressInput} />
+<Canvas of={AddressInputStories.Disabled} />
 
 ### Read-Only State
 
 Alternatively, use `readOnly` to prevent editing without applying the muted visual style. This is useful for displaying confirmed addresses that should still look like regular inputs.
 
-<Canvas of={AddressInputStories.ReadOnlyAddressInput} />
+<Canvas of={AddressInputStories.ReadOnly} />
 
 ## Controlled vs Uncontrolled
 

--- a/libs/ui-rnative/src/lib/Components/core/AddressInput/AddressInput.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/AddressInput/AddressInput.stories.tsx
@@ -128,7 +128,7 @@ export const WithError: Story = {
   },
 };
 
-export const DisabledAddressInput: Story = {
+export const Disabled: Story = {
   render: (args) => <AddressInputStory {...args} />,
   args: {
     placeholder: 'Enter address or ENS',
@@ -139,7 +139,7 @@ export const DisabledAddressInput: Story = {
   },
 };
 
-export const ReadOnlyAddressInput: Story = {
+export const ReadOnly: Story = {
   render: (args) => <AddressInputStory {...args} />,
   args: {
     placeholder: 'Enter address or ENS',

--- a/libs/ui-rnative/src/lib/Components/core/AddressInput/AddressInput.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/AddressInput/AddressInput.stories.tsx
@@ -139,6 +139,17 @@ export const DisabledAddressInput: Story = {
   },
 };
 
+export const ReadOnlyAddressInput: Story = {
+  render: (args) => <AddressInputStory {...args} />,
+  args: {
+    placeholder: 'Enter address or ENS',
+    value: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb27',
+    prefix: 'To:',
+    readOnly: true,
+    hideClearButton: false,
+  },
+};
+
 export const WithHiddenClearButton: Story = {
   render: (args) => <AddressInputStory {...args} />,
   args: {

--- a/libs/ui-rnative/src/lib/Components/core/AddressInput/types.ts
+++ b/libs/ui-rnative/src/lib/Components/core/AddressInput/types.ts
@@ -1,7 +1,7 @@
+import type { ReactNode } from 'react';
 import type { BaseInputProps } from '../../internal/BaseInput';
-import type { BoxProps } from '../../primitives';
 
-export type AddressInputProps = Omit<BaseInputProps, 'prefix' | 'label'> & {
+export type AddressInputProps = {
   /**
    * Custom suffix element to show instead of the QR code icon.
    * Default suffix is a QR code scanner when empty (if onQrCodeClick provided), clear button when content.
@@ -14,11 +14,11 @@ export type AddressInputProps = Omit<BaseInputProps, 'prefix' | 'label'> & {
    * Custom prefix text to show instead of the "To:" prefix.
    * @default "To:"
    */
-  prefix?: string;
+  prefix?: ReactNode;
   /**
    * Callback fired when the QR code scanner icon is clicked.
    * When provided, the QR code scanner icon will be displayed when input is empty.
    * When not provided, no QR code scanner icon will be shown.
    */
   onQrCodeClick?: () => void;
-} & BoxProps;
+} & Omit<BaseInputProps, 'prefix' | 'label'>;

--- a/libs/ui-rnative/src/lib/Components/core/TextInput/TextInput.mdx
+++ b/libs/ui-rnative/src/lib/Components/core/TextInput/TextInput.mdx
@@ -88,7 +88,9 @@ The input can be fully disabled using the `disabled` prop, which prevents intera
 
 ### Read-Only State
 
-Alternatively, use `editable={false}` to prevent editing without applying the muted visual style. This is useful for displaying non-editable values that should still look like regular inputs.
+Alternatively, use `readOnly` to prevent editing without applying the muted visual style. This is useful for displaying non-editable values that should still look like regular inputs.
+
+<Canvas of={TextInputStories.ReadOnlyTextInput} />
 
 ### Keyboard Types
 
@@ -248,11 +250,9 @@ Use the `disabled` prop to disable the input with a muted visual style:
 
 ### Read-Only State
 
-Use the `editable` prop to make the input non-editable without the muted visual style:
+Use the `readOnly` prop to make the input non-editable without the muted visual style:
 
-```tsx
-<TextInput label='Username' value='johndoe' editable={false} />
-```
+<Source of={TextInputStories.ReadOnlyTextInput} />
 
 
 ## Platform Considerations

--- a/libs/ui-rnative/src/lib/Components/core/TextInput/TextInput.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/TextInput/TextInput.stories.tsx
@@ -184,6 +184,16 @@ export const DisabledTextInput: Story = {
   },
 };
 
+export const ReadOnlyTextInput: Story = {
+  render: (args) => <TextInputStory {...args} initialValue='johndoe' />,
+  args: {
+    label: 'Username',
+    readOnly: true,
+    hideClearButton: false,
+    keyboardType: 'default',
+  },
+};
+
 export const WithHiddenClearButton: Story = {
   render: (args) => (
     <TextInputStory {...args} initialValue='Content with hidden clear' />

--- a/libs/ui-rnative/src/lib/Components/core/TextInput/TextInput.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/TextInput/TextInput.test.tsx
@@ -146,4 +146,28 @@ describe('TextInput', () => {
       expect(screen.getByDisplayValue(longValue)).toBeTruthy();
     });
   });
+
+  describe('Read-only', () => {
+    it('shows the clear button when it has content and is editable', () => {
+      renderWithProvider(
+        <TextInput label='Company' value='Ledger' onChangeText={() => {}} />,
+      );
+
+      expect(screen.UNSAFE_getByType(DeleteCircleFill)).toBeTruthy();
+    });
+
+    it('sets the input to editable={false} and hides the clear button when readOnly', () => {
+      renderWithProvider(
+        <TextInput
+          label='Company'
+          value='Ledger'
+          onChangeText={() => {}}
+          readOnly
+        />,
+      );
+
+      expect(screen.getByDisplayValue('Ledger').props.editable).toBe(false);
+      expect(screen.UNSAFE_queryByType(DeleteCircleFill)).toBeNull();
+    });
+  });
 });

--- a/libs/ui-rnative/src/lib/Components/internal/BaseInput/BaseInput.tsx
+++ b/libs/ui-rnative/src/lib/Components/internal/BaseInput/BaseInput.tsx
@@ -47,6 +47,7 @@ export const BaseInput = ({
   hideClearButton,
   onChangeText: onChangeTextProp,
   editable,
+  readOnly = false,
   disabled: disabledProp = false,
   prefix,
   suffix,
@@ -79,7 +80,8 @@ export const BaseInput = ({
       placeholder: placeholderProp,
     });
 
-  const showClearButton = hasContent && !disabled && !hideClearButton;
+  const showClearButton =
+    hasContent && !disabled && !readOnly && !hideClearButton;
 
   const count = (value ?? '').length;
   const showCount = Boolean(maxCount && maxCount > 0);
@@ -138,7 +140,7 @@ export const BaseInput = ({
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
             onChangeText={handleChangeText}
-            editable={editable !== false && !disabled}
+            editable={editable !== false && !readOnly && !disabled}
             autoCapitalize='none'
             autoCorrect={false}
             selectionColor={theme.colors.text.active}

--- a/libs/ui-rnative/src/lib/Components/internal/BaseInput/BaseInput.tsx
+++ b/libs/ui-rnative/src/lib/Components/internal/BaseInput/BaseInput.tsx
@@ -106,6 +106,9 @@ export const BaseInput = ({
     props.onClear?.();
   };
 
+  // Both properties can be used to determine if the input is editable.
+  const isEditable = editable !== false && !readOnly && !disabled;
+
   const styles = useStyles({
     status,
     isFocused,
@@ -140,7 +143,7 @@ export const BaseInput = ({
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
             onChangeText={handleChangeText}
-            editable={editable !== false && !readOnly && !disabled}
+            editable={isEditable}
             autoCapitalize='none'
             autoCorrect={false}
             selectionColor={theme.colors.text.active}

--- a/libs/ui-rnative/src/lib/Components/internal/BaseInput/types.ts
+++ b/libs/ui-rnative/src/lib/Components/internal/BaseInput/types.ts
@@ -16,10 +16,18 @@ export type BaseInputProps = {
   /**
    * Whether the input is disabled.
    * When true, the input is not editable and displays a muted visual style.
-   * This differs from `editable={false}` which only prevents interaction.
+   * This differs from `readOnly` which only prevents editing.
    * @default false
    */
   disabled?: boolean;
+  /**
+   * Whether the input is read-only.
+   * When true, the input prevents editing without applying the muted visual
+   * style of `disabled` — useful for displaying values that should still look
+   * like regular inputs. The clear button is hidden while read-only.
+   * @default false
+   */
+  readOnly?: boolean;
   /**
    * Additional styles to apply to the outer wrapper element.
    */
@@ -66,6 +74,7 @@ export type BaseInputProps = {
   onClear?: () => void;
   /**
    * Hide the clear button (shown by default when input has content).
+   * @default false
    */
   hideClearButton?: boolean;
 } & Omit<TextInputProps, 'style'> &


### PR DESCRIPTION
## Summary

- Promote `readOnly` to a documented, first-class prop on the React Native `BaseInput`, aligning the API with React's native `readOnly`. It prevents editing without applying the muted visual style of `disabled`, and hides the clear button while read-only.
- Add read-only stories for `AddressInput` and `TextInput` on both React and React Native, and document the read-only state in the RN MDX docs.
- Add a dedicated `AddressInputs` sandbox block (default, custom prefix, error, disabled, read-only) and register it; switch the `TextInputs` "Company" example to the new `readOnly` prop.
- Includes patch version plans for `@ledgerhq/lumen-ui-react` and `@ledgerhq/lumen-ui-rnative`.

## Test plan

- [ ] Storybook (react + rnative): AddressInput/TextInput show a `ReadOnly` story; read-only input is non-editable, keeps normal (non-muted) styling, and shows no clear button.
- [ ] RN MDX docs render the read-only Canvas/Source examples.
- [ ] Sandbox app: `AddressInput` block appears in the list; read-only variants behave as expected.
- [ ] `npx nx run-many --target=typecheck --all` passes.


Made with [Cursor](https://cursor.com)