### PR TITLE
feat(MediaBanner): ensure fixed height regardless of description length

### DIFF
--- a/.nx/version-plans/version-plan-1786634016804-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1786634016804-ui-rnative.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+fix(MediaBanner): keep a fixed height regardless of description line count

--- a/libs/ui-rnative/src/lib/Components/core/MediaBanner/MediaBanner.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/MediaBanner/MediaBanner.test.tsx
@@ -81,6 +81,37 @@ describe('MediaBanner', () => {
     );
   });
 
+  it('should keep a fixed height regardless of description line count', () => {
+    const { getByTestId, rerender } = render(
+      <TestWrapper>
+        <MediaBanner testID='media-banner' imageUrl={IMAGE_URL}>
+          <MediaBannerTitle>Title</MediaBannerTitle>
+          <MediaBannerDescription>One line</MediaBannerDescription>
+        </MediaBanner>
+      </TestWrapper>,
+    );
+
+    expect(getByTestId('media-banner').props.style.height).toBe(
+      ledgerLiveThemes.dark.sizes.s72,
+    );
+
+    rerender(
+      <TestWrapper>
+        <MediaBanner testID='media-banner' imageUrl={IMAGE_URL}>
+          <MediaBannerTitle>Title</MediaBannerTitle>
+          <MediaBannerDescription>
+            The image failed to load so the banner decided to gracefully hide
+            it.
+          </MediaBannerDescription>
+        </MediaBanner>
+      </TestWrapper>,
+    );
+
+    expect(getByTestId('media-banner').props.style.height).toBe(
+      ledgerLiveThemes.dark.sizes.s72,
+    );
+  });
+
   it('should render with imageUrl prop', () => {
     const { getByTestId } = render(
       <TestWrapper>

--- a/libs/ui-rnative/src/lib/Components/core/MediaBanner/MediaBanner.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/MediaBanner/MediaBanner.tsx
@@ -43,7 +43,7 @@ export function MediaBanner({
         borderRadius: t.borderRadius.md,
         overflow: 'hidden',
         flexDirection: 'row',
-        minHeight: t.sizes.s72,
+        height: t.sizes.s72,
         userSelect: 'none',
       },
       contentWrapper: {


### PR DESCRIPTION
Before:
<img width="482" height="138" alt="image" src="https://github.com/user-attachments/assets/43c55012-c2c4-44ff-8f40-25e01e10100f" />


After:

<img width="466" height="130" alt="image" src="https://github.com/user-attachments/assets/aabe6fbe-808f-43dd-a83b-4e01259a5baf" />
