### PR TITLE
BREAKING_CHANGE(DotIcon, DotSymbol): apply getDotSize mapper pattern

### DIFF
--- a/.nx/version-plans/version-plan-1788882601760-ui-react.md
+++ b/.nx/version-plans/version-plan-1788882601760-ui-react.md
@@ -8,7 +8,7 @@ Helpers like `mediaImageDotIconSizeMap` and `spotDotSizeMap` have been replaced 
 
 This pattern will make it consistent with the `getDotIndicatorProps` resolver introduced a few patches ago which affected the Avatar component's composition.
 
-If you previously overlayed dot indicators on components like Spot and MediaImage, you might need to take action! See below:
+If you previously overlaid dot indicators on components like Spot and MediaImage, you might need to take action! See below:
 
 ## Migration
 

--- a/.nx/version-plans/version-plan-1788882601760-ui-react.md
+++ b/.nx/version-plans/version-plan-1788882601760-ui-react.md
@@ -1,0 +1,25 @@
+---
+'@ledgerhq/lumen-ui-react': patch
+---
+
+BREAKING_CHANGE(DotIcon, DotSymbol): apply getDotSize mapper pattern
+
+Helpers like `mediaImageDotIconSizeMap` and `spotDotSizeMap` have been replaced with `getDotIconProps` and `getDotSymbolProps` resolver functions.
+
+This pattern will make it consistent with the `getDotIndicatorProps` resolver introduced a few patches ago which affected the Avatar component's composition.
+
+If you previously overlayed dot indicators on components like Spot and MediaImage, you might need to take action! See below:
+
+## Migration
+
+```tsx
+// Before
+import { mediaImageDotIconSizeMap } from '@ledgerhq/lumen-ui-react';
+<DotIcon {...mediaImageDotIconSizeMap[parentSize]} />
+
+// After
+import { getDotIconProps } from '@ledgerhq/lumen-ui-react';
+<DotIcon {...getDotIconProps('mediaImage', parentSize)} />
+```
+
+The same pattern applies to `getDotSymbolProps` for `DotSymbol`.

--- a/.nx/version-plans/version-plan-1788882601760-ui-react.md
+++ b/.nx/version-plans/version-plan-1788882601760-ui-react.md
@@ -15,11 +15,11 @@ If you previously overlayed dot indicators on components like Spot and MediaImag
 ```tsx
 // Before
 import { mediaImageDotIconSizeMap } from '@ledgerhq/lumen-ui-react';
-<DotIcon {...mediaImageDotIconSizeMap[parentSize]} />
+<DotIcon size={mediaImageDotIconSizeMap[48]} />
 
 // After
 import { getDotIconProps } from '@ledgerhq/lumen-ui-react';
-<DotIcon {...getDotIconProps('mediaImage', parentSize)} />
+<DotIcon {...getDotIconProps('mediaImage', 48)} />
 ```
 
 The same pattern applies to `getDotSymbolProps` for `DotSymbol`.

--- a/.nx/version-plans/version-plan-1788882601760-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1788882601760-ui-rnative.md
@@ -1,0 +1,25 @@
+---
+'@ledgerhq/lumen-ui-rnative': patch
+---
+
+BREAKING_CHANGE(DotIcon, DotSymbol): apply getDotSize mapper pattern
+
+Helpers like `mediaImageDotIconSizeMap` and `spotDotSizeMap` have been replaced with `getDotIconProps` and `getDotSymbolProps` resolver functions.
+
+This pattern will make it consistent with the `getDotIndicatorProps` resolver introduced a few patches ago which affected the Avatar component's composition.
+
+If you previously overlayed dot indicators on components like Spot and MediaImage, you might need to take action! See below:
+
+## Migration
+
+```tsx
+// Before
+import { mediaImageDotIconSizeMap } from '@ledgerhq/lumen-ui-rnative';
+<DotIcon {...mediaImageDotIconSizeMap[parentSize]} />
+
+// After
+import { getDotIconProps } from '@ledgerhq/lumen-ui-rnative';
+<DotIcon {...getDotIconProps('mediaImage', parentSize)} />
+```
+
+The same pattern applies to `getDotSymbolProps` for `DotSymbol`.

--- a/.nx/version-plans/version-plan-1788882601760-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1788882601760-ui-rnative.md
@@ -8,7 +8,7 @@ Helpers like `mediaImageDotIconSizeMap` and `spotDotSizeMap` have been replaced 
 
 This pattern will make it consistent with the `getDotIndicatorProps` resolver introduced a few patches ago which affected the Avatar component's composition.
 
-If you previously overlayed dot indicators on components like Spot and MediaImage, you might need to take action! See below:
+If you previously overlaid dot indicators on components like Spot and MediaImage, you might need to take action! See below:
 
 ## Migration
 

--- a/.nx/version-plans/version-plan-1788882601760-ui-rnative.md
+++ b/.nx/version-plans/version-plan-1788882601760-ui-rnative.md
@@ -15,11 +15,11 @@ If you previously overlayed dot indicators on components like Spot and MediaImag
 ```tsx
 // Before
 import { mediaImageDotIconSizeMap } from '@ledgerhq/lumen-ui-rnative';
-<DotIcon {...mediaImageDotIconSizeMap[parentSize]} />
+<DotIcon size={mediaImageDotIconSizeMap[48]} />
 
 // After
 import { getDotIconProps } from '@ledgerhq/lumen-ui-rnative';
-<DotIcon {...getDotIconProps('mediaImage', parentSize)} />
+<DotIcon {...getDotIconProps('mediaImage', 48)} />
 ```
 
 The same pattern applies to `getDotSymbolProps` for `DotSymbol`.

--- a/apps/app-sandbox-rnative/src/app/(blocks)/DotIcons.tsx
+++ b/apps/app-sandbox-rnative/src/app/(blocks)/DotIcons.tsx
@@ -1,7 +1,7 @@
 import {
   Box,
   DotIcon,
-  mediaImageDotIconSizeMap,
+  getDotIconProps,
   MediaImage,
   Spinner,
 } from '@ledgerhq/lumen-ui-rnative';
@@ -22,8 +22,8 @@ export default function DotIcons() {
         <DotIcon
           appearance='success'
           icon={ArrowDown}
-          size={mediaImageDotIconSizeMap[48]}
           pin='bottom-end'
+          {...getDotIconProps('mediaImage', 48)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/USDC.png'
@@ -36,8 +36,8 @@ export default function DotIcons() {
         <DotIcon
           appearance='muted'
           icon={ArrowUp}
-          size={mediaImageDotIconSizeMap[48]}
           pin='bottom-end'
+          {...getDotIconProps('mediaImage', 48)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/ETH.png'
@@ -50,8 +50,8 @@ export default function DotIcons() {
         <DotIcon
           appearance='error'
           icon={Spinner}
-          size={mediaImageDotIconSizeMap[48]}
           pin='bottom-end'
+          {...getDotIconProps('mediaImage', 48)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/BTC.png'
@@ -64,8 +64,8 @@ export default function DotIcons() {
         <DotIcon
           appearance='muted'
           icon={Link}
-          size={mediaImageDotIconSizeMap[40]}
           pin='bottom-end'
+          {...getDotIconProps('mediaImage', 40)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/USDC.png'
@@ -78,8 +78,8 @@ export default function DotIcons() {
         <DotIcon
           appearance='success'
           icon={ArrowDown}
-          size={mediaImageDotIconSizeMap[64]}
           pin='top-end'
+          {...getDotIconProps('mediaImage', 64)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/ETH.png'
@@ -92,9 +92,9 @@ export default function DotIcons() {
         <DotIcon
           appearance='success'
           icon={ArrowDown}
-          size={mediaImageDotIconSizeMap[48]}
           shape='square'
           pin='bottom-end'
+          {...getDotIconProps('mediaImage', 48)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/BTC.png'
@@ -107,9 +107,9 @@ export default function DotIcons() {
         <DotIcon
           appearance='muted'
           icon={Link}
-          size={mediaImageDotIconSizeMap[40]}
           shape='square'
           pin='top-start'
+          {...getDotIconProps('mediaImage', 40)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/USDT.png'
@@ -122,9 +122,9 @@ export default function DotIcons() {
         <DotIcon
           appearance='error'
           icon={ArrowUp}
-          size={mediaImageDotIconSizeMap[64]}
           shape='square'
           pin='top-end'
+          {...getDotIconProps('mediaImage', 64)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/SOL.png'

--- a/apps/app-sandbox-rnative/src/app/(blocks)/DotSymbols.tsx
+++ b/apps/app-sandbox-rnative/src/app/(blocks)/DotSymbols.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   DotSymbol,
-  mediaImageDotSizeMap,
   MediaImage,
   Spot,
   getDotSymbolProps,
@@ -23,7 +22,7 @@ export default function DotSymbols() {
           src='https://crypto-icons.ledger.com/ETH.png'
           alt='Ethereum'
           pin='bottom-end'
-          size={mediaImageDotSizeMap[48]}
+          {...getDotSymbolProps('mediaImage', 48)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/USDC.png'
@@ -37,7 +36,7 @@ export default function DotSymbols() {
           src='https://crypto-icons.ledger.com/BTC.png'
           alt='Bitcoin'
           pin='bottom-start'
-          size={mediaImageDotSizeMap[56]}
+          {...getDotSymbolProps('mediaImage', 56)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/USDC.png'
@@ -51,7 +50,7 @@ export default function DotSymbols() {
           src='https://crypto-icons.ledger.com/ETH.png'
           alt='Ethereum'
           pin='top-start'
-          size={mediaImageDotSizeMap[40]}
+          {...getDotSymbolProps('mediaImage', 40)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/XRP.png'
@@ -65,7 +64,7 @@ export default function DotSymbols() {
           src='https://crypto-icons.ledger.com/AVAX.png'
           alt='Avalanche'
           pin='top-end'
-          size={mediaImageDotSizeMap[64]}
+          {...getDotSymbolProps('mediaImage', 64)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/ADA.png'
@@ -88,8 +87,8 @@ export default function DotSymbols() {
           src='https://crypto-icons.ledger.com/BTC.png'
           alt='Bitcoin'
           pin='bottom-end'
-          size={mediaImageDotSizeMap[40]}
           shape='square'
+          {...getDotSymbolProps('mediaImage', 40)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/ETH.png'
@@ -103,8 +102,8 @@ export default function DotSymbols() {
           src='https://crypto-icons.ledger.com/ETH.png'
           alt='Ethereum'
           pin='bottom-end'
-          size={mediaImageDotSizeMap[48]}
           shape='square'
+          {...getDotSymbolProps('mediaImage', 48)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/BTC.png'
@@ -118,8 +117,8 @@ export default function DotSymbols() {
           src='https://crypto-icons.ledger.com/USDC.png'
           alt='USD Coin'
           pin='top-start'
-          size={mediaImageDotSizeMap[40]}
           shape='square'
+          {...getDotSymbolProps('mediaImage', 40)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/XRP.png'
@@ -133,8 +132,8 @@ export default function DotSymbols() {
           src='https://crypto-icons.ledger.com/AVAX.png'
           alt='Avalanche'
           pin='top-end'
-          size={mediaImageDotSizeMap[64]}
           shape='square'
+          {...getDotSymbolProps('mediaImage', 64)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/ADA.png'
@@ -148,8 +147,8 @@ export default function DotSymbols() {
           src='https://crypto-icons.ledger.com/DOGE.png'
           alt='Dogecoin'
           pin='bottom-start'
-          size={mediaImageDotSizeMap[56]}
           shape='square'
+          {...getDotSymbolProps('mediaImage', 56)}
         >
           <MediaImage
             src='https://crypto-icons.ledger.com/TRX.png'

--- a/apps/app-sandbox-rnative/src/app/(blocks)/DotSymbols.tsx
+++ b/apps/app-sandbox-rnative/src/app/(blocks)/DotSymbols.tsx
@@ -4,7 +4,7 @@ import {
   mediaImageDotSizeMap,
   MediaImage,
   Spot,
-  spotDotSizeMap,
+  getDotSymbolProps,
 } from '@ledgerhq/lumen-ui-rnative';
 import { ExternalLink } from '@ledgerhq/lumen-ui-rnative/symbols';
 
@@ -79,7 +79,7 @@ export default function DotSymbols() {
           src='https://crypto-icons.ledger.com/ETH.png'
           alt='Ethereum'
           pin='top-end'
-          size={spotDotSizeMap[48]}
+          {...getDotSymbolProps('spot', 48)}
         >
           <Spot appearance='icon' icon={ExternalLink} size={48} />
         </DotSymbol>

--- a/apps/app-sandbox-rnative/src/app/(blocks)/Spots.tsx
+++ b/apps/app-sandbox-rnative/src/app/(blocks)/Spots.tsx
@@ -1,5 +1,10 @@
-import { Box, Spot } from '@ledgerhq/lumen-ui-rnative';
-import { ExternalLink } from '@ledgerhq/lumen-ui-rnative/symbols';
+import {
+  Box,
+  DotSymbol,
+  getDotSymbolProps,
+  Spot,
+} from '@ledgerhq/lumen-ui-rnative';
+import { CoinAlert, ExternalLink } from '@ledgerhq/lumen-ui-rnative/symbols';
 
 export default function Spots() {
   return (
@@ -14,6 +19,13 @@ export default function Spots() {
         <Spot appearance='warning' />
         <Spot appearance='info' />
         <Spot appearance='loader' />
+        <DotSymbol
+          src='https://crypto-icons.ledger.com/BTC.png'
+          pin='bottom-end'
+          {...getDotSymbolProps('spot', 48)}
+        >
+          <Spot appearance='icon' icon={CoinAlert} />
+        </DotSymbol>
       </Box>
       <Box lx={{ flexDirection: 'row', gap: 's8' }}>
         <Spot appearance='icon' icon={ExternalLink} size={48} />

--- a/libs/ui-react/src/lib/Components/core/DotIcon/DotIcon.mdx
+++ b/libs/ui-react/src/lib/Components/core/DotIcon/DotIcon.mdx
@@ -51,7 +51,7 @@ The `appearance` prop controls the semantic background color of the dot: `succes
 
 ### Sizes
 
-The dot size is driven by the parent MediaImage or Spot size via the mapping helpers `mediaImageDotIconSizeMap` and `spotDotIconSizeMap`. Allowed sizes are `16`, `20`, and `24`. The icon size is handled internally by the component.
+The dot size is driven by the parent MediaImage or Spot size via the `getDotIconProps` helper. Allowed sizes are `16`, `20`, `24`, and `32`. The icon size is handled internally by the component.
 
 <Canvas of={DotIconStories.SizeShowcase} />
 
@@ -125,12 +125,12 @@ Pick a semantic color via `appearance`:
 The dot size is driven by the parent's size via the mapping helpers:
 
 ```tsx
-import { DotIcon, mediaImageDotIconSizeMap, MediaImage } from '@ledgerhq/lumen-ui-react';
+import { DotIcon, getDotIconProps, MediaImage } from '@ledgerhq/lumen-ui-react';
 
 <DotIcon
   appearance='success'
   icon={ArrowDown}
-  size={mediaImageDotIconSizeMap[48]}
+  {...getDotIconProps('mediaImage', 48)}
 >
   <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
 </DotIcon>;

--- a/libs/ui-react/src/lib/Components/core/DotIcon/DotIcon.stories.tsx
+++ b/libs/ui-react/src/lib/Components/core/DotIcon/DotIcon.stories.tsx
@@ -8,7 +8,8 @@ import {
 } from '../../symbols';
 import { MediaImage } from '../MediaImage';
 import { Spinner } from '../Spinner';
-import { DotIcon, mediaImageDotIconSizeMap } from './DotIcon';
+import { DotIcon } from './DotIcon';
+import { getDotIconProps } from './getDotIconProps';
 
 const meta = {
   component: DotIcon,
@@ -37,7 +38,7 @@ export const Base: Story = {
     appearance: 'success',
     icon: ArrowDown,
     pin: 'bottom-end',
-    size: mediaImageDotIconSizeMap[48],
+    ...getDotIconProps('mediaImage', 48),
     shape: 'circle',
     children: (
       <MediaImage src={parentSrc} alt='Cardano' size={48} shape='circle' />
@@ -106,8 +107,8 @@ export const AppearanceShowcase: Story = {
       <DotIcon
         appearance='success'
         icon={ArrowDown}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage
           src={parentSrc}
@@ -119,8 +120,8 @@ export const AppearanceShowcase: Story = {
       <DotIcon
         appearance='muted'
         icon={ArrowUp}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage
           src={parentSrc}
@@ -132,8 +133,8 @@ export const AppearanceShowcase: Story = {
       <DotIcon
         appearance='error'
         icon={Close}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage
           src={parentSrc}
@@ -153,9 +154,9 @@ export const DisabledShowcase: Story = {
       <DotIcon
         appearance='success'
         icon={ArrowDown}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
         disabled
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage
           src={parentSrc}
@@ -167,9 +168,9 @@ export const DisabledShowcase: Story = {
       <DotIcon
         appearance='muted'
         icon={ArrowUp}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
         disabled
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage
           src={parentSrc}
@@ -181,9 +182,9 @@ export const DisabledShowcase: Story = {
       <DotIcon
         appearance='error'
         icon={Close}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
         disabled
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage
           src={parentSrc}
@@ -203,8 +204,8 @@ export const SizeShowcase: Story = {
       <DotIcon
         appearance='muted'
         icon={Link}
-        size={mediaImageDotIconSizeMap[40]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 40)}
       >
         <MediaImage
           src={parentSrc}
@@ -216,8 +217,8 @@ export const SizeShowcase: Story = {
       <DotIcon
         appearance='success'
         icon={Star}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage
           src={parentSrc}
@@ -229,8 +230,8 @@ export const SizeShowcase: Story = {
       <DotIcon
         appearance='success'
         icon={ArrowDown}
-        size={mediaImageDotIconSizeMap[56]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 56)}
       >
         <MediaImage
           src={parentSrc}
@@ -242,8 +243,8 @@ export const SizeShowcase: Story = {
       <DotIcon
         appearance='muted'
         icon={Spinner}
-        size={mediaImageDotIconSizeMap[64]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 64)}
       >
         <MediaImage
           src={parentSrc}
@@ -255,8 +256,8 @@ export const SizeShowcase: Story = {
       <DotIcon
         appearance='muted'
         icon={Spinner}
-        size={mediaImageDotIconSizeMap[72]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 72)}
       >
         <MediaImage
           src={parentSrc}

--- a/libs/ui-react/src/lib/Components/core/DotIcon/DotIcon.test.tsx
+++ b/libs/ui-react/src/lib/Components/core/DotIcon/DotIcon.test.tsx
@@ -92,6 +92,7 @@ describe('DotIcon Component', () => {
     { size: 16 as const, offset: '-3px' },
     { size: 20 as const, offset: '-3px' },
     { size: 24 as const, offset: '-3px' },
+    { size: 32 as const, offset: '-3px' },
   ])('should apply correct offset for size $size', ({ size, offset }) => {
     const { container } = render(
       <DotIcon
@@ -192,5 +193,13 @@ describe('DotIcon Component', () => {
 
   it('should have correct displayName', () => {
     expect(DotIcon.displayName).toBe('DotIcon');
+  });
+
+  it('should apply opacity class when disabled', () => {
+    const { container } = render(
+      <DotIcon appearance='success' icon={ArrowDown} disabled />,
+    );
+
+    expect(container.firstChild).toHaveClass('opacity-30');
   });
 });

--- a/libs/ui-react/src/lib/Components/core/DotIcon/DotIcon.tsx
+++ b/libs/ui-react/src/lib/Components/core/DotIcon/DotIcon.tsx
@@ -53,21 +53,6 @@ const dotVariants = cva(
   },
 );
 
-export const mediaImageDotIconSizeMap = {
-  40: 16,
-  48: 20,
-  56: 24,
-  64: 24,
-  72: 32,
-} as const satisfies Record<number, DotIconSize>;
-
-export const spotDotIconSizeMap = {
-  40: 16,
-  48: 20,
-  56: 24,
-  72: 32,
-} as const satisfies Record<number, DotIconSize>;
-
 export const dotIconSizeMap: Record<DotIconSize, IconSize> = {
   16: 12,
   20: 16,

--- a/libs/ui-react/src/lib/Components/core/DotIcon/getDotIconProps.test.ts
+++ b/libs/ui-react/src/lib/Components/core/DotIcon/getDotIconProps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getDotIconProps } from './getDotIconProps';
+import { getDotIconProps, mediaImageDotIconSizeMap } from './index';
 
 describe('getDotIconProps', () => {
   it('resolves mediaImage dot icon props', () => {
@@ -8,6 +8,10 @@ describe('getDotIconProps', () => {
     expect(getDotIconProps('mediaImage', 56)).toEqual({ size: 24 });
     expect(getDotIconProps('mediaImage', 64)).toEqual({ size: 24 });
     expect(getDotIconProps('mediaImage', 72)).toEqual({ size: 32 });
+  });
+
+  it('exports mediaImageDotIconSizeMap shim', () => {
+    expect(mediaImageDotIconSizeMap[56]).toBe(24);
   });
 
   it('resolves spot dot icon props', () => {

--- a/libs/ui-react/src/lib/Components/core/DotIcon/getDotIconProps.test.ts
+++ b/libs/ui-react/src/lib/Components/core/DotIcon/getDotIconProps.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getDotIconProps } from './getDotIconProps';
+
+describe('getDotIconProps', () => {
+  it('resolves mediaImage dot icon props', () => {
+    expect(getDotIconProps('mediaImage', 40)).toEqual({ size: 16 });
+    expect(getDotIconProps('mediaImage', 48)).toEqual({ size: 20 });
+    expect(getDotIconProps('mediaImage', 56)).toEqual({ size: 24 });
+    expect(getDotIconProps('mediaImage', 64)).toEqual({ size: 24 });
+    expect(getDotIconProps('mediaImage', 72)).toEqual({ size: 32 });
+  });
+
+  it('resolves spot dot icon props', () => {
+    expect(getDotIconProps('spot', 40)).toEqual({ size: 16 });
+    expect(getDotIconProps('spot', 48)).toEqual({ size: 20 });
+    expect(getDotIconProps('spot', 56)).toEqual({ size: 24 });
+    expect(getDotIconProps('spot', 72)).toEqual({ size: 32 });
+  });
+});

--- a/libs/ui-react/src/lib/Components/core/DotIcon/getDotIconProps.ts
+++ b/libs/ui-react/src/lib/Components/core/DotIcon/getDotIconProps.ts
@@ -1,0 +1,20 @@
+import { createPropsResolver } from '@ledgerhq/lumen-utils-shared';
+import type { MediaImageSize } from '../MediaImage';
+import type { SpotSize } from '../Spot';
+import type { DotIconProps } from './types';
+
+export const getDotIconProps = createPropsResolver({
+  mediaImage: {
+    40: { size: 16 },
+    48: { size: 20 },
+    56: { size: 24 },
+    64: { size: 24 },
+    72: { size: 32 },
+  } satisfies Partial<Record<MediaImageSize, Partial<DotIconProps>>>,
+  spot: {
+    40: { size: 16 },
+    48: { size: 20 },
+    56: { size: 24 },
+    72: { size: 32 },
+  } satisfies Partial<Record<SpotSize, Partial<DotIconProps>>>,
+});

--- a/libs/ui-react/src/lib/Components/core/DotIcon/index.ts
+++ b/libs/ui-react/src/lib/Components/core/DotIcon/index.ts
@@ -2,9 +2,9 @@ export { DotIcon, dotIconSizeMap } from './DotIcon';
 export * from './getDotIconProps';
 export * from './types';
 
-// shim: @ledgerhq/crypto-icons imports this which used by our Storybook build...
-// remove once that package drops the dependency
-export const mediaImageDotSizeMap = {
+// shim: @ledgerhq/crypto-icons imports this
+// remove once the package drops the dependency
+export const mediaImageDotIconSizeMap = {
   40: 16,
   48: 20,
   56: 24,

--- a/libs/ui-react/src/lib/Components/core/DotIcon/index.ts
+++ b/libs/ui-react/src/lib/Components/core/DotIcon/index.ts
@@ -1,3 +1,13 @@
 export { DotIcon, dotIconSizeMap } from './DotIcon';
 export * from './getDotIconProps';
 export * from './types';
+
+// shim: @ledgerhq/crypto-icons imports this which used by our Storybook build...
+// remove once that package drops the dependency
+export const mediaImageDotSizeMap = {
+  40: 16,
+  48: 20,
+  56: 24,
+  64: 24,
+  72: 32,
+} as const;

--- a/libs/ui-react/src/lib/Components/core/DotIcon/index.ts
+++ b/libs/ui-react/src/lib/Components/core/DotIcon/index.ts
@@ -1,7 +1,3 @@
-export {
-  DotIcon,
-  dotIconSizeMap,
-  mediaImageDotIconSizeMap,
-  spotDotIconSizeMap,
-} from './DotIcon';
+export { DotIcon, dotIconSizeMap } from './DotIcon';
+export * from './getDotIconProps';
 export * from './types';

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/DotSymbol.mdx
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/DotSymbol.mdx
@@ -108,7 +108,7 @@ Use `shape='square'` to match a square child element:
 The dot size is driven by the parent's size via the mapping helpers:
 
 ```tsx
-import { DotSymbol, getDotSymbolProps, MediaImage, } from '@ledgerhq/lumen-ui-react';
+import { DotSymbol, getDotSymbolProps, MediaImage } from '@ledgerhq/lumen-ui-react';
 
 <DotSymbol
   src='https://example.com/btc.png'

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/DotSymbol.mdx
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/DotSymbol.mdx
@@ -45,7 +45,7 @@ Four corner placements are available: `bottom-end` (default), `top-end`, `bottom
 
 ### Sizes
 
-The dot size is driven by the parent MediaImage or Spot size via the mapping helpers `mediaImageDotSizeMap` and `spotDotSizeMap`.
+The dot size is driven by the parent MediaImage or Spot size via the `getDotSymbolProps` helper.
 
 <Canvas of={DotSymbolStories.SizeShowcase} />
 
@@ -108,12 +108,12 @@ Use `shape='square'` to match a square child element:
 The dot size is driven by the parent's size via the mapping helpers:
 
 ```tsx
-import { DotSymbol, mediaImageDotSizeMap, MediaImage } from '@ledgerhq/lumen-ui-react';
+import { DotSymbol, getDotSymbolProps, MediaImage, } from '@ledgerhq/lumen-ui-react';
 
 <DotSymbol
   src='https://example.com/btc.png'
   alt='Bitcoin'
-  size={mediaImageDotSizeMap[48]}
+  {...getDotSymbolProps('mediaImage', 48)}
 >
   <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
 </DotSymbol>;

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/DotSymbol.stories.tsx
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/DotSymbol.stories.tsx
@@ -2,7 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CoinAlert } from '../../symbols';
 import { MediaImage } from '../MediaImage';
 import { Spot } from '../Spot';
-import { DotSymbol, mediaImageDotSizeMap } from './DotSymbol';
+import { DotSymbol } from './DotSymbol';
+import { getDotSymbolProps } from './getDotSymbolProps';
 
 const meta = {
   component: DotSymbol,
@@ -32,7 +33,7 @@ export const Base: Story = {
     src: dotSrc,
     alt: 'Ethereum network',
     pin: 'bottom-end',
-    size: mediaImageDotSizeMap[48],
+    ...getDotSymbolProps('mediaImage', 48),
     shape: 'circle',
   },
   render: (args) => (
@@ -157,8 +158,8 @@ export const SizeShowcase: Story = {
       <div className='inline-flex items-end gap-24 body-2'>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[20]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 20)}
         >
           <MediaImage
             src={parentSrc}
@@ -169,8 +170,8 @@ export const SizeShowcase: Story = {
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[24]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 24)}
         >
           <MediaImage
             src={parentSrc}
@@ -181,8 +182,8 @@ export const SizeShowcase: Story = {
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[32]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 32)}
         >
           <MediaImage
             src={parentSrc}
@@ -193,8 +194,8 @@ export const SizeShowcase: Story = {
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[40]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 40)}
         >
           <MediaImage
             src={parentSrc}
@@ -205,8 +206,8 @@ export const SizeShowcase: Story = {
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[48]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 48)}
         >
           <MediaImage
             src={parentSrc}
@@ -217,8 +218,8 @@ export const SizeShowcase: Story = {
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[56]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 56)}
         >
           <MediaImage
             src={parentSrc}
@@ -229,8 +230,8 @@ export const SizeShowcase: Story = {
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[64]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 64)}
         >
           <MediaImage
             src={parentSrc}
@@ -241,8 +242,8 @@ export const SizeShowcase: Story = {
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[72]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 72)}
         >
           <MediaImage
             src={parentSrc}
@@ -256,8 +257,8 @@ export const SizeShowcase: Story = {
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[20]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 20)}
         >
           <MediaImage
             src={parentSrc}
@@ -269,8 +270,8 @@ export const SizeShowcase: Story = {
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[24]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 24)}
         >
           <MediaImage
             src={parentSrc}
@@ -282,8 +283,8 @@ export const SizeShowcase: Story = {
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[32]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 32)}
         >
           <MediaImage
             src={parentSrc}
@@ -295,8 +296,8 @@ export const SizeShowcase: Story = {
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[40]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 40)}
         >
           <MediaImage
             src={parentSrc}
@@ -308,8 +309,8 @@ export const SizeShowcase: Story = {
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[48]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 48)}
         >
           <MediaImage
             src={parentSrc}
@@ -321,8 +322,8 @@ export const SizeShowcase: Story = {
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[56]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 56)}
         >
           <MediaImage
             src={parentSrc}
@@ -334,8 +335,8 @@ export const SizeShowcase: Story = {
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[64]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 64)}
         >
           <MediaImage
             src={parentSrc}
@@ -347,8 +348,8 @@ export const SizeShowcase: Story = {
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[72]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 72)}
         >
           <MediaImage
             src={parentSrc}

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/DotSymbol.tsx
@@ -5,7 +5,6 @@ import {
 } from '@ledgerhq/lumen-utils-shared';
 import { cva } from 'class-variance-authority';
 import { useEffect, useMemo, useState } from 'react';
-import type { MediaImageSize } from '../MediaImage';
 import type { DotSymbolPin, DotSymbolProps, DotSymbolSize } from './types';
 
 const rootVariants = cva('relative inline-flex w-fit', {
@@ -66,19 +65,6 @@ const offsetBySize: Record<DotSymbolSize, number> = {
   24: -3,
   32: -3,
 };
-
-export const mediaImageDotSizeMap: Record<MediaImageSize, DotSymbolSize> = {
-  12: 8,
-  16: 8,
-  20: 8,
-  24: 10,
-  32: 12,
-  40: 16,
-  48: 20,
-  56: 24,
-  64: 24,
-  72: 32,
-} as const;
 
 const pinAxisMap: Record<DotSymbolPin, [vertical: string, horizontal: string]> =
   {

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/DotSymbol.tsx
@@ -6,7 +6,6 @@ import {
 import { cva } from 'class-variance-authority';
 import { useEffect, useMemo, useState } from 'react';
 import type { MediaImageSize } from '../MediaImage';
-import type { SpotSize } from '../Spot';
 import type { DotSymbolPin, DotSymbolProps, DotSymbolSize } from './types';
 
 const rootVariants = cva('relative inline-flex w-fit', {
@@ -78,14 +77,6 @@ export const mediaImageDotSizeMap: Record<MediaImageSize, DotSymbolSize> = {
   48: 20,
   56: 24,
   64: 24,
-  72: 32,
-} as const;
-
-export const spotDotSizeMap: Record<SpotSize, DotSymbolSize> = {
-  32: 12,
-  40: 16,
-  48: 20,
-  56: 24,
   72: 32,
 } as const;
 

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/getDotSymbolProps.test.ts
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/getDotSymbolProps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getDotSymbolProps } from './getDotSymbolProps';
+import { getDotSymbolProps, mediaImageDotSizeMap } from './index';
 
 describe('getDotSymbolProps', () => {
   it('resolves mediaImage dot symbol props', () => {
@@ -13,6 +13,10 @@ describe('getDotSymbolProps', () => {
     expect(getDotSymbolProps('mediaImage', 56)).toEqual({ size: 24 });
     expect(getDotSymbolProps('mediaImage', 64)).toEqual({ size: 24 });
     expect(getDotSymbolProps('mediaImage', 72)).toEqual({ size: 32 });
+  });
+
+  it('exports mediaImageDotSizeMap shim', () => {
+    expect(mediaImageDotSizeMap[48]).toBe(20);
   });
 
   it('resolves spot dot symbol props', () => {

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/getDotSymbolProps.test.ts
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/getDotSymbolProps.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { getDotSymbolProps } from './getDotSymbolProps';
+
+describe('getDotSymbolProps', () => {
+  it('resolves mediaImage dot symbol props', () => {
+    expect(getDotSymbolProps('mediaImage', 12)).toEqual({ size: 8 });
+    expect(getDotSymbolProps('mediaImage', 16)).toEqual({ size: 8 });
+    expect(getDotSymbolProps('mediaImage', 20)).toEqual({ size: 8 });
+    expect(getDotSymbolProps('mediaImage', 24)).toEqual({ size: 10 });
+    expect(getDotSymbolProps('mediaImage', 32)).toEqual({ size: 12 });
+    expect(getDotSymbolProps('mediaImage', 40)).toEqual({ size: 16 });
+    expect(getDotSymbolProps('mediaImage', 48)).toEqual({ size: 20 });
+    expect(getDotSymbolProps('mediaImage', 56)).toEqual({ size: 24 });
+    expect(getDotSymbolProps('mediaImage', 64)).toEqual({ size: 24 });
+    expect(getDotSymbolProps('mediaImage', 72)).toEqual({ size: 32 });
+  });
+
+  it('resolves spot dot symbol props', () => {
+    expect(getDotSymbolProps('spot', 32)).toEqual({ size: 12 });
+    expect(getDotSymbolProps('spot', 40)).toEqual({ size: 16 });
+    expect(getDotSymbolProps('spot', 48)).toEqual({ size: 20 });
+    expect(getDotSymbolProps('spot', 56)).toEqual({ size: 24 });
+    expect(getDotSymbolProps('spot', 72)).toEqual({ size: 32 });
+  });
+});

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/getDotSymbolProps.ts
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/getDotSymbolProps.ts
@@ -1,0 +1,13 @@
+import { createPropsResolver } from '@ledgerhq/lumen-utils-shared';
+import type { SpotSize } from '../Spot';
+import type { DotSymbolProps } from './types';
+
+export const getDotSymbolProps = createPropsResolver({
+  spot: {
+    32: { size: 12 },
+    40: { size: 16 },
+    48: { size: 20 },
+    56: { size: 24 },
+    72: { size: 40 },
+  } satisfies Record<SpotSize, Partial<DotSymbolProps>>,
+});

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/getDotSymbolProps.ts
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/getDotSymbolProps.ts
@@ -1,13 +1,26 @@
 import { createPropsResolver } from '@ledgerhq/lumen-utils-shared';
+import type { MediaImageSize } from '../MediaImage';
 import type { SpotSize } from '../Spot';
 import type { DotSymbolProps } from './types';
 
 export const getDotSymbolProps = createPropsResolver({
+  mediaImage: {
+    12: { size: 8 },
+    16: { size: 8 },
+    20: { size: 8 },
+    24: { size: 10 },
+    32: { size: 12 },
+    40: { size: 16 },
+    48: { size: 20 },
+    56: { size: 24 },
+    64: { size: 24 },
+    72: { size: 32 },
+  } satisfies Record<MediaImageSize, Partial<DotSymbolProps>>,
   spot: {
     32: { size: 12 },
     40: { size: 16 },
     48: { size: 20 },
     56: { size: 24 },
-    72: { size: 40 },
+    72: { size: 32 },
   } satisfies Record<SpotSize, Partial<DotSymbolProps>>,
 });

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/index.ts
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/index.ts
@@ -1,3 +1,3 @@
-export { DotSymbol, mediaImageDotSizeMap } from './DotSymbol';
+export { DotSymbol } from './DotSymbol';
 export * from './getDotSymbolProps';
 export * from './types';

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/index.ts
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/index.ts
@@ -1,3 +1,18 @@
 export { DotSymbol } from './DotSymbol';
 export * from './getDotSymbolProps';
 export * from './types';
+
+// shim: @ledgerhq/crypto-icons imports this
+// remove once the package drops the dependency
+export const mediaImageDotSizeMap = {
+  12: 8,
+  16: 8,
+  20: 8,
+  24: 10,
+  32: 12,
+  40: 16,
+  48: 20,
+  56: 24,
+  64: 24,
+  72: 32,
+} as const;

--- a/libs/ui-react/src/lib/Components/core/DotSymbol/index.ts
+++ b/libs/ui-react/src/lib/Components/core/DotSymbol/index.ts
@@ -1,2 +1,3 @@
-export { DotSymbol, mediaImageDotSizeMap, spotDotSizeMap } from './DotSymbol';
+export { DotSymbol, mediaImageDotSizeMap } from './DotSymbol';
+export * from './getDotSymbolProps';
 export * from './types';

--- a/libs/ui-react/src/lib/Components/core/Spot/Spot.stories.tsx
+++ b/libs/ui-react/src/lib/Components/core/Spot/Spot.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Settings, Plus, Heart, Star, CoinAlert } from '../../symbols';
 import type { IconSize } from '../../symbols/Icon';
-import { DotSymbol, spotDotSizeMap } from '../DotSymbol';
+import { DotSymbol, getDotSymbolProps } from '../DotSymbol';
 import { Spot } from './Spot';
 import type { SpotAppearance } from './types';
 
@@ -156,7 +156,7 @@ export const WithDotSymbol: Story = {
         <DotSymbol
           src='https://crypto-icons.ledger.com/BTC.png'
           pin='bottom-end'
-          size={spotDotSizeMap[48]}
+          {...getDotSymbolProps('spot', 48)}
         >
           <Spot appearance='icon' icon={CoinAlert} />
         </DotSymbol>

--- a/libs/ui-rnative/src/lib/Components/core/DotIcon/DotIcon.mdx
+++ b/libs/ui-rnative/src/lib/Components/core/DotIcon/DotIcon.mdx
@@ -51,7 +51,7 @@ The `appearance` prop controls the semantic background color of the dot: `succes
 
 ### Sizes
 
-The dot size is driven by the parent MediaImage or Spot size via the mapping helpers `mediaImageDotIconSizeMap` and `spotDotIconSizeMap`. Allowed sizes are `16`, `20`, and `24`. The icon size is handled internally by the component.
+The dot size is driven by the parent MediaImage or Spot size via the `getDotIconProps` helper. Allowed sizes are `16`, `20`, `24`, and `32`. The icon size is handled internally by the component.
 
 <Canvas of={DotIconStories.SizeShowcase} />
 
@@ -123,12 +123,12 @@ Pick a semantic color via `appearance`:
 The dot size is driven by the parent's size via the mapping helpers:
 
 ```tsx
-import { DotIcon, mediaImageDotIconSizeMap, MediaImage } from '@ledgerhq/lumen-ui-rnative';
+import { DotIcon, getDotIconProps, MediaImage } from '@ledgerhq/lumen-ui-rnative';
 
 <DotIcon
   appearance='success'
   icon={ArrowDown}
-  size={mediaImageDotIconSizeMap[48]}
+  {...getDotIconProps('mediaImage', 48)}
 >
   <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
 </DotIcon>;

--- a/libs/ui-rnative/src/lib/Components/core/DotIcon/DotIcon.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/DotIcon/DotIcon.stories.tsx
@@ -3,7 +3,8 @@ import { Box } from '../../primitives';
 import { ArrowDown, ArrowUp, Close, Link, Star } from '../../symbols';
 import { MediaImage } from '../MediaImage';
 import { Spinner } from '../Spinner';
-import { DotIcon, mediaImageDotIconSizeMap } from './DotIcon';
+import { DotIcon } from './DotIcon';
+import { getDotIconProps } from './getDotIconProps';
 
 const meta = {
   component: DotIcon,
@@ -30,7 +31,7 @@ export const Base: Story = {
     appearance: 'success',
     icon: ArrowDown,
     pin: 'bottom-end',
-    size: mediaImageDotIconSizeMap[48],
+    ...getDotIconProps('mediaImage', 48),
     shape: 'circle',
     children: (
       <MediaImage src={parentSrc} alt='Cardano' size={48} shape='circle' />
@@ -89,24 +90,24 @@ export const AppearanceShowcase: Story = {
       <DotIcon
         appearance='success'
         icon={ArrowDown}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage src={parentSrc} size={48} shape='circle' />
       </DotIcon>
       <DotIcon
         appearance='muted'
         icon={ArrowUp}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage src={parentSrc} size={48} shape='circle' />
       </DotIcon>
       <DotIcon
         appearance='error'
         icon={Close}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage src={parentSrc} size={48} shape='circle' />
       </DotIcon>
@@ -121,27 +122,27 @@ export const DisabledShowcase: Story = {
       <DotIcon
         appearance='success'
         icon={ArrowDown}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
         disabled
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage src={parentSrc} size={48} shape='circle' />
       </DotIcon>
       <DotIcon
         appearance='muted'
         icon={ArrowUp}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
         disabled
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage src={parentSrc} size={48} shape='circle' />
       </DotIcon>
       <DotIcon
         appearance='error'
         icon={Close}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
         disabled
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage src={parentSrc} size={48} shape='circle' />
       </DotIcon>
@@ -156,40 +157,40 @@ export const SizeShowcase: Story = {
       <DotIcon
         appearance='muted'
         icon={Link}
-        size={mediaImageDotIconSizeMap[40]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 40)}
       >
         <MediaImage src={parentSrc} size={40} shape='circle' />
       </DotIcon>
       <DotIcon
         appearance='success'
         icon={Star}
-        size={mediaImageDotIconSizeMap[48]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 48)}
       >
         <MediaImage src={parentSrc} size={48} shape='circle' />
       </DotIcon>
       <DotIcon
         appearance='success'
         icon={ArrowDown}
-        size={mediaImageDotIconSizeMap[56]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 56)}
       >
         <MediaImage src={parentSrc} size={56} shape='circle' />
       </DotIcon>
       <DotIcon
         appearance='muted'
         icon={Spinner}
-        size={mediaImageDotIconSizeMap[64]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 64)}
       >
         <MediaImage src={parentSrc} size={64} shape='circle' />
       </DotIcon>
       <DotIcon
         appearance='muted'
         icon={Spinner}
-        size={mediaImageDotIconSizeMap[72]}
         pin='bottom-end'
+        {...getDotIconProps('mediaImage', 72)}
       >
         <MediaImage src={parentSrc} size={72} shape='circle' />
       </DotIcon>

--- a/libs/ui-rnative/src/lib/Components/core/DotIcon/DotIcon.test.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/DotIcon/DotIcon.test.tsx
@@ -77,6 +77,7 @@ describe('DotIcon Component', () => {
       { size: 16 as const, expectedSize: sizes.s16 },
       { size: 20 as const, expectedSize: sizes.s20 },
       { size: 24 as const, expectedSize: sizes.s24 },
+      { size: 32 as const, expectedSize: sizes.s32 },
     ])(
       'should apply correct width and height for size $size',
       ({ size, expectedSize }) => {
@@ -159,6 +160,7 @@ describe('DotIcon Component', () => {
       { size: 16 as const, expectedRadius: 5 },
       { size: 20 as const, expectedRadius: 6 },
       { size: 24 as const, expectedRadius: 8 },
+      { size: 32 as const, expectedRadius: 10 },
     ])(
       'should apply correct border radius for square shape at size $size',
       ({ size, expectedRadius }) => {
@@ -191,6 +193,24 @@ describe('DotIcon Component', () => {
       );
 
       expect(ref.current).not.toBeNull();
+    });
+  });
+
+  describe('Disabled', () => {
+    it('should apply opacity when disabled', () => {
+      const { getByTestId } = render(
+        <TestWrapper>
+          <DotIcon
+            testID='dot-icon'
+            appearance='success'
+            icon={ArrowDown}
+            disabled
+          />
+        </TestWrapper>,
+      );
+
+      const root = getByTestId('dot-icon');
+      expect(root.props.style.opacity).toBe(0.3);
     });
   });
 

--- a/libs/ui-rnative/src/lib/Components/core/DotIcon/DotIcon.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/DotIcon/DotIcon.tsx
@@ -26,21 +26,6 @@ const dotSquareRadiusMap: Record<DotIconSize, number> = {
   32: 10,
 };
 
-export const mediaImageDotIconSizeMap = {
-  40: 16,
-  48: 20,
-  56: 24,
-  64: 24,
-  72: 32,
-} as const satisfies Record<number, DotIconSize>;
-
-export const spotDotIconSizeMap = {
-  40: 16,
-  48: 20,
-  56: 24,
-  72: 32,
-} as const satisfies Record<number, DotIconSize>;
-
 const pinAxisMap: Record<DotIconPin, [vertical: string, horizontal: string]> = {
   'top-start': ['top', 'left'],
   'top-end': ['top', 'right'],

--- a/libs/ui-rnative/src/lib/Components/core/DotIcon/getDotIconProps.test.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotIcon/getDotIconProps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { getDotIconProps } from './getDotIconProps';
+import { getDotIconProps, mediaImageDotIconSizeMap } from './index';
 
 describe('getDotIconProps', () => {
   it('resolves mediaImage dot icon props', () => {
@@ -8,6 +8,10 @@ describe('getDotIconProps', () => {
     expect(getDotIconProps('mediaImage', 56)).toEqual({ size: 24 });
     expect(getDotIconProps('mediaImage', 64)).toEqual({ size: 24 });
     expect(getDotIconProps('mediaImage', 72)).toEqual({ size: 32 });
+  });
+
+  it('exports mediaImageDotIconSizeMap shim', () => {
+    expect(mediaImageDotIconSizeMap[56]).toBe(24);
   });
 
   it('resolves spot dot icon props', () => {

--- a/libs/ui-rnative/src/lib/Components/core/DotIcon/getDotIconProps.test.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotIcon/getDotIconProps.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from '@jest/globals';
+import { getDotIconProps } from './getDotIconProps';
+
+describe('getDotIconProps', () => {
+  it('resolves mediaImage dot icon props', () => {
+    expect(getDotIconProps('mediaImage', 40)).toEqual({ size: 16 });
+    expect(getDotIconProps('mediaImage', 48)).toEqual({ size: 20 });
+    expect(getDotIconProps('mediaImage', 56)).toEqual({ size: 24 });
+    expect(getDotIconProps('mediaImage', 64)).toEqual({ size: 24 });
+    expect(getDotIconProps('mediaImage', 72)).toEqual({ size: 32 });
+  });
+
+  it('resolves spot dot icon props', () => {
+    expect(getDotIconProps('spot', 40)).toEqual({ size: 16 });
+    expect(getDotIconProps('spot', 48)).toEqual({ size: 20 });
+    expect(getDotIconProps('spot', 56)).toEqual({ size: 24 });
+    expect(getDotIconProps('spot', 72)).toEqual({ size: 32 });
+  });
+});

--- a/libs/ui-rnative/src/lib/Components/core/DotIcon/getDotIconProps.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotIcon/getDotIconProps.ts
@@ -1,0 +1,20 @@
+import { createPropsResolver } from '@ledgerhq/lumen-utils-shared';
+import type { MediaImageSize } from '../MediaImage';
+import type { SpotSize } from '../Spot';
+import type { DotIconProps } from './types';
+
+export const getDotIconProps = createPropsResolver({
+  mediaImage: {
+    40: { size: 16 },
+    48: { size: 20 },
+    56: { size: 24 },
+    64: { size: 24 },
+    72: { size: 32 },
+  } satisfies Partial<Record<MediaImageSize, Partial<DotIconProps>>>,
+  spot: {
+    40: { size: 16 },
+    48: { size: 20 },
+    56: { size: 24 },
+    72: { size: 32 },
+  } satisfies Partial<Record<SpotSize, Partial<DotIconProps>>>,
+});

--- a/libs/ui-rnative/src/lib/Components/core/DotIcon/index.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotIcon/index.ts
@@ -1,3 +1,13 @@
 export { DotIcon } from './DotIcon';
 export * from './getDotIconProps';
 export * from './types';
+
+// shim: @ledgerhq/crypto-icons imports this
+// remove once the package drops the dependency
+export const mediaImageDotIconSizeMap = {
+  40: 16,
+  48: 20,
+  56: 24,
+  64: 24,
+  72: 32,
+} as const;

--- a/libs/ui-rnative/src/lib/Components/core/DotIcon/index.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotIcon/index.ts
@@ -1,6 +1,3 @@
-export {
-  DotIcon,
-  mediaImageDotIconSizeMap,
-  spotDotIconSizeMap,
-} from './DotIcon';
+export { DotIcon } from './DotIcon';
+export * from './getDotIconProps';
 export * from './types';

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/DotSymbol.mdx
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/DotSymbol.mdx
@@ -45,7 +45,7 @@ Four corner placements are available: `bottom-end` (default), `top-end`, `bottom
 
 ### Sizes
 
-The dot size is driven by the parent MediaImage or Spot size via the mapping helpers `mediaImageDotSizeMap` and `spotDotSizeMap`.
+The dot size is driven by the parent MediaImage or Spot size via the `getDotSymbolProps` helper.
 
 <Canvas of={DotSymbolStories.SizeShowcase} />
 
@@ -106,12 +106,12 @@ Use `shape='square'` to match a square child element:
 The dot size is driven by the parent's size via the mapping helpers:
 
 ```tsx
-import { DotSymbol, mediaImageDotSizeMap, MediaImage } from '@ledgerhq/lumen-ui-rnative';
+import { DotSymbol, getDotSymbolProps, MediaImage } from '@ledgerhq/lumen-ui-rnative';
 
 <DotSymbol
   src='https://example.com/btc.png'
   alt='Bitcoin'
-  size={mediaImageDotSizeMap[48]}
+  {...getDotSymbolProps('mediaImage', 48)}
 >
   <MediaImage src='https://example.com/ada.png' alt='Cardano' size={48} />
 </DotSymbol>;

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/DotSymbol.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/DotSymbol.stories.tsx
@@ -3,7 +3,8 @@ import { Box } from '../../primitives';
 import { CoinAlert } from '../../symbols';
 import { MediaImage } from '../MediaImage';
 import { Spot } from '../Spot';
-import { DotSymbol, mediaImageDotSizeMap } from './DotSymbol';
+import { DotSymbol } from './DotSymbol';
+import { getDotSymbolProps } from './getDotSymbolProps';
 
 const meta = {
   component: DotSymbol,
@@ -117,57 +118,57 @@ export const SizeShowcase: Story = {
       <Box lx={{ flexDirection: 'row', alignItems: 'flex-end', gap: 's24' }}>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[20]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 20)}
         >
           <MediaImage src={parentSrc} size={20} shape='circle' />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[24]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 24)}
         >
           <MediaImage src={parentSrc} size={24} shape='circle' />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[32]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 32)}
         >
           <MediaImage src={parentSrc} size={32} shape='circle' />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[40]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 40)}
         >
           <MediaImage src={parentSrc} size={40} shape='circle' />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[48]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 48)}
         >
           <MediaImage src={parentSrc} size={48} shape='circle' />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[56]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 56)}
         >
           <MediaImage src={parentSrc} size={56} shape='circle' />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[64]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 64)}
         >
           <MediaImage src={parentSrc} size={64} shape='circle' />
         </DotSymbol>
         <DotSymbol
           src={dotSrc}
-          size={mediaImageDotSizeMap[72]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 72)}
         >
           <MediaImage src={parentSrc} size={72} shape='circle' />
         </DotSymbol>
@@ -176,64 +177,64 @@ export const SizeShowcase: Story = {
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[20]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 20)}
         >
           <MediaImage src={parentSrc} size={20} shape='square' />
         </DotSymbol>
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[24]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 24)}
         >
           <MediaImage src={parentSrc} size={24} shape='square' />
         </DotSymbol>
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[32]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 32)}
         >
           <MediaImage src={parentSrc} size={32} shape='square' />
         </DotSymbol>
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[40]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 40)}
         >
           <MediaImage src={parentSrc} size={40} shape='square' />
         </DotSymbol>
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[48]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 48)}
         >
           <MediaImage src={parentSrc} size={48} shape='square' />
         </DotSymbol>
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[56]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 56)}
         >
           <MediaImage src={parentSrc} size={56} shape='square' />
         </DotSymbol>
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[64]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 64)}
         >
           <MediaImage src={parentSrc} size={64} shape='square' />
         </DotSymbol>
         <DotSymbol
           shape='square'
           src={dotSrc}
-          size={mediaImageDotSizeMap[72]}
           pin='bottom-end'
+          {...getDotSymbolProps('mediaImage', 72)}
         >
           <MediaImage src={parentSrc} size={72} shape='square' />
         </DotSymbol>

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/DotSymbol.tsx
@@ -7,7 +7,6 @@ import { Image } from 'react-native';
 import { useStyleSheet } from '../../../../styles';
 import { Box } from '../../primitives';
 import type { MediaImageSize } from '../MediaImage';
-import type { SpotSize } from '../Spot';
 import type { DotSymbolPin, DotSymbolProps, DotSymbolSize } from './types';
 
 const dotSquareRadiusMap: Record<DotSymbolSize, number> = {
@@ -40,14 +39,6 @@ export const mediaImageDotSizeMap: Record<MediaImageSize, DotSymbolSize> = {
   48: 20,
   56: 24,
   64: 24,
-  72: 32,
-};
-
-export const spotDotSizeMap: Record<SpotSize, DotSymbolSize> = {
-  32: 12,
-  40: 16,
-  48: 20,
-  56: 24,
   72: 32,
 };
 

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/DotSymbol.tsx
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/DotSymbol.tsx
@@ -6,7 +6,6 @@ import { useEffect, useState } from 'react';
 import { Image } from 'react-native';
 import { useStyleSheet } from '../../../../styles';
 import { Box } from '../../primitives';
-import type { MediaImageSize } from '../MediaImage';
 import type { DotSymbolPin, DotSymbolProps, DotSymbolSize } from './types';
 
 const dotSquareRadiusMap: Record<DotSymbolSize, number> = {
@@ -27,19 +26,6 @@ const offsetBySize: Record<DotSymbolSize, number> = {
   20: -3,
   24: -3,
   32: -3,
-};
-
-export const mediaImageDotSizeMap: Record<MediaImageSize, DotSymbolSize> = {
-  12: 8,
-  16: 8,
-  20: 8,
-  24: 10,
-  32: 12,
-  40: 16,
-  48: 20,
-  56: 24,
-  64: 24,
-  72: 32,
 };
 
 const pinAxisMap: Record<DotSymbolPin, [vertical: string, horizontal: string]> =

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/getDotSymbolProps.test.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/getDotSymbolProps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { getDotSymbolProps } from './getDotSymbolProps';
+import { getDotSymbolProps, mediaImageDotSizeMap } from './index';
 
 describe('getDotSymbolProps', () => {
   it('resolves mediaImage dot symbol props', () => {
@@ -13,6 +13,10 @@ describe('getDotSymbolProps', () => {
     expect(getDotSymbolProps('mediaImage', 56)).toEqual({ size: 24 });
     expect(getDotSymbolProps('mediaImage', 64)).toEqual({ size: 24 });
     expect(getDotSymbolProps('mediaImage', 72)).toEqual({ size: 32 });
+  });
+
+  it('exports mediaImageDotSizeMap shim', () => {
+    expect(mediaImageDotSizeMap[48]).toBe(20);
   });
 
   it('resolves spot dot symbol props', () => {

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/getDotSymbolProps.test.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/getDotSymbolProps.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from '@jest/globals';
+import { getDotSymbolProps } from './getDotSymbolProps';
+
+describe('getDotSymbolProps', () => {
+  it('resolves mediaImage dot symbol props', () => {
+    expect(getDotSymbolProps('mediaImage', 12)).toEqual({ size: 8 });
+    expect(getDotSymbolProps('mediaImage', 16)).toEqual({ size: 8 });
+    expect(getDotSymbolProps('mediaImage', 20)).toEqual({ size: 8 });
+    expect(getDotSymbolProps('mediaImage', 24)).toEqual({ size: 10 });
+    expect(getDotSymbolProps('mediaImage', 32)).toEqual({ size: 12 });
+    expect(getDotSymbolProps('mediaImage', 40)).toEqual({ size: 16 });
+    expect(getDotSymbolProps('mediaImage', 48)).toEqual({ size: 20 });
+    expect(getDotSymbolProps('mediaImage', 56)).toEqual({ size: 24 });
+    expect(getDotSymbolProps('mediaImage', 64)).toEqual({ size: 24 });
+    expect(getDotSymbolProps('mediaImage', 72)).toEqual({ size: 32 });
+  });
+
+  it('resolves spot dot symbol props', () => {
+    expect(getDotSymbolProps('spot', 32)).toEqual({ size: 12 });
+    expect(getDotSymbolProps('spot', 40)).toEqual({ size: 16 });
+    expect(getDotSymbolProps('spot', 48)).toEqual({ size: 20 });
+    expect(getDotSymbolProps('spot', 56)).toEqual({ size: 24 });
+    expect(getDotSymbolProps('spot', 72)).toEqual({ size: 32 });
+  });
+});

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/getDotSymbolProps.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/getDotSymbolProps.ts
@@ -1,0 +1,13 @@
+import { createPropsResolver } from '@ledgerhq/lumen-utils-shared';
+import type { SpotSize } from '../Spot';
+import type { DotSymbolProps } from './types';
+
+export const getDotSymbolProps = createPropsResolver({
+  spot: {
+    32: { size: 12 },
+    40: { size: 16 },
+    48: { size: 20 },
+    56: { size: 24 },
+    72: { size: 40 },
+  } satisfies Record<SpotSize, Partial<DotSymbolProps>>,
+});

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/getDotSymbolProps.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/getDotSymbolProps.ts
@@ -1,13 +1,26 @@
 import { createPropsResolver } from '@ledgerhq/lumen-utils-shared';
+import type { MediaImageSize } from '../MediaImage';
 import type { SpotSize } from '../Spot';
 import type { DotSymbolProps } from './types';
 
 export const getDotSymbolProps = createPropsResolver({
+  mediaImage: {
+    12: { size: 8 },
+    16: { size: 8 },
+    20: { size: 8 },
+    24: { size: 10 },
+    32: { size: 12 },
+    40: { size: 16 },
+    48: { size: 20 },
+    56: { size: 24 },
+    64: { size: 24 },
+    72: { size: 32 },
+  } satisfies Record<MediaImageSize, Partial<DotSymbolProps>>,
   spot: {
     32: { size: 12 },
     40: { size: 16 },
     48: { size: 20 },
     56: { size: 24 },
-    72: { size: 40 },
+    72: { size: 32 },
   } satisfies Record<SpotSize, Partial<DotSymbolProps>>,
 });

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/index.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/index.ts
@@ -1,3 +1,3 @@
-export { DotSymbol, mediaImageDotSizeMap } from './DotSymbol';
+export { DotSymbol } from './DotSymbol';
 export * from './getDotSymbolProps';
 export * from './types';

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/index.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/index.ts
@@ -1,3 +1,3 @@
-export { DotSymbol, mediaImageDotSizeMap, spotDotSizeMap } from './DotSymbol';
+export { DotSymbol, mediaImageDotSizeMap } from './DotSymbol';
 export * from './getDotSymbolProps';
 export * from './types';

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/index.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/index.ts
@@ -1,2 +1,3 @@
 export { DotSymbol, mediaImageDotSizeMap, spotDotSizeMap } from './DotSymbol';
+export * from './getDotSymbolProps';
 export * from './types';

--- a/libs/ui-rnative/src/lib/Components/core/DotSymbol/index.ts
+++ b/libs/ui-rnative/src/lib/Components/core/DotSymbol/index.ts
@@ -1,3 +1,18 @@
 export { DotSymbol } from './DotSymbol';
 export * from './getDotSymbolProps';
 export * from './types';
+
+// shim: @ledgerhq/crypto-icons imports this
+// remove once the package drops the dependency
+export const mediaImageDotSizeMap = {
+  12: 8,
+  16: 8,
+  20: 8,
+  24: 10,
+  32: 12,
+  40: 16,
+  48: 20,
+  56: 24,
+  64: 24,
+  72: 32,
+} as const;


### PR DESCRIPTION
Closes [DLS-873](https://ledgerhq.atlassian.net/browse/DLS-873).


## Regarding the shims

Note the shims added in https://github.com/LedgerHQ/lumen/pull/860/commits/a8e19ae06d38ed32bb3c702bd7d00b49fd9113b4. `@ledgerhq/crypto-icons` imports `mediaImageDotSizeMap` and `mediaImageDotIconSizeMap` (see [usage in repo](https://github.com/search?q=repo%3ALedgerHQ%2Fcrypto-icons+mediaImageDotSizeMap&type=code)) which used by our Storybook build. Without those exports, Vercel won't build. Once the package drops the dependencies, we should remove the shims.

[DLS-873]: https://ledgerhq.atlassian.net/browse/DLS-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ